### PR TITLE
feat(ghostty): add split navigation keybindings

### DIFF
--- a/openspec/changes/ghostty-split-keybindings/proposal.md
+++ b/openspec/changes/ghostty-split-keybindings/proposal.md
@@ -5,8 +5,8 @@ Ghostty supports native splits but the config has no keybindings for them. Users
 ## What Changes
 
 - Add keybindings for creating vertical (`super+d`) and horizontal (`super+shift+d`) splits
-- Add keybindings for navigating between splits (`super+alt+arrow`)
-- Add keybindings for resizing splits (`super+ctrl+arrow`) using `resize_split` with 40px increments per keypress
+- Add keybindings for navigating between splits: `super+alt+left/right/up/down` mapping to `goto_split:left/right/top/bottom`
+- Add keybindings for resizing splits: `super+ctrl+left/right/up/down` mapping to `resize_split:left/right/up/down,40` (40px increments per keypress)
 - Add keybindings for split zoom toggle (`super+shift+enter`) and equalize (`super+shift+equal`)
 - Group all split keybindings under a dedicated comment section in the config
 
@@ -25,3 +25,21 @@ _(none)_
 - **File**: `dot_config/ghostty/config` — new keybind lines added to the keybindings section
 - **No breaking changes** — all new bindings use currently unbound key combinations
 - **No dependency changes**
+
+### Example config lines
+
+```
+# Splits
+keybind = super+d=new_split:right
+keybind = super+shift+d=new_split:down
+keybind = super+alt+left=goto_split:left
+keybind = super+alt+right=goto_split:right
+keybind = super+alt+up=goto_split:top
+keybind = super+alt+down=goto_split:bottom
+keybind = super+ctrl+left=resize_split:left,40
+keybind = super+ctrl+right=resize_split:right,40
+keybind = super+ctrl+up=resize_split:up,40
+keybind = super+ctrl+down=resize_split:down,40
+keybind = super+shift+enter=toggle_split_zoom
+keybind = super+shift+equal=equalize_splits
+```


### PR DESCRIPTION
## Summary

- Propose native Ghostty split keybindings: create (`super+d`/`super+shift+d`), navigate (`super+alt+arrow`), resize (`super+ctrl+arrow`), zoom (`super+shift+enter`), and equalize (`super+shift+=`)
- Extends existing modifier pattern consistently (super+shift=tabs, super+alt=split nav, super+ctrl=split resize)
- Includes resize_split support (40px increments) beyond the original issue scope

## Test plan

- [ ] Review proposal at `openspec/changes/ghostty-split-keybindings/proposal.md`
- [ ] Validate no keybinding conflicts with existing config
- [ ] Once approved, implement changes to `dot_config/ghostty/config`
- [ ] Reload Ghostty config and verify all split operations work

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added split keybindings for vertical/horizontal split creation, navigation, resizing, zoom toggle, and equalize; uses unbound key combinations and introduces a dedicated config section for these bindings. No breaking changes.

* **Documentation**
  * Added docs describing the split keybinding options, configuration grouping, and the new capability for Ghostty split keybindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->