### PR TITLE
docs: ghostty font unification artifacts (#31)

### DIFF
--- a/openspec/changes/ghostty-font-unification/.openspec.yaml
+++ b/openspec/changes/ghostty-font-unification/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-13

--- a/openspec/changes/ghostty-font-unification/design.md
+++ b/openspec/changes/ghostty-font-unification/design.md
@@ -1,0 +1,49 @@
+## Context
+
+Two machines currently diverge on Ghostty font configuration:
+
+- **Repo/Machine A (Mac 2019)**: Hack Nerd Font @ 14, font-thicken ON
+- **Machine B (Mac 2024)**: JetBrainsMono Nerd Font @ 15, font-thicken ON
+
+Hands-on evaluation of all 8 combinations (2 fonts x 2 sizes x thicken on/off) on the lower-density display (2019 Mac) determined the winner. The 2019 Mac is the harder test — if it looks good there, it looks equal or better on the 2024.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Single font configuration in the repo that works across both machines
+- Commented alternative for quick switching between the two best options
+- Both fonts available on any machine running the dotfiles setup
+
+**Non-Goals:**
+
+- Per-machine conditional font config (would add complexity for minimal gain)
+- Supporting fonts beyond Hack and JetBrainsMono Nerd Font
+- Changing any non-font visual settings
+
+## Decisions
+
+### Primary font: Hack Nerd Font @ 14, thicken ON
+
+Evaluated winner across both display densities. Rounder, wider characters provide better readability at 14pt, especially on the lower-density 2019 Retina display. `font-thicken = true` is essential — without it, strokes look too thin on macOS.
+
+**Alternatives considered:**
+
+- JetBrainsMono @ 14 thicken ON — close second, slightly less readable on lower-density display
+- Any font @ 15 — too large on both machines, reduces visible terminal content
+- Any font with thicken OFF — universally worse on macOS Retina
+
+### Commented alternative in config
+
+The runner-up (JetBrainsMono @ 14, thicken ON) will be present as commented lines directly below the active font config. This allows switching with a two-line edit rather than remembering the alternative values.
+
+### Font installation via Homebrew cask
+
+Nerd Font variants are available as Homebrew casks (`font-hack-nerd-font`, `font-jetbrains-mono-nerd-font`). This is the standard installation method — JetBrains IDEs bundle JetBrains Mono but NOT the Nerd Font variant, so Homebrew is needed regardless.
+
+The setup script (Brewfile or equivalent) should ensure both fonts are installed so switching is always possible.
+
+## Risks / Trade-offs
+
+- **[Risk] Font size 14 may feel small on the 2024 Mac's larger display** → The commented alternative makes it trivial to switch. If this becomes a pattern, per-machine config could be revisited later.
+- **[Risk] Homebrew cask names could change** → Nerd Font casks have been stable for years; low probability.

--- a/openspec/changes/ghostty-font-unification/proposal.md
+++ b/openspec/changes/ghostty-font-unification/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Two machines run different Ghostty font configurations (Hack Nerd Font @ 14 vs JetBrainsMono Nerd Font @ 15). The dotfiles repo should define a single font config that works well across both machines. After hands-on evaluation of all 8 combinations (2 fonts x 2 sizes x thicken on/off), the winner is clear — but the runner-up should be available as a commented alternative for quick switching.
+
+Additionally, the chosen font may not be pre-installed (e.g., it comes bundled with JetBrains IDEs but not with macOS itself), so the setup script needs to ensure the font is available.
+
+## What Changes
+
+- Unify Ghostty font config to **Hack Nerd Font @ 14, font-thicken ON** (confirmed winner from evaluation)
+- Add commented alternative config for **JetBrainsMono Nerd Font @ 14, thicken ON** (runner-up) for fast switching
+- Verify font installation requirements and update setup script if needed to install both fonts
+- Update `ghostty-visual-polish` spec to reflect the unified decision and alternative
+
+## Capabilities
+
+### New Capabilities
+
+_None_
+
+### Modified Capabilities
+
+- `ghostty-visual-polish`: Font specification changes from a single hardcoded choice to a primary + commented alternative pattern. Setup requirements may expand to include font installation.
+
+## Impact
+
+- `dot_config/ghostty/config` — font section updated with alternative
+- `ghostty-visual-polish` spec — updated to reflect decision
+- Setup script — may need font installation step (depends on investigation of whether fonts need manual install or come from tooling like JetBrains/Homebrew)

--- a/openspec/changes/ghostty-font-unification/specs/ghostty-visual-polish/spec.md
+++ b/openspec/changes/ghostty-font-unification/specs/ghostty-visual-polish/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: Font rendering is thickened on macOS
+
+The Ghostty config SHALL include `font-thicken = true` to draw fonts with a thicker stroke on macOS Retina displays, improving legibility at the configured font size (14pt Hack Nerd Font). The config SHALL also include a commented alternative font configuration (JetBrainsMono Nerd Font @ 14, thicken ON) directly below the active font settings for quick switching.
+
+#### Scenario: Font thickening is enabled
+
+- **WHEN** a user opens a Ghostty terminal on macOS
+- **THEN** the config contains `font-thicken = true` and text renders with thicker strokes compared to the default
+
+#### Scenario: Commented alternative font is present
+
+- **WHEN** a user inspects the font section of the Ghostty config
+- **THEN** commented lines for `font-family = "JetBrainsMono Nerd Font"` with `font-size = 14` and `font-thicken = true` SHALL be present directly below the active font configuration
+
+## ADDED Requirements
+
+### Requirement: Both font families are installed via setup
+
+The dotfiles setup SHALL install both `font-hack-nerd-font` and `font-jetbrains-mono-nerd-font` Homebrew casks so that either font choice is available without manual installation.
+
+#### Scenario: Fresh machine setup installs both fonts
+
+- **WHEN** a user runs the dotfiles setup script on a new machine
+- **THEN** both Hack Nerd Font and JetBrainsMono Nerd Font are installed and available to Ghostty
+
+#### Scenario: Switching to alternative font works without extra steps
+
+- **WHEN** a user uncomments the alternative font config and comments out the primary
+- **THEN** Ghostty reloads successfully with the alternative font because it is already installed

--- a/openspec/changes/ghostty-font-unification/tasks.md
+++ b/openspec/changes/ghostty-font-unification/tasks.md
@@ -1,0 +1,12 @@
+## 1. Ghostty config — font section
+
+- [ ] 1.1 Add commented alternative font block (`JetBrainsMono Nerd Font @ 14, thicken ON`) below the active font settings in `dot_config/ghostty/config`
+
+## 2. Setup script — font installation
+
+- [ ] 2.1 Add `font-jetbrains-mono-nerd-font` cask installation to the fonts group in `run_once_install-packages.sh.tmpl`, following the same pattern as the existing Hack Nerd Font block
+- [ ] 2.2 Update the confirm prompt to reflect both fonts (e.g., "Install terminal fonts (Hack + JetBrainsMono Nerd Font)?")
+
+## 3. Spec update
+
+- [ ] 3.1 Update `openspec/specs/ghostty-visual-polish/spec.md` to reflect the commented alternative pattern and font installation requirement


### PR DESCRIPTION
## Summary

- OpenSpec artifacts (proposal, design, specs, tasks) for unifying Ghostty font config across machines
- Decision from hands-on evaluation of 8 combinations: **Hack Nerd Font @ 14, thicken ON** wins
- JetBrainsMono @ 14 as commented alternative for quick switching
- Setup script to install both fonts via Homebrew casks

Closes #31

## Tasks (for implementation)

1. Add commented JetBrainsMono alternative in ghostty config
2. Add `font-jetbrains-mono-nerd-font` to setup script
3. Update ghostty-visual-polish spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Standardized Ghostty terminal font configuration with a pre-configured, commented alternative font option for convenient quick switching between preferences

* **Documentation**
  - Added comprehensive design documentation and detailed technical specifications for terminal font configuration strategy and installation procedures

* **Chores**
  - Updated automated installation scripts to provision and install required terminal font packages during initial machine setup and configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->