### PR TITLE
docs: add openspec artifacts for ghostty prompt navigation

### DIFF
--- a/openspec/changes/ghostty-prompt-navigation/.openspec.yaml
+++ b/openspec/changes/ghostty-prompt-navigation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-14

--- a/openspec/changes/ghostty-prompt-navigation/design.md
+++ b/openspec/changes/ghostty-prompt-navigation/design.md
@@ -1,0 +1,38 @@
+## Context
+
+Ghostty's shell integration (`shell-integration = zsh`) injects code that emits OSC 133 escape sequences at each prompt. The terminal records these positions. The `jump_to_prompt` action uses these markers to scroll directly to a prompt boundary.
+
+The config already has `super+shift+left/right` for tab navigation. Adding `super+shift+up/down` for prompt navigation completes the directional keybinding pattern.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Enable instant navigation between prompts via keyboard shortcuts
+- Follow the existing `super+shift+direction` keybinding convention
+
+**Non-Goals:**
+
+- Changing shell integration features or configuration
+- Adding prompt-related visual indicators or decorations
+- Customizable jump distances (e.g., jump 3 prompts at once)
+
+## Decisions
+
+### Keybinding choice: `super+shift+up/down`
+
+Use `super+shift+up` for previous prompt and `super+shift+down` for next prompt.
+
+**Rationale**: Extends the existing directional pattern (`super+shift+left/right` for tabs). Vertical axis maps naturally to scrollback navigation. These keys are currently unbound.
+
+**Alternative considered**: `super+up/down` (without shift) — rejected because these are commonly used by macOS for window management and could conflict with system shortcuts.
+
+### Placement: after tab navigation keybindings
+
+Place the two new lines immediately after the existing `super+shift+left/right` tab navigation keybindings and before the `goto_tab` keybindings.
+
+**Rationale**: Groups all `super+shift+direction` keybindings together for readability.
+
+## Risks / Trade-offs
+
+- [Minimal risk] If shell integration is disabled or breaks, `jump_to_prompt` silently does nothing — no error, no crash, just no navigation. → No mitigation needed.

--- a/openspec/changes/ghostty-prompt-navigation/proposal.md
+++ b/openspec/changes/ghostty-prompt-navigation/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Claude Code and other AI tools produce verbose terminal output, forcing users to scroll hundreds of lines to find previous commands. Ghostty's shell integration already marks prompt locations via OSC 133 — adding `jump_to_prompt` keybindings lets users navigate between prompts instantly.
+
+## What Changes
+
+- Add `keybind = super+shift+up=jump_to_prompt:-1` to jump to the previous prompt
+- Add `keybind = super+shift+down=jump_to_prompt:1` to jump to the next prompt
+- Both keybindings are placed in the existing Keybindings section of `dot_config/ghostty/config`
+
+## Capabilities
+
+### New Capabilities
+
+- `ghostty-prompt-navigation`: Keybindings for jumping between shell prompts in the Ghostty terminal scrollback
+
+### Modified Capabilities
+
+_None — no existing spec requirements change._
+
+## Impact
+
+- **File**: `dot_config/ghostty/config` — two new `keybind` lines added to the Keybindings section
+- **Dependencies**: Relies on `shell-integration = zsh` (already configured) which emits OSC 133 prompt markers
+- **No breaking changes**: `super+shift+up/down` are currently unbound

--- a/openspec/changes/ghostty-prompt-navigation/specs/ghostty-prompt-navigation/spec.md
+++ b/openspec/changes/ghostty-prompt-navigation/specs/ghostty-prompt-navigation/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Jump to previous prompt keybinding
+
+The Ghostty config SHALL include `keybind = super+shift+up=jump_to_prompt:-1` to enable jumping to the previous prompt in the scrollback buffer.
+
+#### Scenario: Jump to previous prompt
+
+- **WHEN** the user presses Cmd+Shift+Up
+- **THEN** the terminal scrolls to the nearest prompt marker above the current viewport position
+
+#### Scenario: No previous prompt available
+
+- **WHEN** the user presses Cmd+Shift+Up and no prompt marker exists above the current position
+- **THEN** nothing happens (no error, no scroll)
+
+### Requirement: Jump to next prompt keybinding
+
+The Ghostty config SHALL include `keybind = super+shift+down=jump_to_prompt:1` to enable jumping to the next prompt in the scrollback buffer.
+
+#### Scenario: Jump to next prompt
+
+- **WHEN** the user presses Cmd+Shift+Down
+- **THEN** the terminal scrolls to the nearest prompt marker below the current viewport position
+
+#### Scenario: No next prompt available
+
+- **WHEN** the user presses Cmd+Shift+Down and no prompt marker exists below the current position
+- **THEN** nothing happens (no error, no scroll)
+
+### Requirement: Prompt navigation keybindings are grouped with tab navigation
+
+The prompt navigation keybindings SHALL be placed immediately after the tab navigation keybindings (`super+shift+left`/`super+shift+right`) in the Keybindings section of the Ghostty config.
+
+#### Scenario: Keybinding ordering in config file
+
+- **WHEN** a contributor reads the Keybindings section of `dot_config/ghostty/config`
+- **THEN** the `super+shift+up` and `super+shift+down` keybindings appear immediately after `super+shift+right=next_tab` and before the `goto_tab` keybindings

--- a/openspec/changes/ghostty-prompt-navigation/tasks.md
+++ b/openspec/changes/ghostty-prompt-navigation/tasks.md
@@ -1,0 +1,8 @@
+## 1. Add prompt navigation keybindings
+
+- [ ] 1.1 Add `keybind = super+shift+up=jump_to_prompt:-1` after the `super+shift+right=next_tab` line in `dot_config/ghostty/config`
+- [ ] 1.2 Add `keybind = super+shift+down=jump_to_prompt:1` immediately after the previous keybinding
+
+## 2. Verify
+
+- [ ] 2.1 Confirm both keybindings appear between tab navigation and goto_tab keybindings in the Keybindings section


### PR DESCRIPTION
## Summary

- Adds OpenSpec change proposal for `jump_to_prompt` keybindings in Ghostty config
- `super+shift+up` to jump to previous prompt, `super+shift+down` for next
- Leverages existing shell integration (OSC 133 prompt markers)

Closes #37

## Artifacts

- **proposal.md**: Motivation and scope
- **design.md**: Keybinding choice rationale and placement decision
- **specs/ghostty-prompt-navigation/spec.md**: 3 requirements, 5 scenarios
- **tasks.md**: Implementation checklist (3 tasks)

## Test plan

- [ ] Review proposal and design for completeness
- [ ] Verify spec scenarios cover edge cases (no previous/next prompt)
- [ ] Run `/opsx:apply` to implement the actual config changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design specifications and implementation proposal for vertical prompt navigation shortcuts in the terminal.
  * Documented keybindings (Super+Shift+Up/Down) to navigate between shell prompts in scrollback history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->