### PR TITLE
feat: add user preferences to chezmoi Claude settings

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -98,5 +98,8 @@
       "autoUpdate": true
     }
   },
-  "effortLevel": "high"
+  "effortLevel": "high",
+  "alwaysThinkingEnabled": true,
+  "voiceEnabled": true,
+  "skipDangerousModePermissionPrompt": true
 }

--- a/openspec/changes/chezmoi-claude-preferences/tasks.md
+++ b/openspec/changes/chezmoi-claude-preferences/tasks.md
@@ -1,8 +1,8 @@
 ## 1. Add user preferences to chezmoi template
 
-- [ ] 1.1 Add `alwaysThinkingEnabled`, `voiceEnabled`, and `skipDangerousModePermissionPrompt` as `true` to `dot_claude/settings.json.tmpl`, grouped near `effortLevel`
+- [x] 1.1 Add `alwaysThinkingEnabled`, `voiceEnabled`, and `skipDangerousModePermissionPrompt` as `true` to `dot_claude/settings.json.tmpl`, grouped near `effortLevel`
 
 ## 2. Verify
 
-- [ ] 2.1 Run `chezmoi diff` to confirm the template produces the expected output with all three new keys
-- [ ] 2.2 Validate rendered JSON contains `alwaysThinkingEnabled`, `voiceEnabled`, and `skipDangerousModePermissionPrompt` set to `true` via `chezmoi execute-template` piped to `jq`
+- [x] 2.1 Run `chezmoi diff` to confirm the template produces the expected output with all three new keys
+- [x] 2.2 Validate rendered JSON contains `alwaysThinkingEnabled`, `voiceEnabled`, and `skipDangerousModePermissionPrompt` set to `true` via `chezmoi execute-template` piped to `jq`


### PR DESCRIPTION
## Summary
- Adds `alwaysThinkingEnabled`, `voiceEnabled`, and `skipDangerousModePermissionPrompt` as static `true` values to `dot_claude/settings.json.tmpl`
- Groups these session behavior preferences near the existing `effortLevel` key
- Makes daily workflow preferences portable across machines via chezmoi

Closes #76

## Test plan
- [x] `chezmoi execute-template` renders valid JSON with all three keys set to `true`
- [x] `jq` extraction confirms correct key names and values

🤖 Generated with [Claude Code](https://claude.com/claude-code)