### PR TITLE
docs: OpenSpec proposal for chezmoi Claude hooks and plugins

### DIFF
--- a/openspec/changes/chezmoi-claude-hooks-plugins/.openspec.yaml
+++ b/openspec/changes/chezmoi-claude-hooks-plugins/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-21

--- a/openspec/changes/chezmoi-claude-hooks-plugins/design.md
+++ b/openspec/changes/chezmoi-claude-hooks-plugins/design.md
@@ -15,14 +15,13 @@ The template is static JSON with chezmoi Go template expressions only for `statu
 
 **Non-Goals:**
 
-- Installing the `bd` CLI (handled separately; hooks no-op gracefully without it)
 - Installing beads or code-simplifier plugin code (marketplace auto-update handles this)
 - Adding conditional logic (e.g., platform-specific hooks)
 - Modifying any existing settings entries
 
 ## Decisions
 
-### 1. Single file, additive-only edits
+### 1. Single-file, additive-only edits
 
 All three issues modify `dot_claude/settings.json.tmpl`. Changes are insertions only — no existing lines are modified or removed. This minimizes merge risk and keeps the diff reviewable.
 
@@ -40,5 +39,5 @@ New entries are appended to the end of `enabledPlugins` and `extraKnownMarketpla
 
 ## Risks / Trade-offs
 
-- **`bd` not installed** → Hooks will fail silently or error on machines without the beads CLI. Mitigation: `bd prime` is a no-op when beads isn't relevant; a future change could add `bd` to the install script.
+- **`bd` not installed** → Hooks will error on machines without the beads CLI. Mitigation: `bd` is added to the brew packages list in `run_once_install-packages.sh.tmpl` so it's installed alongside other CLI tools.
 - **JSON validity** → Adding entries requires correct comma placement in the template. Mitigation: verification step confirms valid JSON output after `chezmoi apply`.

--- a/openspec/changes/chezmoi-claude-hooks-plugins/proposal.md
+++ b/openspec/changes/chezmoi-claude-hooks-plugins/proposal.md
@@ -8,6 +8,8 @@ The chezmoi template `dot_claude/settings.json.tmpl` is out of sync with plugins
 - Add `code-simplifier@claude-plugins-official` to `enabledPlugins`
 - Add `beads-marketplace` entry (steveyegge/beads) to `extraKnownMarketplaces`
 - Add new top-level `hooks` key with `PreCompact` and `SessionStart` entries that run `bd prime`
+- Add `bd` to brew packages in `run_once_install-packages.sh.tmpl`
+- Add beads plugin/marketplace registration to Claude Code plugin dependencies group in `run_once_install-packages.sh.tmpl`
 
 ## Capabilities
 
@@ -21,6 +23,6 @@ The chezmoi template `dot_claude/settings.json.tmpl` is out of sync with plugins
 
 ## Impact
 
-- **File**: `dot_claude/settings.json.tmpl` (single file, additive changes only)
-- **Dependencies**: `bd` CLI must be available on PATH for hooks to function (no-ops gracefully if absent or if `.beads/` doesn't exist)
+- **Files**: `dot_claude/settings.json.tmpl` and `run_once_install-packages.sh.tmpl` (additive changes only)
+- **Dependencies**: `bd` CLI is installed via brew in the run_once script; required on PATH for hooks to function. `bd prime` no-ops gracefully if `.beads/` doesn't exist in the current directory.
 - **No breaking changes**: all additions are additive to existing config

--- a/openspec/changes/chezmoi-claude-hooks-plugins/specs/claude-code-plugins/spec.md
+++ b/openspec/changes/chezmoi-claude-hooks-plugins/specs/claude-code-plugins/spec.md
@@ -28,6 +28,20 @@ The Claude Code settings dotfile (`dot_claude/settings.json.tmpl`) SHALL include
 - **WHEN** Claude Code checks for plugin updates
 - **THEN** the beads marketplace is included in the auto-update cycle because `autoUpdate` is `true`
 
+### Requirement: Beads plugin and marketplace are registered in install script
+
+The install script (`run_once_install-packages.sh.tmpl`) SHALL register the `beads-marketplace` marketplace (`steveyegge/beads`) and install the `beads@beads-marketplace` plugin in the Claude Code plugin dependencies group.
+
+#### Scenario: First run with Claude Code installed
+
+- **WHEN** `chezmoi apply` runs the install script and the user confirms the Claude Code plugin dependencies group
+- **THEN** the beads marketplace is registered via `claude plugin marketplace add steveyegge/beads` and the beads plugin is installed via `claude plugin install beads@beads-marketplace`
+
+#### Scenario: Claude Code not installed
+
+- **WHEN** `claude` is not available on the machine
+- **THEN** the Claude Code plugin dependencies group is skipped with a warning
+
 ### Requirement: Code-simplifier plugin is enabled by default
 
 The Claude Code settings dotfile (`dot_claude/settings.json.tmpl`) SHALL include `"code-simplifier@claude-plugins-official": true` in the `enabledPlugins` object.

--- a/openspec/changes/chezmoi-claude-hooks-plugins/specs/claude-hooks/spec.md
+++ b/openspec/changes/chezmoi-claude-hooks-plugins/specs/claude-hooks/spec.md
@@ -6,6 +6,20 @@ Claude Code hook configuration managed by chezmoi — hook definitions in the se
 
 ## ADDED Requirements
 
+### Requirement: bd CLI is installed via brew
+
+The brew packages list in `run_once_install-packages.sh.tmpl` SHALL include `bd` so that the beads CLI is available on PATH for hooks to function.
+
+#### Scenario: Fresh machine setup
+
+- **WHEN** `chezmoi apply` runs the install script and the user confirms the brew packages group
+- **THEN** `bd` is installed via `brew install bd`
+
+#### Scenario: Already installed
+
+- **WHEN** the `bd` command is already available on the machine
+- **THEN** the brew packages group skips `bd` installation and reports it as already installed
+
 ### Requirement: bd prime runs on SessionStart
 
 The Claude Code settings dotfile (`dot_claude/settings.json.tmpl`) SHALL include a `hooks.SessionStart` entry that runs `bd prime` with an empty matcher (global scope).
@@ -17,12 +31,12 @@ The Claude Code settings dotfile (`dot_claude/settings.json.tmpl`) SHALL include
 
 #### Scenario: Session starts in a beads-enabled project
 
-- **WHEN** a Claude Code session starts in a directory containing `.beads/`
+- **WHEN** a Claude Code session starts in a directory containing `.beads/` and `bd` is installed
 - **THEN** the `bd prime` hook executes and initializes beads context
 
 #### Scenario: Session starts in a non-beads project
 
-- **WHEN** a Claude Code session starts in a directory without `.beads/`
+- **WHEN** a Claude Code session starts in a directory without `.beads/` and `bd` is installed
 - **THEN** the `bd prime` hook executes and exits as a no-op without errors
 
 ### Requirement: bd prime runs on PreCompact
@@ -36,10 +50,10 @@ The Claude Code settings dotfile (`dot_claude/settings.json.tmpl`) SHALL include
 
 #### Scenario: Context compaction in a beads-enabled project
 
-- **WHEN** Claude Code triggers context compaction in a directory containing `.beads/`
+- **WHEN** Claude Code triggers context compaction in a directory containing `.beads/` and `bd` is installed
 - **THEN** the `bd prime` hook executes and re-primes beads context before compaction
 
 #### Scenario: Context compaction in a non-beads project
 
-- **WHEN** Claude Code triggers context compaction in a directory without `.beads/`
+- **WHEN** Claude Code triggers context compaction in a directory without `.beads/` and `bd` is installed
 - **THEN** the `bd prime` hook executes and exits as a no-op without errors

--- a/openspec/changes/chezmoi-claude-hooks-plugins/tasks.md
+++ b/openspec/changes/chezmoi-claude-hooks-plugins/tasks.md
@@ -11,7 +11,16 @@
 
 - [ ] 3.1 Add top-level `hooks` key to `dot_claude/settings.json.tmpl` with `PreCompact` and `SessionStart` entries running `bd prime` with empty matcher
 
-## 4. Verification
+## 4. Install script updates
 
-- [ ] 4.1 Validate the resulting template produces valid JSON (no trailing commas, correct nesting)
-- [ ] 4.2 Run `chezmoi diff` to confirm expected changes to `~/.claude/settings.json`
+- [ ] 4.1 Add `bd` to the `BREW_PACKAGES` array in `run_once_install-packages.sh.tmpl`
+- [ ] 4.2 Add beads marketplace registration (`claude plugin marketplace add steveyegge/beads`) to Claude Code plugin dependencies group
+- [ ] 4.3 Add beads plugin install (`claude plugin install beads@beads-marketplace`) to Claude Code plugin dependencies group
+- [ ] 4.4 Add code-simplifier plugin install (`claude plugin install code-simplifier@claude-plugins-official`) to Claude Code plugin dependencies group
+
+## 5. Verification
+
+- [ ] 5.1 Validate the resulting template produces valid JSON (no trailing commas, correct nesting)
+- [ ] 5.2 Run `chezmoi diff` to confirm expected changes to `~/.claude/settings.json`
+- [ ] 5.3 Verify `bd prime` runs without errors in a directory with `.beads/`
+- [ ] 5.4 Verify `bd prime` no-ops without errors in a directory without `.beads/`


### PR DESCRIPTION
## Summary

- Adds OpenSpec change `chezmoi-claude-hooks-plugins` with all artifacts (proposal, design, specs, tasks)
- Covers syncing the chezmoi Claude settings template with locally installed plugins (beads, code-simplifier), marketplace (beads-marketplace), and hooks (`bd prime` for PreCompact/SessionStart)
- **Proposal only** — implementation will follow in a separate PR that closes the issues

## Artifacts created

| Artifact | Description |
|----------|-------------|
| `proposal.md` | Motivation and scope (references #72, #73, #77) |
| `design.md` | Single-file additive approach, global matcher decision |
| `specs/claude-hooks/spec.md` | New capability: PreCompact + SessionStart hooks |
| `specs/claude-code-plugins/spec.md` | Modified capability: beads + code-simplifier plugins |
| `tasks.md` | 6 implementation tasks across 4 groups |

## Test plan

- [ ] Review proposal covers all three issues
- [ ] Review specs have testable scenarios
- [ ] Review tasks are sufficient for implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added docs and specs describing default Claude Code changes: two plugins enabled by default, a registered marketplace, and installer updates to include the required CLI.
  * Introduced global session hooks (PreCompact, SessionStart) configured to run a short lifecycle command; hooks run globally and safely no-op when not applicable.
  * Guidance ensures resulting settings remain valid JSON and verification steps for install/run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->