### PR TITLE
feat(ghostty): use shell-integration detect instead of hardcoded zsh

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -31,7 +31,7 @@ cursor-style-blink = false
 cursor-click-to-move = true
 
 # Shell integration
-shell-integration = zsh
+shell-integration = detect
 shell-integration-features = cursor,sudo,title
 
 # Copy/paste

--- a/openspec/changes/ghostty-shell-integration-detect/tasks.md
+++ b/openspec/changes/ghostty-shell-integration-detect/tasks.md
@@ -1,10 +1,10 @@
 ## 1. Config change
 
-- [ ] 1.1 Change `shell-integration = zsh` to `shell-integration = detect` in `dot_config/ghostty/config`
+- [x] 1.1 Change `shell-integration = zsh` to `shell-integration = detect` in `dot_config/ghostty/config`
 
 ## 2. Spec update
 
-- [ ] 2.1 Update `openspec/specs/ghostty-ux-enhancements/spec.md` — change the `shell-integration = zsh` reference to `shell-integration = detect` in the "Cursor can be moved by clicking at prompts" requirement
+- [x] 2.1 Update `openspec/specs/ghostty-ux-enhancements/spec.md` — change the `shell-integration = zsh` reference to `shell-integration = detect` in the "Cursor can be moved by clicking at prompts" requirement
 
 ## 3. Verification
 

--- a/openspec/specs/ghostty-ux-enhancements/spec.md
+++ b/openspec/specs/ghostty-ux-enhancements/spec.md
@@ -17,7 +17,7 @@ The Ghostty config SHALL include `keybind = super+shift+comma=reload_config` to 
 
 ### Requirement: Cursor can be moved by clicking at prompts
 
-The Ghostty config SHALL include `cursor-click-to-move = true` to enable Option+click cursor positioning at shell prompts. This requires shell integration (already configured with `shell-integration = zsh`).
+The Ghostty config SHALL include `cursor-click-to-move = true` to enable Option+click cursor positioning at shell prompts. This requires shell integration (configured with `shell-integration = detect`).
 
 #### Scenario: Option+click moves cursor
 


### PR DESCRIPTION
## Summary
- Change `shell-integration = zsh` to `shell-integration = detect` in Ghostty config so integration features (cursor positioning, sudo forwarding, title updates) activate for any supported shell, not just zsh
- Update `ghostty-ux-enhancements` spec to reflect the new setting value
- Mark implementation tasks complete in OpenSpec change

## Test plan
- [ ] Confirm zsh behavior is unchanged with `shell-integration = detect`
- [ ] Launch a bash sub-shell in Ghostty and confirm shell-integration features activate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated shell integration configuration to use automatic detection instead of a fixed shell setting.

* **Documentation**
  * Updated specification and task documentation to reflect shell integration detection configuration change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->