### PR TITLE
fix: consolidate expo plugin entries

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -9,9 +9,7 @@
   "enabledPlugins": {
     "claude-hud@claude-hud": true,
     "typescript-lsp@claude-plugins-official": true,
-    "expo-app-design@expo-plugins": true,
-    "upgrading-expo@expo-plugins": true,
-    "expo-deployment@expo-plugins": true,
+    "expo@expo-plugins": true,
     "claude-code-wakatime@wakatime": true,
     "expo-developer@monolab": true,
     "double-shot-latte@superpowers-marketplace": true,

--- a/openspec/changes/chezmoi-expo-plugin/tasks.md
+++ b/openspec/changes/chezmoi-expo-plugin/tasks.md
@@ -1,11 +1,11 @@
 ## 1. Update enabledPlugins
 
-- [ ] 1.1 Add `"expo@expo-plugins": true` to the `enabledPlugins` object in `dot_claude/settings.json.tmpl`
-- [ ] 1.2 Remove `"expo-app-design@expo-plugins": true` from `enabledPlugins`
-- [ ] 1.3 Remove `"upgrading-expo@expo-plugins": true` from `enabledPlugins`
-- [ ] 1.4 Remove `"expo-deployment@expo-plugins": true` from `enabledPlugins`
+- [x] 1.1 Add `"expo@expo-plugins": true` to the `enabledPlugins` object in `dot_claude/settings.json.tmpl`
+- [x] 1.2 Remove `"expo-app-design@expo-plugins": true` from `enabledPlugins`
+- [x] 1.3 Remove `"upgrading-expo@expo-plugins": true` from `enabledPlugins`
+- [x] 1.4 Remove `"expo-deployment@expo-plugins": true` from `enabledPlugins`
 
 ## 2. Verify
 
-- [ ] 2.1 Confirm `settings.json.tmpl` is valid JSON (no trailing commas, correct brackets)
-- [ ] 2.2 Confirm `expo-plugins` marketplace entry is unchanged in `extraKnownMarketplaces`
+- [x] 2.1 Confirm `settings.json.tmpl` is valid JSON (no trailing commas, correct brackets)
+- [x] 2.2 Confirm `expo-plugins` marketplace entry is unchanged in `extraKnownMarketplaces`


### PR DESCRIPTION
## Summary
- Replaces three stale expo plugin entries (`expo-app-design`, `upgrading-expo`, `expo-deployment`) with the consolidated `expo@expo-plugins` entry in `dot_claude/settings.json.tmpl`
- Upstream `expo/skills` repo consolidated these into a single plugin; the old entries caused 33 duplicate skill registrations
- No functionality change — same 11 skills, no duplicates

## Test plan
- [ ] Run `chezmoi apply --dry-run` to verify template renders valid JSON
- [ ] Confirm `expo@expo-plugins` appears in the generated `~/.claude/settings.json`
- [ ] Confirm the three old entries are no longer present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined plugin configuration by consolidating Expo plugin entries.
  * Updated internal task tracking documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->