### PR TITLE
docs: add tmux config expansion proposal

### DIFF
--- a/openspec/changes/add-tmux-config/.openspec.yaml
+++ b/openspec/changes/add-tmux-config/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-02

--- a/openspec/changes/add-tmux-config/design.md
+++ b/openspec/changes/add-tmux-config/design.md
@@ -1,55 +1,55 @@
 ## Context
 
-Tmux actual: 3 líneas en `dot_tmux.conf` (mouse, 256 colores, focus events). Sin plugins, sin persistencia, sin gestión de sesiones. Referencia: omerxx/dotfiles tiene un setup completo con TPM y 8+ plugins.
+Current tmux: 3 lines in `dot_tmux.conf` (mouse, 256 colors, focus events). No plugins, no persistence, no session management. Reference: omerxx/dotfiles has a full setup with TPM and 8+ plugins.
 
 ## Goals / Non-Goals
 
 **Goals:**
-- Añadir TPM (Tmux Plugin Manager) como gestor de plugins
-- Persistencia automática de sesiones con resurrect + continuum
-- Gestión de sesiones con sessionx (fzf + zoxide integration)
-- Paneles flotantes con floax
-- Selección rápida de texto con thumbs
-- Apertura de URLs con fzf-url
-- Tema Catppuccin Mocha coherente con el resto del setup
-- Prefix Ctrl+A (más ergonómico que Ctrl+B por defecto)
-- Vi copy mode para consistencia con vim keybindings
+- Add TPM (Tmux Plugin Manager) as the plugin manager
+- Automatic session persistence with resurrect + continuum
+- Session management with sessionx (fzf + zoxide integration)
+- Floating panes with floax
+- Fast text selection with thumbs
+- URL opening with fzf-url
+- Catppuccin Mocha theme consistent with the rest of the setup
+- Prefix Ctrl+A (more ergonomic than the default Ctrl+B)
+- Vi copy mode for consistency with vim keybindings
 
 **Non-Goals:**
-- Reemplazar Ghostty tabs/splits (tmux es complementario)
-- Configurar tmux para SSH remoto (puede venir después)
-- Scripts de sesiones predefinidas por proyecto (puede venir después)
-- Integración con SketchyBar o status bars externos
+- Replace Ghostty tabs/splits (tmux is complementary)
+- Configure tmux for remote SSH (can come later)
+- Predefined per-project session scripts (can come later)
+- Integration with SketchyBar or external status bars
 
 ## Decisions
 
-### TPM como plugin manager
-TPM (tmux-plugin-manager) se instala via git clone en `~/.tmux/plugins/tpm`. Los plugins se declaran en `dot_tmux.conf` con `set -g @plugin`. TPM se encarga de instalar/actualizar.
-- **Alternativa:** Instalar plugins manualmente → descartado por mantenimiento.
-- **Alternativa:** Nix/Home Manager → descartado porque usamos Chezmoi, no Nix.
+### TPM as plugin manager
+TPM (tmux-plugin-manager) is installed via git clone into `~/.tmux/plugins/tpm`. Plugins are declared in `dot_tmux.conf` with `set -g @plugin`. TPM handles install/update.
+- **Alternative:** install plugins manually → rejected for maintenance reasons.
+- **Alternative:** Nix/Home Manager → rejected because we use Chezmoi, not Nix.
 
-### Plugin selection (de omerxx, adaptado)
-| Plugin | Propósito | De omerxx? |
-|--------|-----------|------------|
-| tmux-resurrect | Persistir sesiones entre reinicios | Sí |
-| tmux-continuum | Auto-save cada 15 min | Sí |
-| tmux-sessionx | Session picker con fzf/zoxide | Sí (plugin propio) |
-| tmux-floax | Paneles flotantes | Sí (plugin propio) |
-| tmux-thumbs | Selección rápida de texto | Sí |
-| tmux-fzf-url | Abrir URLs visibles | Sí |
-| catppuccin/tmux | Tema | Sí (fork propio, nosotros usamos el oficial) |
-| tmux-sensible | Defaults razonables | Sí |
-| tmux-yank | Copy to system clipboard | Sí |
+### Plugin selection (from omerxx, adapted)
+| Plugin | Purpose | From omerxx? |
+|--------|---------|--------------|
+| tmux-resurrect | Persist sessions across restarts | Yes |
+| tmux-continuum | Auto-save every 15 min | Yes |
+| tmux-sessionx | Session picker with fzf/zoxide | Yes (own plugin) |
+| tmux-floax | Floating panes | Yes (own plugin) |
+| tmux-thumbs | Fast text selection | Yes |
+| tmux-fzf-url | Open visible URLs | Yes |
+| catppuccin/tmux | Theme | Yes (own fork, we use the official one) |
+| tmux-sensible | Sensible defaults | Yes |
+| tmux-yank | Copy to system clipboard | Yes |
 
 ### Prefix: Ctrl+A
-Ctrl+A es más accesible que Ctrl+B (especialmente con Caps→Ctrl de Karabiner). Conflicto potencial con readline "inicio de línea" → mitigado con `bind C-a send-prefix` para enviar Ctrl+A literal.
+Ctrl+A is more accessible than Ctrl+B (especially with Karabiner's Caps→Ctrl). Potential collision with readline "start of line" → mitigated with `bind C-a send-prefix` to send a literal Ctrl+A.
 
-### Status bar en top
-Coherente con la posición de tabs de Ghostty. Información mínima: sesión a la izquierda, directorio a la derecha.
+### Status bar on top
+Consistent with Ghostty's tab position. Minimal information: session on the left, directory on the right.
 
 ## Risks / Trade-offs
 
-- **[Conflicto Ctrl+A con readline]** → Mitigación: `send-prefix` permite enviar Ctrl+A literal con doble pulsación
-- **[TPM requiere git clone manual]** → Mitigación: añadir al install script como paso automático
-- **[Plugins pueden romperse en actualizaciones de tmux]** → Mitigación: todos los plugins seleccionados están activamente mantenidos
-- **[Duplicación con Ghostty tabs]** → No es un riesgo real, son complementarios. Tmux añade persistencia y detach
+- **[Ctrl+A collision with readline]** → Mitigation: `send-prefix` allows sending a literal Ctrl+A by double-tapping.
+- **[TPM requires a manual git clone]** → Mitigation: add it to the install script as an automated step.
+- **[Plugins may break across tmux upgrades]** → Mitigation: every selected plugin is actively maintained.
+- **[Duplication with Ghostty tabs]** → Not a real risk, they are complementary. Tmux adds persistence and detach.

--- a/openspec/changes/add-tmux-config/design.md
+++ b/openspec/changes/add-tmux-config/design.md
@@ -1,0 +1,55 @@
+## Context
+
+Tmux actual: 3 líneas en `dot_tmux.conf` (mouse, 256 colores, focus events). Sin plugins, sin persistencia, sin gestión de sesiones. Referencia: omerxx/dotfiles tiene un setup completo con TPM y 8+ plugins.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Añadir TPM (Tmux Plugin Manager) como gestor de plugins
+- Persistencia automática de sesiones con resurrect + continuum
+- Gestión de sesiones con sessionx (fzf + zoxide integration)
+- Paneles flotantes con floax
+- Selección rápida de texto con thumbs
+- Apertura de URLs con fzf-url
+- Tema Catppuccin Mocha coherente con el resto del setup
+- Prefix Ctrl+A (más ergonómico que Ctrl+B por defecto)
+- Vi copy mode para consistencia con vim keybindings
+
+**Non-Goals:**
+- Reemplazar Ghostty tabs/splits (tmux es complementario)
+- Configurar tmux para SSH remoto (puede venir después)
+- Scripts de sesiones predefinidas por proyecto (puede venir después)
+- Integración con SketchyBar o status bars externos
+
+## Decisions
+
+### TPM como plugin manager
+TPM (tmux-plugin-manager) se instala via git clone en `~/.tmux/plugins/tpm`. Los plugins se declaran en `dot_tmux.conf` con `set -g @plugin`. TPM se encarga de instalar/actualizar.
+- **Alternativa:** Instalar plugins manualmente → descartado por mantenimiento.
+- **Alternativa:** Nix/Home Manager → descartado porque usamos Chezmoi, no Nix.
+
+### Plugin selection (de omerxx, adaptado)
+| Plugin | Propósito | De omerxx? |
+|--------|-----------|------------|
+| tmux-resurrect | Persistir sesiones entre reinicios | Sí |
+| tmux-continuum | Auto-save cada 15 min | Sí |
+| tmux-sessionx | Session picker con fzf/zoxide | Sí (plugin propio) |
+| tmux-floax | Paneles flotantes | Sí (plugin propio) |
+| tmux-thumbs | Selección rápida de texto | Sí |
+| tmux-fzf-url | Abrir URLs visibles | Sí |
+| catppuccin/tmux | Tema | Sí (fork propio, nosotros usamos el oficial) |
+| tmux-sensible | Defaults razonables | Sí |
+| tmux-yank | Copy to system clipboard | Sí |
+
+### Prefix: Ctrl+A
+Ctrl+A es más accesible que Ctrl+B (especialmente con Caps→Ctrl de Karabiner). Conflicto potencial con readline "inicio de línea" → mitigado con `bind C-a send-prefix` para enviar Ctrl+A literal.
+
+### Status bar en top
+Coherente con la posición de tabs de Ghostty. Información mínima: sesión a la izquierda, directorio a la derecha.
+
+## Risks / Trade-offs
+
+- **[Conflicto Ctrl+A con readline]** → Mitigación: `send-prefix` permite enviar Ctrl+A literal con doble pulsación
+- **[TPM requiere git clone manual]** → Mitigación: añadir al install script como paso automático
+- **[Plugins pueden romperse en actualizaciones de tmux]** → Mitigación: todos los plugins seleccionados están activamente mantenidos
+- **[Duplicación con Ghostty tabs]** → No es un riesgo real, son complementarios. Tmux añade persistencia y detach

--- a/openspec/changes/add-tmux-config/proposal.md
+++ b/openspec/changes/add-tmux-config/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+El tmux actual es mínimo (260 bytes: mouse, colores, focus events). No tiene plugins, persistencia de sesiones, ni gestión avanzada. Inspirado en el setup de omerxx/dotfiles, expandir tmux con un ecosistema de plugins que aporte persistencia, sesiones nombradas, paneles flotantes y selección inteligente de texto. Esto permite evaluar tmux como alternativa/complemento a las tabs y splits nativos de Ghostty.
+
+## What Changes
+
+- Expandir `dot_tmux.conf` con configuración completa: prefix Ctrl+A, vi mode, status bar top, historial de 1M líneas
+- Añadir TPM (Tmux Plugin Manager) como gestor de plugins
+- Instalar plugins: resurrect + continuum (persistencia automática de sesiones), sessionx (gestión de sesiones con fzf/zoxide), floax (paneles flotantes), thumbs (selección rápida de texto), fzf-url (abrir URLs desde tmux)
+- Aplicar tema Catppuccin Mocha para consistencia visual con Ghostty y Starship
+- Añadir TPM y plugins al script de instalación interactivo (`run_onchange_install-packages.sh.tmpl`)
+
+## Capabilities
+
+### New Capabilities
+- `tmux-plugins`: Gestión de plugins via TPM, incluyendo resurrect, continuum, sessionx, floax, thumbs, fzf-url y catppuccin theme
+- `tmux-keybindings`: Prefix Ctrl+A, vi copy mode, navegación entre paneles, atajos para splits y sesiones
+
+### Modified Capabilities
+- `tmux-config`: Ampliar la configuración base con status bar, historial expandido, y opciones de comportamiento avanzadas
+
+## Impact
+
+- **Archivos modificados:** `dot_tmux.conf`, `run_onchange_install-packages.sh.tmpl`
+- **Dependencias nuevas:** TPM (git clone), plugins de tmux (gestionados por TPM)
+- **Brew packages:** Ninguno adicional (tmux ya está en el install script)
+- **Riesgo:** Bajo. La config existente de tmux se amplía, no se rompe. Los plugins son opcionales (TPM los instala bajo demanda)

--- a/openspec/changes/add-tmux-config/proposal.md
+++ b/openspec/changes/add-tmux-config/proposal.md
@@ -1,27 +1,27 @@
 ## Why
 
-El tmux actual es mínimo (260 bytes: mouse, colores, focus events). No tiene plugins, persistencia de sesiones, ni gestión avanzada. Inspirado en el setup de omerxx/dotfiles, expandir tmux con un ecosistema de plugins que aporte persistencia, sesiones nombradas, paneles flotantes y selección inteligente de texto. Esto permite evaluar tmux como alternativa/complemento a las tabs y splits nativos de Ghostty.
+The current tmux setup is minimal (260 bytes: mouse, colors, focus events). It has no plugins, no session persistence, and no advanced management. Inspired by the omerxx/dotfiles setup, we expand tmux with a plugin ecosystem that adds persistence, named sessions, floating panes, and smart text selection. This lets us evaluate tmux as an alternative/complement to Ghostty's native tabs and splits.
 
 ## What Changes
 
-- Expandir `dot_tmux.conf` con configuración completa: prefix Ctrl+A, vi mode, status bar top, historial de 1M líneas
-- Añadir TPM (Tmux Plugin Manager) como gestor de plugins
-- Instalar plugins: resurrect + continuum (persistencia automática de sesiones), sessionx (gestión de sesiones con fzf/zoxide), floax (paneles flotantes), thumbs (selección rápida de texto), fzf-url (abrir URLs desde tmux)
-- Aplicar tema Catppuccin Mocha para consistencia visual con Ghostty y Starship
-- Añadir TPM y plugins al script de instalación interactivo (`run_onchange_install-packages.sh.tmpl`)
+- Expand `dot_tmux.conf` with a full configuration: prefix Ctrl+A, vi mode, top status bar, 1M-line history
+- Add TPM (Tmux Plugin Manager) as the plugin manager
+- Install plugins: resurrect + continuum (automatic session persistence), sessionx (session management with fzf/zoxide), floax (floating panes), thumbs (fast text selection), fzf-url (open URLs from tmux)
+- Apply the Catppuccin Mocha theme for visual consistency with Ghostty and Starship
+- Add TPM and plugins to the interactive install script (`run_onchange_install-packages.sh.tmpl`)
 
 ## Capabilities
 
 ### New Capabilities
-- `tmux-plugins`: Gestión de plugins via TPM, incluyendo resurrect, continuum, sessionx, floax, thumbs, fzf-url y catppuccin theme
-- `tmux-keybindings`: Prefix Ctrl+A, vi copy mode, navegación entre paneles, atajos para splits y sesiones
+- `tmux-plugins`: Plugin management via TPM, including resurrect, continuum, sessionx, floax, thumbs, fzf-url, and the catppuccin theme
+- `tmux-keybindings`: Prefix Ctrl+A, vi copy mode, pane navigation, shortcuts for splits and sessions
 
 ### Modified Capabilities
-- `tmux-config`: Ampliar la configuración base con status bar, historial expandido, y opciones de comportamiento avanzadas
+- `tmux-config`: Extend the base configuration with a status bar, expanded history, and advanced behavior options
 
 ## Impact
 
-- **Archivos modificados:** `dot_tmux.conf`, `run_onchange_install-packages.sh.tmpl`
-- **Dependencias nuevas:** TPM (git clone), plugins de tmux (gestionados por TPM)
-- **Brew packages:** Ninguno adicional (tmux ya está en el install script)
-- **Riesgo:** Bajo. La config existente de tmux se amplía, no se rompe. Los plugins son opcionales (TPM los instala bajo demanda)
+- **Modified files:** `dot_tmux.conf`, `run_onchange_install-packages.sh.tmpl`
+- **New dependencies:** TPM (git clone), tmux plugins (managed by TPM)
+- **Brew packages:** None additional (tmux is already in the install script)
+- **Risk:** Low. The existing tmux config is extended, not broken. Plugins are optional (TPM installs them on demand).

--- a/openspec/changes/add-tmux-config/specs/tmux-config/spec.md
+++ b/openspec/changes/add-tmux-config/specs/tmux-config/spec.md
@@ -1,0 +1,8 @@
+## MODIFIED Requirements
+
+### Requirement: Descriptive comment
+Each setting in `dot_tmux.conf` SHALL have a comment line above it explaining its purpose, matching the existing comment style.
+
+#### Scenario: All settings commented
+- **WHEN** reading `dot_tmux.conf`
+- **THEN** every `set` and `bind` directive has a comment above it describing its purpose

--- a/openspec/changes/add-tmux-config/specs/tmux-keybindings/spec.md
+++ b/openspec/changes/add-tmux-config/specs/tmux-keybindings/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Prefix key is Ctrl+A
+`dot_tmux.conf` SHALL set the prefix key to `C-a` and unbind the default `C-b`. A `send-prefix` binding SHALL be configured so that pressing prefix twice sends a literal Ctrl+A to the underlying application.
+
+#### Scenario: Prefix works
+- **WHEN** user presses Ctrl+A followed by a tmux command key
+- **THEN** tmux interprets it as a prefixed command
+
+#### Scenario: Literal Ctrl+A passthrough
+- **WHEN** user presses Ctrl+A twice
+- **THEN** a literal Ctrl+A is sent to the active pane (for readline beginning-of-line)
+
+### Requirement: Vi copy mode
+`dot_tmux.conf` SHALL set `mode-keys` to `vi` so that copy mode uses vim-style navigation.
+
+#### Scenario: Copy mode uses vi keys
+- **WHEN** user enters copy mode
+- **THEN** navigation uses h/j/k/l, visual selection uses v, and yank uses y
+
+### Requirement: Status bar position
+`dot_tmux.conf` SHALL set `status-position` to `top`.
+
+#### Scenario: Status bar at top
+- **WHEN** tmux starts
+- **THEN** the status bar is displayed at the top of the terminal window
+
+### Requirement: History limit
+`dot_tmux.conf` SHALL set `history-limit` to 1000000 (1 million lines).
+
+#### Scenario: Large scrollback available
+- **WHEN** user scrolls back in a pane
+- **THEN** up to 1 million lines of history are available

--- a/openspec/changes/add-tmux-config/specs/tmux-plugins/spec.md
+++ b/openspec/changes/add-tmux-config/specs/tmux-plugins/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: TPM plugin manager
+`dot_tmux.conf` SHALL include TPM (Tmux Plugin Manager) bootstrap at the end of the file. TPM SHALL be cloned to `~/.tmux/plugins/tpm` and initialized with `run '~/.tmux/plugins/tpm/tpm'` as the last line.
+
+#### Scenario: TPM bootstrap present
+- **WHEN** `dot_tmux.conf` is applied via chezmoi
+- **THEN** the file ends with `run '~/.tmux/plugins/tpm/tpm'`
+
+#### Scenario: TPM install in install script
+- **WHEN** user runs the install script and confirms the tmux plugins group
+- **THEN** TPM is git cloned to `~/.tmux/plugins/tpm` if not already present
+
+### Requirement: Session persistence with resurrect and continuum
+`dot_tmux.conf` SHALL declare `tmux-plugins/tmux-resurrect` and `tmux-plugins/tmux-continuum` as TPM plugins. Continuum SHALL be configured for automatic restore on tmux start and automatic save.
+
+#### Scenario: Session survives tmux server restart
+- **WHEN** user kills tmux server and starts a new one
+- **THEN** continuum auto-restores the last saved session (windows, panes, working directories)
+
+#### Scenario: Auto-save is enabled
+- **WHEN** tmux is running
+- **THEN** continuum saves session state automatically at the default interval (15 minutes)
+
+### Requirement: Session manager with sessionx
+`dot_tmux.conf` SHALL declare `omerxx/tmux-sessionx` as a TPM plugin with zoxide integration enabled.
+
+#### Scenario: Session picker available
+- **WHEN** user presses the sessionx keybinding
+- **THEN** a fzf-powered session picker appears listing all tmux sessions with zoxide-suggested directories
+
+### Requirement: Floating panes with floax
+`dot_tmux.conf` SHALL declare `omerxx/tmux-floax` as a TPM plugin configured with 80% width and height.
+
+#### Scenario: Floating pane opens
+- **WHEN** user presses the floax keybinding
+- **THEN** a floating pane appears centered at 80% of the terminal dimensions
+
+### Requirement: Quick text selection with thumbs
+`dot_tmux.conf` SHALL declare `fcsonline/tmux-thumbs` as a TPM plugin.
+
+#### Scenario: Text selection mode activates
+- **WHEN** user presses the thumbs keybinding
+- **THEN** tmux highlights all selectable text objects (URLs, paths, hashes, IPs) with letter hints for quick copy
+
+### Requirement: URL opening with fzf-url
+`dot_tmux.conf` SHALL declare `wfxr/tmux-fzf-url` as a TPM plugin.
+
+#### Scenario: URL picker opens
+- **WHEN** user presses the fzf-url keybinding
+- **THEN** fzf lists all visible URLs in the current pane and selecting one opens it in the default browser
+
+### Requirement: Catppuccin theme
+`dot_tmux.conf` SHALL declare `catppuccin/tmux` as a TPM plugin with the mocha flavor. Status bar SHALL show session name on the left and current directory on the right.
+
+#### Scenario: Theme applied
+- **WHEN** tmux starts with the config applied
+- **THEN** the status bar and pane borders use Catppuccin Mocha colors
+
+### Requirement: Sensible defaults and yank
+`dot_tmux.conf` SHALL declare `tmux-plugins/tmux-sensible` and `tmux-plugins/tmux-yank` as TPM plugins.
+
+#### Scenario: System clipboard integration
+- **WHEN** user copies text in tmux copy mode
+- **THEN** the text is also available in the macOS system clipboard

--- a/openspec/changes/add-tmux-config/tasks.md
+++ b/openspec/changes/add-tmux-config/tasks.md
@@ -1,0 +1,24 @@
+## 1. Install script updates
+
+- [ ] 1.1 Add TPM git clone to install script (`run_onchange_install-packages.sh.tmpl`): clone `https://github.com/tmux-plugins/tpm` to `~/.tmux/plugins/tpm` if not already present
+- [ ] 1.2 Add a new interactive install group "Tmux Plugins" that runs `~/.tmux/plugins/tpm/bin/install_plugins` after TPM is installed
+
+## 2. Expand dot_tmux.conf with base settings
+
+- [ ] 2.1 Set prefix to `C-a`, unbind `C-b`, bind `C-a send-prefix` for passthrough
+- [ ] 2.2 Set `mode-keys vi`, `status-position top`, `history-limit 1000000`
+- [ ] 2.3 Preserve existing settings: mouse on, default-terminal xterm-256color, focus-events on
+
+## 3. Add TPM plugin declarations
+
+- [ ] 3.1 Declare plugins in `dot_tmux.conf`: tmux-sensible, tmux-yank, tmux-resurrect, tmux-continuum, tmux-sessionx, tmux-floax, tmux-thumbs, tmux-fzf-url, catppuccin/tmux
+- [ ] 3.2 Configure continuum: `@continuum-restore on`
+- [ ] 3.3 Configure sessionx: enable zoxide integration (`@sessionx-zoxide-mode on`)
+- [ ] 3.4 Configure floax: 80% width and height
+- [ ] 3.5 Configure catppuccin: mocha flavor, session left module, directory right module
+- [ ] 3.6 Add TPM bootstrap as last line: `run '~/.tmux/plugins/tpm/tpm'`
+
+## 4. Verify and document
+
+- [ ] 4.1 Ensure all settings have descriptive comments matching existing style
+- [ ] 4.2 Verify config loads without errors: `tmux source-file dot_tmux.conf` (or equivalent test)


### PR DESCRIPTION
## Summary
- Add OpenSpec change proposal for expanding tmux with TPM plugin ecosystem
- Includes plugins: resurrect/continuum (persistence), sessionx (session management), floax (floating panes), thumbs (text selection), fzf-url (URL opening)
- Catppuccin Mocha theme, Ctrl+A prefix, vi mode
- Inspired by [omerxx/dotfiles](https://github.com/omerxx/dotfiles)

## Artifacts
- `proposal.md` - Why and what changes
- `design.md` - Technical decisions and rationale
- `specs/` - 3 spec files (tmux-plugins, tmux-keybindings, tmux-config)
- `tasks.md` - Implementation checklist

## Test plan
- [ ] Review proposal for scope alignment
- [ ] Review design decisions
- [ ] Validate specs are testable
- [ ] Approve for implementation via `/opsx:apply`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive tmux design, proposal, specs, and task docs for an improved terminal workflow.
  * Visible changes: Ctrl+A prefix, vi-style copy mode, top status bar, 1M-line scrollback, and requirement that each setting include a descriptive comment.
  * Introduces TPM-driven plugin management and a curated plugin set for session persistence, interactive session selection, floating panes, fast text selection, URL opening, sensible defaults, and Catppuccin theming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->