### PR TITLE
feat(ghostty): add prompt navigation keybindings

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -64,6 +64,8 @@ keybind = super+t=new_tab
 keybind = super+w=close_surface
 keybind = super+shift+left=previous_tab
 keybind = super+shift+right=next_tab
+keybind = super+shift+up=jump_to_prompt:-1
+keybind = super+shift+down=jump_to_prompt:1
 keybind = super+1=goto_tab:1
 keybind = super+2=goto_tab:2
 keybind = super+3=goto_tab:3

--- a/openspec/changes/ghostty-prompt-navigation/tasks.md
+++ b/openspec/changes/ghostty-prompt-navigation/tasks.md
@@ -1,8 +1,8 @@
 ## 1. Add prompt navigation keybindings
 
-- [ ] 1.1 Add `keybind = super+shift+up=jump_to_prompt:-1` after the `super+shift+right=next_tab` line in `dot_config/ghostty/config`
-- [ ] 1.2 Add `keybind = super+shift+down=jump_to_prompt:1` immediately after the previous keybinding
+- [x] 1.1 Add `keybind = super+shift+up=jump_to_prompt:-1` after the `super+shift+right=next_tab` line in `dot_config/ghostty/config`
+- [x] 1.2 Add `keybind = super+shift+down=jump_to_prompt:1` immediately after the previous keybinding
 
 ## 2. Verify
 
-- [ ] 2.1 Confirm both keybindings appear between tab navigation and goto_tab keybindings in the Keybindings section
+- [x] 2.1 Confirm both keybindings appear between tab navigation and goto_tab keybindings in the Keybindings section


### PR DESCRIPTION
## Summary

- Add `super+shift+up` / `super+shift+down` keybindings to jump between shell prompts in Ghostty scrollback via `jump_to_prompt`
- Keybindings placed after tab navigation (`super+shift+left/right`) to group all directional `super+shift` bindings together
- Relies on existing `shell-integration = zsh` which emits OSC 133 prompt markers

## Test plan

- [ ] Open Ghostty, run several commands to generate scrollback
- [ ] Press `Cmd+Shift+Up` — terminal scrolls to previous prompt
- [ ] Press `Cmd+Shift+Down` — terminal scrolls to next prompt
- [ ] Verify no conflict with existing keybindings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added keyboard shortcuts for prompt navigation in Ghostty: Super+Shift+Up jumps to the previous prompt, and Super+Shift+Down jumps to the next prompt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->