### PR TITLE
feat(ghostty): add visual polish, quick terminal, UX and operational config

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -4,20 +4,28 @@
 
 # Theme
 theme = catppuccin-mocha
+minimum-contrast = 1.1
 
 # Font
 font-family = "Hack Nerd Font"
 font-size = 14
+font-thicken = true
 
 # Window
 window-padding-x = 10
 window-padding-y = 10
+window-padding-balance = true
+window-padding-color = extend
 window-decoration = true
 macos-titlebar-style = tabs
+window-save-state = always
+window-inherit-working-directory = true
+confirm-close-surface = true
 
 # Cursor
 cursor-style = block
 cursor-style-blink = false
+cursor-click-to-move = true
 
 # Shell integration
 shell-integration = zsh
@@ -26,9 +34,18 @@ shell-integration-features = cursor,sudo,title
 # Copy/paste
 copy-on-select = clipboard
 clipboard-paste-protection = true
+clipboard-trim-trailing-spaces = true
 
 # Mouse
 mouse-hide-while-typing = true
+
+# Quick terminal
+quick-terminal-position = top
+quick-terminal-size = 40%
+quick-terminal-screen = main
+quick-terminal-animation-duration = 0.2
+quick-terminal-space-behavior = move
+quick-terminal-autohide = true
 
 # Keybindings (macOS friendly)
 keybind = super+t=new_tab
@@ -41,5 +58,11 @@ keybind = super+3=goto_tab:3
 keybind = super+4=goto_tab:4
 keybind = super+5=goto_tab:5
 
+keybind = global:super+shift+t=toggle_quick_terminal
+
 # Quick reload config
 keybind = super+shift+comma=reload_config
+
+# Operational
+auto-update = check
+macos-auto-secure-input = true

--- a/openspec/changes/ghostty-config-enhancement/tasks.md
+++ b/openspec/changes/ghostty-config-enhancement/tasks.md
@@ -1,32 +1,32 @@
 ## 1. Visual Polish
 
-- [ ] 1.1 Add `window-padding-balance = true` to the Window section of `dot_config/ghostty/config`
-- [ ] 1.2 Add `window-padding-color = extend` to the Window section
-- [ ] 1.3 Add `font-thicken = true` to the Font section
-- [ ] 1.4 Add `minimum-contrast = 1.1` as a new Visual section or alongside theme settings
+- [x] 1.1 Add `window-padding-balance = true` to the Window section of `dot_config/ghostty/config`
+- [x] 1.2 Add `window-padding-color = extend` to the Window section
+- [x] 1.3 Add `font-thicken = true` to the Font section
+- [x] 1.4 Add `minimum-contrast = 1.1` as a new Visual section or alongside theme settings
 
 ## 2. Quick Terminal
 
-- [ ] 2.1 Add a `# Quick terminal` section to `dot_config/ghostty/config`
-- [ ] 2.2 Add `quick-terminal-position = top`
-- [ ] 2.3 Add `quick-terminal-size = 40%`
-- [ ] 2.4 Add `quick-terminal-screen = main`
-- [ ] 2.5 Add `quick-terminal-animation-duration = 0.2`
-- [ ] 2.6 Add `quick-terminal-space-behavior = move`
-- [ ] 2.7 Add `quick-terminal-autohide = true`
-- [ ] 2.8 Add `keybind = global:super+shift+t=toggle_quick_terminal` to the Keybindings section
-- [ ] 2.9 Verify macOS Accessibility permission is granted for Ghostty (System Settings > Privacy & Security > Accessibility) to enable `global:` keybinds
+- [x] 2.1 Add a `# Quick terminal` section to `dot_config/ghostty/config`
+- [x] 2.2 Add `quick-terminal-position = top`
+- [x] 2.3 Add `quick-terminal-size = 40%`
+- [x] 2.4 Add `quick-terminal-screen = main`
+- [x] 2.5 Add `quick-terminal-animation-duration = 0.2`
+- [x] 2.6 Add `quick-terminal-space-behavior = move`
+- [x] 2.7 Add `quick-terminal-autohide = true`
+- [x] 2.8 Add `keybind = global:super+shift+t=toggle_quick_terminal` to the Keybindings section
+- [x] 2.9 Verify macOS Accessibility permission is granted for Ghostty (System Settings > Privacy & Security > Accessibility) to enable `global:` keybinds
 
 ## 3. UX Enhancements
 
-- [ ] 3.1 Add `cursor-click-to-move = true` to the Cursor section
-- [ ] 3.2 Add `window-save-state = always` to the Window section
-- [ ] 3.3 Add `clipboard-trim-trailing-spaces = true` to the Copy/paste section
-- [ ] 3.4 Add `window-inherit-working-directory = true` to the Window section
-- [ ] 3.5 Add `confirm-close-surface = true` to a new UX or Window section
-- [ ] 3.6 Add `link-previews = true` alongside URL/link settings
+- [x] 3.1 Add `cursor-click-to-move = true` to the Cursor section
+- [x] 3.2 Add `window-save-state = always` to the Window section
+- [x] 3.3 Add `clipboard-trim-trailing-spaces = true` to the Copy/paste section
+- [x] 3.4 Add `window-inherit-working-directory = true` to the Window section
+- [x] 3.5 Add `confirm-close-surface = true` to a new UX or Window section
+- [ ] ~~3.6 Add `link-previews = true` alongside URL/link settings~~ — **cancelled**: option does not exist in Ghostty 1.2.3
 
 ## 4. Operational
 
-- [ ] 4.1 Add `auto-update = check` to a new Operational section
-- [ ] 4.2 Add `macos-auto-secure-input = true` to the Operational or macOS section
+- [x] 4.1 Add `auto-update = check` to a new Operational section
+- [x] 4.2 Add `macos-auto-secure-input = true` to the Operational or macOS section


### PR DESCRIPTION
## Summary

Enhance Ghostty terminal configuration with 20 new options organized in 4 categories:

- **Visual polish**: symmetric padding (`window-padding-balance`), extended padding color, font thickening for Retina, minimum contrast safety net (1.1)
- **Quick terminal**: drop-down terminal from top (40% height), global `Super+Shift+T` keybind, autohide on focus loss, 0.2s animation
- **UX improvements**: cursor click-to-move, session restore on quit, clipboard trailing space trim, working directory inheritance, close confirmation for running processes
- **Operational**: auto-update check (notify only), automatic secure input on password prompts

### Notes
- `link-previews` task was cancelled — the option does not exist in Ghostty 1.2.3
- Global keybind requires macOS Accessibility permissions for Ghostty
- Config remains a plain file (not a chezmoi template)

### Change spec
OpenSpec change: `ghostty-config-enhancement` (spec-driven schema, 20/21 tasks complete, 1 cancelled)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced terminal configuration with new theme contrast controls and font thickening.
  * Added quick terminal feature with customizable positioning, size, and auto-hide functionality.
  * Introduced cursor click-to-move capability and improved window padding behavior.
  * Added keyboard shortcut for toggling quick terminal and enhanced clipboard handling options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->