### PR TITLE
feat: add global agent skills installation via skills.sh

### DIFF
--- a/openspec/changes/skills-global-setup/tasks.md
+++ b/openspec/changes/skills-global-setup/tasks.md
@@ -1,6 +1,6 @@
 ## 1. macOS install section
 
-- [x] 1.1 Add "Group 6: Agent skills (skills.sh)" section to `run_once_install-packages.sh.tmpl` after the Claude Code plugin dependencies group, with `confirm()` prompt and `npx` availability check
+- [x] 1.1 Add "Group 6: Agent skills (skills.sh)" section to `run_onchange_install-packages.sh.tmpl` after the Claude Code plugin dependencies group, with `confirm()` prompt and `npx` availability check
 - [x] 1.2 Query installed skills via `npx -y skills list -g --json` and parse with available tooling to detect already-installed skills
 - [x] 1.3 Add the ten `npx -y skills add <repo> --skill <name> -g -y` commands with skip-if-installed checks, using `run_claude_step` for error handling (it calls `error()` which increments the global `ERRORS` counter and continues execution)
 

--- a/run_onchange_install-packages.sh.tmpl
+++ b/run_onchange_install-packages.sh.tmpl
@@ -278,6 +278,8 @@ if confirm "Install global agent skills via skills.sh?"; then
         INSTALLED_SKILLS=""
         if SKILLS_JSON="$(npx -y skills list -g --json 2>/dev/null)"; then
             INSTALLED_SKILLS="$SKILLS_JSON"
+        else
+            warn "Could not query installed global skills; proceeding without skip checks"
         fi
 
         skill_installed() {


### PR DESCRIPTION
## Summary
- Adds Group 6 (Agent skills) to the chezmoi install script, installing 10 individual global skills from 3 repos (`vercel-labs/skills`, `vercel-labs/agent-skills`, `anthropics/skills`) via `npx -y skills add`
- Includes idempotency: queries `skills list -g --json` to skip already-installed skills
- Guards with `npx` availability check and `confirm()` prompt
- Adds manual instructions for non-macOS platforms

## Test plan
- [x] Ran the new group — all 10 skills detected as already installed and skipped correctly
- [x] Verified `~/.claude/settings.json` checksum unchanged before/after
- [x] Confirmed all 10 skills present in `~/.agents/skills/` and `~/.claude/skills/`
- [x] Re-run confirmed idempotent skip behavior with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive macOS setup step that detects existing tools and installs missing global agent skills automatically; non-macOS users receive clear manual installation commands.

* **Documentation**
  * Updated the setup task checklist to mark the related verification and installation steps as completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->