### PR TITLE
feat(ghostty): change quick terminal keybind to ctrl+º

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -66,7 +66,7 @@ keybind = super+3=goto_tab:3
 keybind = super+4=goto_tab:4
 keybind = super+5=goto_tab:5
 
-keybind = global:super+shift+t=toggle_quick_terminal
+keybind = global:ctrl+º=toggle_quick_terminal
 
 # Quick reload config
 keybind = super+shift+comma=reload_config

--- a/openspec/changes/floating-shell-keybinding-proposal/design.md
+++ b/openspec/changes/floating-shell-keybinding-proposal/design.md
@@ -18,9 +18,9 @@ Ghostty 1.2.0 introduced W3C-based key code naming, making physical key referenc
 
 ## Decisions
 
-### Decision: Use `ctrl+backquote` as the new keybind
+### Decision: Use `ctrl+º` as the new keybind
 
-**Choice**: `global:ctrl+backquote=toggle_quick_terminal`
+**Choice**: `global:ctrl+º=toggle_quick_terminal`
 
 **Rationale**: On Spanish ISO Mac keyboard, `backquote` is the `º` key (top-left, above Tab). This is the classic "Quake console" position.
 
@@ -32,12 +32,12 @@ Alternatives evaluated:
 | `super+backquote`         | ❌ Collides with macOS "switch windows of same app"      |
 | `alt+backquote`           | ⚠️ macOS may intercept Option+key for character input    |
 | `super+ctrl+t`            | ✅ Free, but triple modifier is awkward                  |
-| `ctrl+backquote`          | ✅ Free in macOS, Chrome, WebStorm. Classic Quake-style. |
+| `ctrl+º`                  | ✅ Free in macOS, Chrome, WebStorm. Classic Quake-style. |
 
-**Trade-off**: `ctrl+backquote` is used by VS Code for "toggle integrated terminal," but user is 95% WebStorm. In VS Code, Ghostty's global binding would take precedence anyway.
+**Trade-off**: `ctrl+º` is used by VS Code for "toggle integrated terminal," but user is 95% WebStorm. In VS Code, Ghostty's global binding would take precedence anyway.
 
 ## Risks / Trade-offs
 
 - **[Muscle memory]** → One-time relearning cost. Low friction since this is a recent addition.
 - **[VS Code conflict]** → Ghostty global keybind overrides VS Code's `ctrl+backtick`. Acceptable given minimal VS Code usage.
-- **[Ghostty W3C key naming]** → `backquote` must be verified to work on Spanish ISO layout. Requires Ghostty ≥1.2.0.
+- **[Ghostty key naming on Spanish ISO]** → W3C key name `backquote` does not map to the `º` key on Spanish ISO Mac (it maps to `IntlBackslash` in W3C). Using the Unicode character `º` directly in the keybind config works correctly — Ghostty matches layout-dependent characters.

--- a/openspec/changes/floating-shell-keybinding-proposal/proposal.md
+++ b/openspec/changes/floating-shell-keybinding-proposal/proposal.md
@@ -1,11 +1,11 @@
 ## Why
 
-`super+shift+t` (Cmd+Shift+T) collides with Chrome's "reopen last closed tab" — a heavily used shortcut. The quick terminal keybind needs to change to `ctrl+backquote` (Ctrl+º on Spanish keyboard), a Quake-style binding that's free in macOS, Chrome, and WebStorm.
+`super+shift+t` (Cmd+Shift+T) collides with Chrome's "reopen last closed tab" — a heavily used shortcut. The quick terminal keybind needs to change to `ctrl+º` (Ctrl+º on Spanish keyboard), a Quake-style binding that's free in macOS, Chrome, and WebStorm.
 
 ## What Changes
 
-- **BREAKING**: Quick terminal global keybind changes from `super+shift+t` to `ctrl+backquote`
-- Ghostty config line updated: `keybind = global:ctrl+backquote=toggle_quick_terminal`
+- **BREAKING**: Quick terminal global keybind changes from `super+shift+t` to `ctrl+º`
+- Ghostty config line updated: `keybind = global:ctrl+º=toggle_quick_terminal`
 
 ## Capabilities
 
@@ -15,7 +15,7 @@ None.
 
 ### Modified Capabilities
 
-- `ghostty-quick-terminal`: Global keybind requirement changes from `super+shift+t` to `ctrl+backquote`
+- `ghostty-quick-terminal`: Global keybind requirement changes from `super+shift+t` to `ctrl+º`
 
 ## Impact
 

--- a/openspec/changes/floating-shell-keybinding-proposal/specs/ghostty-quick-terminal/spec.md
+++ b/openspec/changes/floating-shell-keybinding-proposal/specs/ghostty-quick-terminal/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Global keybind toggles the quick terminal
 
-The Ghostty config SHALL include `keybind = global:ctrl+backquote=toggle_quick_terminal` to toggle the quick terminal from any application using Ctrl+º (Ctrl+Backquote on W3C physical key layout).
+The Ghostty config SHALL include `keybind = global:ctrl+º=toggle_quick_terminal` to toggle the quick terminal from any application using Ctrl+º (Ctrl+Backquote on W3C physical key layout).
 
 #### Scenario: Toggle from another application
 

--- a/openspec/changes/floating-shell-keybinding-proposal/tasks.md
+++ b/openspec/changes/floating-shell-keybinding-proposal/tasks.md
@@ -1,10 +1,10 @@
 ## 1. Update Ghostty config
 
-- [ ] 1.1 Change keybind line in `dot_config/ghostty/config` from `global:super+shift+t=toggle_quick_terminal` to `global:ctrl+backquote=toggle_quick_terminal`
+- [x] 1.1 Change keybind line in `dot_config/ghostty/config` from `global:super+shift+t=toggle_quick_terminal` to `global:ctrl+º=toggle_quick_terminal`
 
 ## 2. Verify
 
-- [ ] 2.1 Confirm Ghostty accepts `ctrl+backquote` syntax (no config errors on reload)
-- [ ] 2.2 Test Ctrl+º toggles quick terminal from another app
-- [ ] 2.3 Test Cmd+Shift+T still reopens closed tabs in Chrome
-- [ ] 2.4 Test Cmd+º still switches windows of the same app
+- [x] 2.1 Confirm Ghostty accepts `ctrl+º` syntax (no config errors on reload)
+- [x] 2.2 Test Ctrl+º toggles quick terminal from another app
+- [x] 2.3 Test Cmd+Shift+T still reopens closed tabs in Chrome
+- [x] 2.4 Test Cmd+º still switches windows of the same app (not affected — our keybind uses ctrl, not cmd)


### PR DESCRIPTION
## Summary
- Replace `super+shift+t` with `ctrl+º` for Ghostty quick terminal toggle — fixes collision with Chrome's "reopen closed tab" (Cmd+Shift+T)
- W3C key name `backquote` doesn't map to `º` on Spanish ISO Mac; using Unicode character directly works with Ghostty's layout-dependent matching
- All artifacts (proposal, design, specs, tasks) updated to reflect the discovery

## Test plan
- [x] Ghostty accepts `ctrl+º` syntax (no config errors on reload)
- [x] Ctrl+º toggles quick terminal from another app
- [x] Cmd+Shift+T still reopens closed tabs in Chrome
- [x] Cmd+º not affected (our keybind uses ctrl, not cmd)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Updated the global quick terminal toggle keybinding from Super+Shift+T to Ctrl+º to eliminate conflicts with Chrome's Cmd+Shift+T tab-restore shortcut and macOS window-switching shortcuts.

* **Documentation**
  * Added comprehensive design documentation, technical specifications, and implementation guidance detailing the keybinding change rationale and supporting user transition to the new shortcut.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->