### PR TITLE
feat(ghostty): set vertical window padding to 6

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -13,7 +13,7 @@ font-thicken = true
 
 # Window
 window-padding-x = 10
-window-padding-y = 10
+window-padding-y = 6
 window-padding-balance = true
 window-padding-color = extend
 scrollbar = system

--- a/openspec/changes/ghostty-padding-values/tasks.md
+++ b/openspec/changes/ghostty-padding-values/tasks.md
@@ -1,3 +1,3 @@
 ## 1. Config Change
 
-- [ ] 1.1 Change `window-padding-y` from `10` to `6` in `dot_config/ghostty/config`
+- [x] 1.1 Change `window-padding-y` from `10` to `6` in `dot_config/ghostty/config`


### PR DESCRIPTION
## Summary
- Reduce `window-padding-y` from `10` to `6` for a 10x6 padding ratio
- Preserves lateral breathing room while maximizing vertical lines for dense output (Claude Code) and the 40%-height quick terminal
- Resolves divergence between repo config and actual machine config after A/B testing

## Test plan
- [ ] Open Ghostty and verify padding looks correct (10px horizontal, 6px vertical)
- [ ] Check quick terminal (40% height) has adequate vertical space
- [ ] Verify `window-padding-balance = true` still distributes padding evenly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted window vertical padding for improved spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->