### PR TITLE
feat: improve zsh dotfiles configuration

### DIFF
--- a/openspec/changes/expand-omz-plugins/.openspec.yaml
+++ b/openspec/changes/expand-omz-plugins/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-02

--- a/openspec/changes/expand-omz-plugins/design.md
+++ b/openspec/changes/expand-omz-plugins/design.md
@@ -1,0 +1,130 @@
+## Context
+
+The shell config (`dot_zshrc.tmpl`) has two initialization paths: oh-my-zsh plugins (declarative, managed by the framework) and manual `eval`/`source` blocks (imperative, hand-maintained). Currently 5 plugins are declared while nvm, gh, and bun are initialized manually with synchronous calls. The nvm synchronous load is the single largest startup bottleneck (~300-700ms). The file is a chezmoi template targeting macOS (arm64/x86) and Linux.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Expand the oh-my-zsh plugin array from 5 to 26 plugins
+- Migrate nvm, gh, and bun initialization from manual code to their oh-my-zsh plugin equivalents
+- Enable nvm lazy loading to eliminate the startup bottleneck
+- Remove manual init lines that become redundant after plugin migration
+- Maintain identical runtime behavior (same completions, same tools available)
+
+**Non-Goals:**
+- Changing custom aliases (eza, bat, zoxide, ripgrep, git, gh shortcuts) -- these stay manual because they use customized flags the plugins don't offer
+- Modifying fzf configuration (covered by the `inline-fzf-init` change)
+- Modifying zsh-autosuggestions/syntax-highlighting sourcing (covered by `tune-autosuggestions` change)
+- Adding any tools not already installed via Homebrew
+- Changing starship, zoxide, or atuin initialization (no plugin equivalents that improve on the current approach)
+
+## Decisions
+
+### D1: Use nvm plugin with lazy mode instead of manual source
+
+**Choice**: Replace lines 30-32 with the `nvm` plugin + `zstyle ':omz:plugins:nvm' lazy yes`
+
+**Rationale**: The nvm plugin's lazy mode creates lightweight wrapper functions for `node`, `npm`, `npx`, `pnpm`, `pnpx`, `yarn`, and `corepack`. The real `nvm.sh` is only sourced on first invocation of any of these commands. This eliminates ~300-700ms from every shell startup at the cost of a one-time ~300ms delay on first use per session.
+
+**Alternative considered**: `zstyle ':omz:plugins:nvm' lazy no` (eager load, same as current behavior) -- rejected because it preserves the startup penalty with no benefit.
+
+**Configuration** (placed before `source $ZSH/oh-my-zsh.sh`):
+```zsh
+export NVM_DIR="$HOME/.nvm"
+zstyle ':omz:plugins:nvm' lazy yes
+zstyle ':omz:plugins:nvm' autoload yes
+zstyle ':omz:plugins:nvm' silent-autoload yes
+```
+
+The `autoload` setting makes nvm automatically switch versions when entering a directory with `.nvmrc`. The `silent-autoload` suppresses the version switch output to keep the terminal clean.
+
+The `export NVM_DIR` line is retained because the plugin uses it as a hint but does not default to `$HOME/.nvm` -- it searches multiple locations. Keeping it explicit avoids ambiguity.
+
+**Lines removed**: 31 (`source nvm.sh`) and 32 (`source bash_completion`).
+
+### D2: Use gh plugin instead of eval for completions
+
+**Choice**: Replace line 76 (`eval "$(gh completion -s zsh)"`) with the `gh` plugin.
+
+**Rationale**: The plugin runs `gh completion --shell zsh >| "$ZSH_CACHE_DIR/completions/_gh" &|` which generates completions in a background process and caches them to disk. The current `eval` approach runs synchronously (~30ms). Both produce identical completions, but the plugin is non-blocking and cached.
+
+**Alternative considered**: Keep the manual eval -- rejected because the plugin is strictly better (async + cached) with no downsides.
+
+**Lines removed**: 76 and its comment on 75.
+
+### D3: Use bun plugin instead of manual source
+
+**Choice**: Replace line 135 (`source ~/.bun/_bun`) with the `bun` plugin.
+
+**Rationale**: Same pattern as gh -- the plugin runs `bun completions` in background and caches the output. The current approach sources a static file that may become stale across bun updates.
+
+**Lines retained**: 138-139 (`BUN_INSTALL` and `PATH`) are NOT covered by the plugin and must stay.
+
+**Lines removed**: 135 and its comment on 134.
+
+### D4: Plugin array ordering convention
+
+**Choice**: Order plugins in the array by category with blank-line separators and inline comments.
+
+**Rationale**: With 26 plugins, a flat unsorted list becomes hard to scan. Grouping by purpose (version control, tooling completions, productivity utilities, runtime managers) makes it clear why each plugin exists and simplifies future additions or removals.
+
+```zsh
+plugins=(
+  # Version control
+  git
+  gitignore
+
+  # Tool completions & aliases
+  brew
+  docker
+  docker-compose
+  npm
+  macos
+  gh
+
+  # Productivity utilities
+  aliases
+  colored-man-pages
+  command-not-found
+  copybuffer
+  copyfile
+  copypath
+  encode64
+  extract
+  fancy-ctrl-z
+  history
+  jsontools
+  safe-paste
+  sudo
+  bgnotify
+  urltools
+  web-search
+  you-should-use
+
+  # Runtime managers
+  nvm
+  bun
+)
+```
+
+**Alternative considered**: Alphabetical ordering -- rejected because it mixes unrelated plugins, making it harder to audit "do I have all my Docker plugins?" at a glance.
+
+### D5: Do NOT add plugins that conflict with existing manual config
+
+**Choice**: Explicitly exclude `eza`, `fzf`, `zoxide`, `starship`, and `z` plugins.
+
+**Rationale**: These tools already have carefully tuned manual configurations in the aliases and init sections. The oh-my-zsh plugins for these tools would either override custom flags (eza), provide a simpler init than what exists (fzf), or duplicate functionality (z vs zoxide). The manual config is superior in each case.
+
+## Risks / Trade-offs
+
+**[nvm lazy first-use delay]** The first `node`/`npm`/`pnpm`/`yarn` command in each shell session takes ~300ms longer.
+-> Mitigation: Acceptable trade-off. Most sessions involve only a few shell startups but many command executions. The startup savings compound across every new terminal tab/window.
+
+**[bgnotify requires terminal-notifier on macOS]** Without `terminal-notifier`, bgnotify falls back to `growlnotify` or does nothing.
+-> Mitigation: `terminal-notifier` can be added to the Brewfile. The plugin degrades gracefully -- it simply won't notify if no notification tool is found. Note: Ghostty is already detected by the plugin (`com.mitchellh.ghostty` is hardcoded in `bgnotify_programid`).
+
+**[Plugin updates may change alias names]** oh-my-zsh plugin aliases are maintained upstream and could change between updates.
+-> Mitigation: The `you-should-use` plugin helps discover aliases. The `aliases` plugin lists all active aliases. Both provide visibility into what's available. Custom aliases in the file always take precedence over plugin aliases.
+
+**[safe-paste on modern zsh is a no-op]** On zsh >= 5.1, `safe-paste` only runs `autoload -Uz bracketed-paste-magic` which is already built-in behavior. It's essentially free but also provides no benefit on modern systems.
+-> Mitigation: Keep it for backwards compatibility with any zsh < 5.1 environment. Zero cost on modern zsh.

--- a/openspec/changes/expand-omz-plugins/proposal.md
+++ b/openspec/changes/expand-omz-plugins/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The current zsh config only uses 5 oh-my-zsh plugins while manually initializing several tools (nvm, gh, bun) with synchronous `eval`/`source` calls. This misses useful productivity plugins available out-of-the-box and leaves ~300-700ms of avoidable startup time on the table (primarily nvm). Expanding the plugin set and migrating manual init to plugin equivalents makes the shell faster, more productive, and easier to maintain.
+
+## What Changes
+
+- Add 21 new oh-my-zsh plugins across three categories:
+  - **Tool completions/aliases**: `brew`, `docker-compose`, `macos`
+  - **Productivity utilities**: `sudo`, `extract`, `encode64`, `jsontools`, `copypath`, `copyfile`, `copybuffer`, `colored-man-pages`, `safe-paste`, `fancy-ctrl-z`, `bgnotify`, `aliases`, `web-search`, `urltools`, `history`, `gitignore`
+  - **Runtime completions**: `nvm`, `gh`, `bun`
+- Migrate nvm initialization from manual `source nvm.sh` to the `nvm` plugin with lazy loading (`zstyle ':omz:plugins:nvm' lazy yes`), eliminating ~300-700ms startup penalty
+- Migrate gh completions from synchronous `eval "$(gh completion -s zsh)"` to the `gh` plugin (async background caching)
+- Migrate bun completions from manual `source ~/.bun/_bun` to the `bun` plugin (async background caching)
+- Remove the manual init lines replaced by plugins (nvm source + bash_completion, gh eval, bun source)
+- Add `zstyle` configuration lines for nvm plugin before oh-my-zsh is sourced
+- Retain all manual config that plugins do NOT cover (NVM_DIR export, pnpm PATH, BUN_INSTALL + PATH, starship, zoxide, fzf, atuin, autosuggestions, syntax-highlighting, all custom aliases)
+
+## Capabilities
+
+### New Capabilities
+- `omz-plugins`: Defines which oh-my-zsh plugins are enabled, their configuration (zstyle settings), and the rationale for each plugin's inclusion or exclusion
+
+### Modified Capabilities
+_(none -- no existing spec-level behavior changes)_
+
+## Impact
+
+- **File modified**: `dot_zshrc.tmpl` -- plugin array expansion, zstyle additions, removal of 4 manual init lines
+- **Shell startup time**: Expected reduction from ~450-850ms to ~120-150ms due to nvm lazy loading and async gh/bun completions
+- **First-use latency**: First invocation of `node`/`npm`/`pnpm`/`yarn` in a session will incur a one-time ~300ms delay (nvm lazy load)
+- **Dependencies**: All 21 plugins are bundled with oh-my-zsh (no new installs required). `bgnotify` benefits from `terminal-notifier` on macOS (optional)
+- **Interaction with in-flight changes**: The `inline-fzf-init` change modifies fzf sourcing in `dot_zshrc.tmpl` but does not touch the plugin array or the lines this change modifies -- no conflict expected

--- a/openspec/changes/expand-omz-plugins/specs/omz-plugins/spec.md
+++ b/openspec/changes/expand-omz-plugins/specs/omz-plugins/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: Plugin array declares all enabled oh-my-zsh plugins
+The `plugins=()` array in `dot_zshrc.tmpl` SHALL declare exactly 26 plugins, organized by category with inline comments as separators.
+
+#### Scenario: Plugin array contains all expected plugins
+- **WHEN** the `plugins=()` array is evaluated
+- **THEN** it SHALL contain exactly these plugins: `git`, `gitignore`, `brew`, `docker`, `docker-compose`, `npm`, `macos`, `gh`, `aliases`, `colored-man-pages`, `command-not-found`, `copybuffer`, `copyfile`, `copypath`, `encode64`, `extract`, `fancy-ctrl-z`, `history`, `jsontools`, `safe-paste`, `sudo`, `bgnotify`, `urltools`, `web-search`, `you-should-use`, `nvm`, `bun`
+
+#### Scenario: Plugins are grouped by category
+- **WHEN** inspecting the `plugins=()` array
+- **THEN** plugins SHALL be grouped under comment headers: "Version control", "Tool completions & aliases", "Productivity utilities", "Runtime managers"
+
+### Requirement: nvm plugin uses lazy loading
+The nvm plugin SHALL be configured with lazy mode to defer loading `nvm.sh` until first use of a Node.js-related command.
+
+#### Scenario: zstyle configuration is set before oh-my-zsh source
+- **WHEN** `dot_zshrc.tmpl` is processed
+- **THEN** the following lines SHALL appear before `source $ZSH/oh-my-zsh.sh`: `zstyle ':omz:plugins:nvm' lazy yes`, `zstyle ':omz:plugins:nvm' autoload yes`, `zstyle ':omz:plugins:nvm' silent-autoload yes`
+
+#### Scenario: NVM_DIR is exported before oh-my-zsh source
+- **WHEN** `dot_zshrc.tmpl` is processed
+- **THEN** `export NVM_DIR="$HOME/.nvm"` SHALL appear before `source $ZSH/oh-my-zsh.sh`
+
+#### Scenario: nvm loads on first node command
+- **WHEN** the user runs `node`, `npm`, `npx`, `pnpm`, `pnpx`, `yarn`, or `corepack` for the first time in a session
+- **THEN** nvm SHALL be fully loaded and the command SHALL execute normally
+
+#### Scenario: Automatic .nvmrc detection
+- **WHEN** the user enters a directory containing a `.nvmrc` file (after nvm has been lazy-loaded)
+- **THEN** nvm SHALL automatically switch to the version specified in `.nvmrc` without printing output
+
+### Requirement: Manual nvm initialization lines are removed
+The manual nvm `source` and `bash_completion` lines SHALL be removed since the nvm plugin handles initialization.
+
+#### Scenario: No duplicate nvm loading
+- **WHEN** `dot_zshrc.tmpl` is processed
+- **THEN** the lines `[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"` and `[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"` SHALL NOT exist in the file
+
+### Requirement: Manual gh completion line is removed
+The synchronous `eval "$(gh completion -s zsh)"` line SHALL be removed since the `gh` plugin generates completions asynchronously.
+
+#### Scenario: No duplicate gh completion loading
+- **WHEN** `dot_zshrc.tmpl` is processed
+- **THEN** the line `eval "$(gh completion -s zsh)"` and its preceding comment SHALL NOT exist in the file
+
+#### Scenario: gh completions remain functional
+- **WHEN** the user types `gh ` and presses Tab
+- **THEN** gh subcommand completions SHALL appear (provided by the `gh` plugin via cached background generation)
+
+### Requirement: Manual bun completion source is removed
+The manual `source ~/.bun/_bun` line SHALL be removed since the `bun` plugin generates completions asynchronously.
+
+#### Scenario: No duplicate bun completion loading
+- **WHEN** `dot_zshrc.tmpl` is processed
+- **THEN** the line `[ -s "{{ .chezmoi.homeDir }}/.bun/_bun" ] && source "{{ .chezmoi.homeDir }}/.bun/_bun"` and its preceding comment SHALL NOT exist in the file
+
+#### Scenario: Bun PATH and install dir are retained
+- **WHEN** `dot_zshrc.tmpl` is processed
+- **THEN** the lines `export BUN_INSTALL="$HOME/.bun"` and `export PATH="$BUN_INSTALL/bin:$PATH"` SHALL still exist in the file
+
+### Requirement: Conflicting plugins are not included
+The plugin array SHALL NOT contain plugins that conflict with existing manual configuration.
+
+#### Scenario: eza plugin excluded
+- **WHEN** inspecting the `plugins=()` array
+- **THEN** the `eza` plugin SHALL NOT be present (manual aliases with `--icons --group-directories-first` are preferred)
+
+#### Scenario: fzf plugin excluded
+- **WHEN** inspecting the `plugins=()` array
+- **THEN** the `fzf` plugin SHALL NOT be present (inline fzf config with fd backend and bat preview is preferred)
+
+#### Scenario: zoxide and z plugins excluded
+- **WHEN** inspecting the `plugins=()` array
+- **THEN** neither the `zoxide` nor `z` plugins SHALL be present (manual zoxide init with custom aliases is preferred)
+
+#### Scenario: starship plugin excluded
+- **WHEN** inspecting the `plugins=()` array
+- **THEN** the `starship` plugin SHALL NOT be present (manual `eval "$(starship init zsh)"` is equivalent)
+
+### Requirement: Existing manual configuration is preserved
+All manual configuration not superseded by plugins SHALL remain unchanged.
+
+#### Scenario: Custom aliases unchanged
+- **WHEN** `dot_zshrc.tmpl` is processed
+- **THEN** all alias blocks (eza, bat, zoxide, git, GitHub CLI, ripgrep, utility) SHALL remain exactly as they were before this change
+
+#### Scenario: Tool initializations unchanged
+- **WHEN** `dot_zshrc.tmpl` is processed
+- **THEN** the `starship init`, `zoxide init`, `atuin init`, fzf configuration, and zsh-autosuggestions/syntax-highlighting source blocks SHALL remain unchanged
+
+#### Scenario: PATH and environment exports unchanged
+- **WHEN** `dot_zshrc.tmpl` is processed
+- **THEN** `PNPM_HOME`, `BUN_INSTALL`, and their PATH additions SHALL remain unchanged

--- a/openspec/changes/expand-omz-plugins/tasks.md
+++ b/openspec/changes/expand-omz-plugins/tasks.md
@@ -1,0 +1,32 @@
+## 1. nvm plugin migration
+
+- [ ] 1.1 Move `export NVM_DIR="$HOME/.nvm"` from line 30 to before `source $ZSH/oh-my-zsh.sh`
+- [ ] 1.2 Add `zstyle ':omz:plugins:nvm' lazy yes` before `source $ZSH/oh-my-zsh.sh`
+- [ ] 1.3 Add `zstyle ':omz:plugins:nvm' autoload yes` before `source $ZSH/oh-my-zsh.sh`
+- [ ] 1.4 Add `zstyle ':omz:plugins:nvm' silent-autoload yes` before `source $ZSH/oh-my-zsh.sh`
+- [ ] 1.5 Remove line 31 (`[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"`)
+- [ ] 1.6 Remove line 32 (`[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"`)
+
+## 2. gh plugin migration
+
+- [ ] 2.1 Remove line 75 (`# GitHub CLI completions` comment)
+- [ ] 2.2 Remove line 76 (`eval "$(gh completion -s zsh)"`)
+
+## 3. bun plugin migration
+
+- [ ] 3.1 Remove line 134 (`# bun completions` comment)
+- [ ] 3.2 Remove line 135 (`[ -s "{{ .chezmoi.homeDir }}/.bun/_bun" ] && source ...`)
+- [ ] 3.3 Verify lines 138-139 (`BUN_INSTALL` and `PATH`) remain intact
+
+## 4. Expand plugin array
+
+- [ ] 4.1 Replace the current `plugins=()` block (lines 16-22) with the categorized 26-plugin array from design decision D4
+- [ ] 4.2 Verify all 26 plugins are present: `git`, `gitignore`, `brew`, `docker`, `docker-compose`, `npm`, `macos`, `gh`, `aliases`, `colored-man-pages`, `command-not-found`, `copybuffer`, `copyfile`, `copypath`, `encode64`, `extract`, `fancy-ctrl-z`, `history`, `jsontools`, `safe-paste`, `sudo`, `bgnotify`, `urltools`, `web-search`, `you-should-use`, `nvm`, `bun`
+- [ ] 4.3 Verify excluded plugins are NOT present: `eza`, `fzf`, `zoxide`, `starship`, `z`
+
+## 5. Validation
+
+- [ ] 5.1 Verify all custom alias blocks are unchanged (eza, bat, zoxide, git, gh shortcuts, ripgrep, utility)
+- [ ] 5.2 Verify tool init lines are unchanged (starship, zoxide, atuin, fzf, autosuggestions, syntax-highlighting)
+- [ ] 5.3 Verify PATH/env exports are unchanged (PNPM_HOME, BUN_INSTALL)
+- [ ] 5.4 Verify no orphaned comments remain from removed lines


### PR DESCRIPTION
## Summary

- Add expand-omz-plugins change artifacts: proposal, design, specs, and tasks for expanding oh-my-zsh plugins from 5 to 26 and migrating nvm/gh/bun from manual init to plugin equivalents with lazy loading
- Add tune-autosuggestions change artifacts
- Add improve-zsh-completions change proposal

## Changes

### expand-omz-plugins (new)
- Expand oh-my-zsh plugin array from 5 to 26 plugins
- Migrate nvm, gh, and bun initialization from manual `eval`/`source` to oh-my-zsh plugin equivalents
- Enable nvm lazy loading to reduce shell startup from ~450-850ms to ~120-150ms
- Full spec-driven artifacts: proposal, design (5 decisions), specs (8 requirements, 17 scenarios), tasks (16 tasks)

### tune-autosuggestions
- Change artifacts for tuning zsh-autosuggestions configuration

### improve-zsh-completions
- Change proposal for improving zsh completions