### PR TITLE
feat(tmux): add focus-events on for vim autoread and shell integration

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -3,3 +3,6 @@ set -g mouse on
 
 # Fix terminal compatibility with Ghostty
 set -g default-terminal "xterm-256color"
+
+# Forward focus events to applications (enables vim autoread, shell integration)
+set -g focus-events on

--- a/openspec/changes/tmux-focus-events/tasks.md
+++ b/openspec/changes/tmux-focus-events/tasks.md
@@ -1,3 +1,3 @@
 ## 1. Add focus-events setting
 
-- [ ] 1.1 Add comment and `set -g focus-events on` to `dot_tmux.conf` after the existing settings, with blank line separator
+- [x] 1.1 Add comment and `set -g focus-events on` to `dot_tmux.conf` after the existing settings, with blank line separator


### PR DESCRIPTION
## Summary
- Add `set -g focus-events on` to `dot_tmux.conf` so tmux forwards focus/unfocus events to inner applications
- Enables vim `autoread` and shell integration when switching panes

## Test plan
- [ ] Run `chezmoi apply` and verify `dot_tmux.conf` includes `focus-events on`
- [ ] Open vim in tmux, modify file externally, switch back — confirm autoread triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Enabled terminal focus event forwarding in tmux configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->