### PR TITLE
docs: add git-dotfile-proposal change artifacts

### DIFF
--- a/openspec/changes/git-dotfile-proposal/.openspec.yaml
+++ b/openspec/changes/git-dotfile-proposal/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-04

--- a/openspec/changes/git-dotfile-proposal/design.md
+++ b/openspec/changes/git-dotfile-proposal/design.md
@@ -1,0 +1,69 @@
+## Context
+
+The dotfiles repo manages shell configuration via chezmoi but git configuration (`~/.gitconfig`, `~/.gitignore_global`) remains unmanaged. The current gitconfig was hand-edited over time, accumulating Sourcetree entries (app no longer installed), a stale commit template reference, and hardcoded absolute paths. The system git is Apple's bundled 2.33.0, which lacks modern features like `push.autoSetupRemote` and `merge.conflictstyle = zdiff3`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Manage `~/.gitconfig` and `~/.gitignore_global` via chezmoi so they travel across machines
+- Remove legacy cruft and add modern git defaults
+- Ensure brew-installed git (2.47+) is available so all modern config options work
+- Curate git aliases that complement (not duplicate) OMZ shell aliases
+
+**Non-Goals:**
+- Delta Catppuccin theming — delta 0.18.2 can't use bat's built-in themes; deferred to zshrc `BAT_THEME`
+- Per-project git config overrides — out of scope, handled by `.git/config` in each repo
+- GPG signing setup — separate concern, can be layered later
+- `core.fsmonitor` — requires git 2.37+ and has edge cases; left as a commented hint
+
+## Decisions
+
+### D1: Reuse existing chezmoi data for user identity
+
+**Decision:** Use `{{ .name }}` and `{{ .email }}` from `.chezmoi.toml.tmpl` rather than adding new `git_name`/`git_email` fields.
+
+**Rationale:** The existing prompts already collect name and email. Adding separate git-specific fields doubles the prompts on first setup with no practical benefit — the values are identical. If they ever diverge (e.g., work machine with different git email), a future change can add a conditional.
+
+**Alternative considered:** Separate `git_name`/`git_email` with `promptStringOnce`. Rejected because YAGNI — no current need for divergent values.
+
+### D2: Add `git` to BREW_PACKAGES
+
+**Decision:** Add `git` to the brew packages list in `run_once_install-packages.sh.tmpl`.
+
+**Rationale:** Apple bundles git 2.33.0 via Xcode CLT, which is 4+ years behind. Homebrew git (2.47+) unlocks `push.autoSetupRemote`, `merge.conflictstyle = zdiff3`, `diff.algorithm = histogram`. The `pkg_bin` function already maps package names to binaries, and git's binary name matches the package name — no mapping needed. Homebrew's `/usr/local/bin` (or `/opt/homebrew/bin` on Apple Silicon) takes PATH precedence over `/usr/bin`.
+
+**Alternative considered:** Template version-conditional config sections. Rejected — fragile, hard to test, and the real fix is just upgrading git.
+
+### D3: Static gitignore_global (no template)
+
+**Decision:** `dot_gitignore_global` is a plain file, not a `.tmpl`.
+
+**Rationale:** Nothing in the gitignore varies per machine. No template syntax needed. Chezmoi manages plain files just as well as templates.
+
+### D4: Git aliases = semantic operations only
+
+**Decision:** Only include aliases for operations that don't exist natively in git (`lg`, `last`, `unstage`, `undo`, `amend`, `branches`, `remotes`). Exclude shorthand aliases (`st`, `co`, `ci`, `cm`).
+
+**Rationale:** OMZ's `git` plugin provides 150+ shell aliases for shorthand (`gs` = `git status`, `gco` = `git checkout`, etc.). Duplicating those in gitconfig creates confusion about which layer provides what. Git aliases should add semantic value — commands that read naturally as git subcommands.
+
+### D5: Selective .vscode/ ignoring in gitignore_global
+
+**Decision:** Ignore `.vscode/settings.json` and `.vscode/extensions.json` but NOT the entire `.vscode/` directory.
+
+**Rationale:** `settings.json` and `extensions.json` contain personal preferences. But `launch.json` (debug configs) and `tasks.json` (build tasks) are often project-specific and intentionally committed. Full-directory ignore is too aggressive.
+
+### D6: Explicit credential helper
+
+**Decision:** Include `[credential] helper = osxkeychain` in the gitconfig.
+
+**Rationale:** This is already the macOS default, but making it explicit means the config is self-documenting. On a future Linux machine, this section can be templated to use `store` or `cache`.
+
+## Risks / Trade-offs
+
+**[First `chezmoi apply` overwrites existing gitconfig]** → All useful settings from the current config are captured in the template. The Sourcetree entries and stale commit template are intentionally dropped. No data loss.
+
+**[Brew git shadows system git]** → Homebrew git at `/usr/local/bin/git` takes PATH precedence over `/usr/bin/git`. This is standard practice and Homebrew's intended behavior. Xcode CLT git remains available at its absolute path if needed.
+
+**[`autoSetupRemote` changes push behavior]** → With `push.autoSetupRemote = true`, `git push` on a new branch auto-creates the remote tracking branch. This is the desired behavior — eliminates `--set-upstream` boilerplate. If a user wants explicit control for a specific repo, they can override with `git config --local push.autoSetupRemote false`.
+
+**[Global gitignore as safety net may mask missing project-level ignores]** → If `node_modules/` or `.env` are globally ignored, a project might forget to add them to its own `.gitignore`. This is acceptable — the safety net prevents accidental commits, and `git add -f` bypasses it when needed.

--- a/openspec/changes/git-dotfile-proposal/proposal.md
+++ b/openspec/changes/git-dotfile-proposal/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The `~/.gitconfig` and `~/.gitignore_global` are not managed by chezmoi. They don't travel across machines, accumulate cruft (Sourcetree entries for an app no longer installed, stale commit templates), and new machines start with bare git defaults — missing modern conveniences like `push.autoSetupRemote`, `fetch.prune`, and `rerere`.
+
+## What Changes
+
+- Add `dot_gitconfig.tmpl` as a chezmoi-managed template with:
+  - Templated `[user]` section using existing `.name`/`.email` chezmoi data (no new prompts)
+  - Removal of all Sourcetree/legacy entries
+  - Modern defaults: `[init] defaultBranch = main`, `[push] autoSetupRemote = true`, `[fetch] prune = true`, `[rerere] enabled = true`
+  - Delta pager configuration (carried over + enhanced with `line-numbers`)
+  - Curated git aliases (`lg`, `last`, `unstage`, `undo`, `amend`, `branches`, `remotes`) that complement — not duplicate — OMZ shell aliases
+  - Explicit `[credential] helper = osxkeychain`
+  - `[diff] algorithm = histogram` and `[merge] conflictstyle = zdiff3` for better diffs/conflicts
+- Add `dot_gitignore_global` as a static chezmoi-managed file with comprehensive safety-net patterns (macOS, IDE, env/secrets, node_modules, build outputs)
+- Add `git` to `BREW_PACKAGES` in `run_once_install-packages.sh.tmpl` to get modern git (2.47+) instead of Apple's bundled 2.33.0 — unlocks `autoSetupRemote`, `zdiff3`, `histogram`
+- **Drop** `delta.syntax-theme = "Catppuccin Mocha"` from the proposal — delta 0.18.2 doesn't inherit bat's built-in themes; handle via `BAT_THEME` env var in zshrc instead
+
+## Capabilities
+
+### New Capabilities
+- `git-config`: Chezmoi-managed git configuration (gitconfig template + gitignore_global) with modern defaults, curated aliases, and delta integration
+
+### Modified Capabilities
+<!-- None — no existing specs are affected by this change -->
+
+## Impact
+
+- **New files**: `dot_gitconfig.tmpl`, `dot_gitignore_global`
+- **Modified files**: `run_once_install-packages.sh.tmpl` (add `git` to `BREW_PACKAGES`)
+- **Overwritten on apply**: `~/.gitconfig` (replaces unmanaged file — all useful settings are captured in the template), `~/.gitignore_global`
+- **Deleted implicitly**: `~/.stCommitMsg` reference removed (Sourcetree commit template no longer referenced)
+- **Cross-change note**: Delta theming deferred to zshrc change (BAT_THEME env var); shell git aliases (gs, gp) remain in OMZ git plugin

--- a/openspec/changes/git-dotfile-proposal/specs/git-config/spec.md
+++ b/openspec/changes/git-dotfile-proposal/specs/git-config/spec.md
@@ -1,0 +1,134 @@
+## ADDED Requirements
+
+### Requirement: Chezmoi-managed gitconfig template
+The system SHALL provide a `dot_gitconfig.tmpl` file that chezmoi renders to `~/.gitconfig`. The template SHALL use `{{ .name }}` and `{{ .email }}` from chezmoi data for the `[user]` section.
+
+#### Scenario: Fresh machine apply
+- **WHEN** `chezmoi apply` runs on a machine with no `~/.gitconfig`
+- **THEN** `~/.gitconfig` is created with the user's name and email from chezmoi data, and all configured sections are present
+
+#### Scenario: Existing unmanaged gitconfig
+- **WHEN** `chezmoi apply` runs on a machine with an existing unmanaged `~/.gitconfig`
+- **THEN** the file is replaced with the managed version containing all modern defaults
+
+### Requirement: No legacy Sourcetree entries
+The gitconfig SHALL NOT contain any `[difftool "sourcetree"]`, `[mergetool "sourcetree"]`, or `[commit] template` entries referencing Sourcetree.
+
+#### Scenario: Clean config output
+- **WHEN** the rendered gitconfig is inspected
+- **THEN** no lines reference `sourcetree`, `opendiff`, or `.stCommitMsg`
+
+### Requirement: Modern git defaults
+The gitconfig SHALL include the following sections with the specified values:
+- `[init] defaultBranch = main`
+- `[push] default = current` and `autoSetupRemote = true`
+- `[pull] rebase = false`
+- `[fetch] prune = true`
+- `[rerere] enabled = true`
+- `[diff] colorMoved = default` and `algorithm = histogram`
+- `[merge] conflictstyle = zdiff3`
+- `[credential] helper = osxkeychain`
+
+#### Scenario: New repository init
+- **WHEN** `git init` is run in a new directory
+- **THEN** the default branch is named `main`
+
+#### Scenario: Push new branch
+- **WHEN** `git push` is run on a branch with no upstream
+- **THEN** the remote tracking branch is automatically created without requiring `--set-upstream`
+
+#### Scenario: Fetch prunes stale remotes
+- **WHEN** `git fetch` is run
+- **THEN** remote-tracking branches that no longer exist on the remote are automatically removed
+
+#### Scenario: Rerere records conflict resolution
+- **WHEN** a merge conflict is resolved and the same conflict appears again
+- **THEN** git automatically applies the previously recorded resolution
+
+### Requirement: Core settings
+The gitconfig SHALL set `[core]` with:
+- `editor = code --wait`
+- `autocrlf = input`
+- `excludesfile = ~/.gitignore_global`
+- `pager = delta`
+
+#### Scenario: Git commit without -m flag
+- **WHEN** `git commit` is run without a message flag
+- **THEN** VS Code opens as the commit message editor and git waits for it to close
+
+### Requirement: Delta pager configuration
+The gitconfig SHALL configure delta with:
+- `[interactive] diffFilter = delta --color-only`
+- `[delta] navigate = true`, `light = false`, `side-by-side = true`, `line-numbers = true`
+
+#### Scenario: Git diff output
+- **WHEN** `git diff` is run
+- **THEN** output is rendered through delta with side-by-side view and line numbers
+
+### Requirement: Delta does not set syntax-theme
+The gitconfig SHALL NOT include a `syntax-theme` setting in the `[delta]` section. Delta 0.18.2 does not inherit bat's built-in themes; theming is handled via `BAT_THEME` environment variable in zshrc.
+
+#### Scenario: No theme warning
+- **WHEN** `git diff` is run
+- **THEN** no `[bat warning]: Unknown theme` message appears
+
+### Requirement: Curated git aliases
+The gitconfig SHALL define exactly these aliases:
+- `lg` = graph log with color formatting and abbreviated commits
+- `last` = `log -1 HEAD --stat`
+- `unstage` = `reset HEAD --`
+- `undo` = `reset --soft HEAD~1`
+- `amend` = `commit --amend --no-edit`
+- `branches` = `branch -a`
+- `remotes` = `remote -v`
+
+The gitconfig SHALL NOT include shorthand aliases (`st`, `co`, `ci`, `cm`, `ca`, `br`, `df`, `dc`) as these are provided by the OMZ git plugin.
+
+#### Scenario: Git lg shows graph
+- **WHEN** `git lg` is run in a repository with commits
+- **THEN** a colored graph log with abbreviated hashes, branch names, relative dates, and author names is displayed
+
+#### Scenario: Git unstage removes from index
+- **WHEN** `git unstage <file>` is run
+- **THEN** the file is removed from the staging area but remains in the working tree
+
+#### Scenario: Git amend adds to last commit
+- **WHEN** staged changes exist and `git amend` is run
+- **THEN** the staged changes are added to the previous commit without changing its message
+
+### Requirement: Chezmoi-managed gitignore_global
+The system SHALL provide a `dot_gitignore_global` file (not a template) that chezmoi places at `~/.gitignore_global`.
+
+#### Scenario: Static file management
+- **WHEN** `chezmoi apply` runs
+- **THEN** `~/.gitignore_global` is created as a plain file (no template rendering)
+
+### Requirement: Comprehensive ignore patterns
+The gitignore_global SHALL include safety-net patterns for:
+- macOS artifacts (`.DS_Store`, `.AppleDouble`, `.LSOverride`, `._*`)
+- Editor/IDE files (selective `.vscode/` files, `.idea/`, `*.swp`, `*.swo`, `*~`, Sublime files)
+- Environment/secrets (`.env`, `.env.local`, `.env.*.local`)
+- Node.js (`node_modules/`, debug logs for npm/yarn/pnpm)
+- Logs (`logs/`, `*.log`)
+- Build outputs (`dist/`, `build/`, `*.map`)
+- Testing (`coverage/`, `.nyc_output/`)
+- Temporary (`tmp/`, `temp/`)
+
+#### Scenario: .vscode selective ignore
+- **WHEN** a project contains `.vscode/settings.json` and `.vscode/launch.json`
+- **THEN** `settings.json` is globally ignored but `launch.json` is NOT globally ignored
+
+#### Scenario: Env files ignored globally
+- **WHEN** a project without its own `.gitignore` contains a `.env` file
+- **THEN** the `.env` file is excluded from `git status` and `git add`
+
+### Requirement: Brew-installed git
+The install script SHALL include `git` in `BREW_PACKAGES` so that Homebrew installs a modern version (2.37+) that supports all configured features.
+
+#### Scenario: Git added to brew packages
+- **WHEN** `run_once_install-packages.sh.tmpl` is rendered
+- **THEN** `git` appears in the `BREW_PACKAGES` array
+
+#### Scenario: Modern git available after install
+- **WHEN** brew packages are installed and shell is restarted
+- **THEN** `git --version` reports 2.37 or higher

--- a/openspec/changes/git-dotfile-proposal/tasks.md
+++ b/openspec/changes/git-dotfile-proposal/tasks.md
@@ -1,0 +1,23 @@
+## 1. Install Script
+
+- [ ] 1.1 Add `git` to `BREW_PACKAGES` array in `run_once_install-packages.sh.tmpl`
+
+## 2. Gitconfig Template
+
+- [ ] 2.1 Create `dot_gitconfig.tmpl` with `[user]` section using `{{ .name }}` and `{{ .email }}` chezmoi data
+- [ ] 2.2 Add `[core]` section: editor, autocrlf, excludesfile, pager (no Sourcetree entries)
+- [ ] 2.3 Add modern defaults: `[init]`, `[push]`, `[pull]`, `[fetch]`, `[rerere]`, `[credential]`
+- [ ] 2.4 Add `[diff]` section with `colorMoved` and `algorithm = histogram`
+- [ ] 2.5 Add `[merge]` section with `conflictstyle = zdiff3`
+- [ ] 2.6 Add `[interactive]` and `[delta]` sections (no syntax-theme)
+- [ ] 2.7 Add `[alias]` section: `lg`, `last`, `unstage`, `undo`, `amend`, `branches`, `remotes`
+
+## 3. Gitignore Global
+
+- [ ] 3.1 Create `dot_gitignore_global` with macOS, IDE (selective .vscode/), env/secrets, Node.js, logs, build, testing, and temp patterns
+
+## 4. Verification
+
+- [ ] 4.1 Run `chezmoi diff` to confirm rendered gitconfig matches expected output
+- [ ] 4.2 Verify no Sourcetree or legacy entries in rendered output
+- [ ] 4.3 Verify `dot_gitignore_global` includes selective `.vscode/` entries (settings.json + extensions.json only)


### PR DESCRIPTION
## Summary
- Adds OpenSpec change artifacts for managing `~/.gitconfig` and `~/.gitignore_global` via chezmoi
- Proposal covers: templated user identity, modern git defaults (autoSetupRemote, zdiff3, histogram), curated aliases, delta config, comprehensive gitignore_global
- Design documents 6 key decisions: reuse existing chezmoi data, brew-install git for modern features, selective .vscode/ ignoring, alias philosophy (semantic ops vs keystroke shortcuts)
- Spec defines 11 requirements with testable scenarios
- Tasks break implementation into 12 items across 4 groups

## Test plan
- [ ] Review proposal for completeness and accuracy
- [ ] Verify design decisions align with existing dotfiles patterns
- [ ] Confirm spec requirements are testable and cover all gitconfig sections
- [ ] Validate task breakdown covers all files to create/modify

🤖 Generated with [Claude Code](https://claude.com/claude-code)