### PR TITLE
docs: add television fuzzy finder proposal

### DIFF
--- a/openspec/changes/add-television/.openspec.yaml
+++ b/openspec/changes/add-television/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-02

--- a/openspec/changes/add-television/design.md
+++ b/openspec/changes/add-television/design.md
@@ -1,0 +1,57 @@
+## Context
+
+Actualmente usamos fzf con funciones shell custom en `.zshrc` (frg, fgco, fglog, fkill) y configuración de FZF_DEFAULT_COMMAND/OPTS. Television ofrece un sistema declarativo de canales TOML con autocomplete contextual (Ctrl+T detecta el comando que se está escribiendo).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Instalar television y configurar shell integration (Ctrl+T contextual, Ctrl+R historia)
+- Configurar channel triggers para nuestro stack: git, gh, docker, bun, brew
+- Crear canal custom bun-scripts para ejecutar scripts de package.json
+- Aplicar tema Catppuccin
+- Evaluar qué funciones fzf custom de .zshrc puede reemplazar television
+
+**Non-Goals:**
+- Eliminar fzf por completo (television lo usa internamente y fzf sigue siendo útil para pipes ad-hoc)
+- Crear canales custom para kubernetes/AWS (no es nuestro stack principal)
+- Reemplazar atuin para historial (atuin tiene sync y AI, television solo tiene búsqueda local)
+
+## Decisions
+
+### Coexistencia fzf + television
+fzf sigue instalado. Television usa fzf internamente para el fuzzy matching. Lo que cambia:
+- Ctrl+T: pasa de fzf (siempre archivos) a television (contextual)
+- Ctrl+R: sigue con atuin (tiene sync + AI), no con television
+- Las funciones custom (frg, fgco, fglog, fkill) se mantienen inicialmente y se evalúa su eliminación después de validar que television las cubre
+
+### Keybinding strategy
+| Keybinding | Actual | Propuesto |
+|------------|--------|-----------|
+| Ctrl+R | atuin (historial AI) | atuin (sin cambio) |
+| Ctrl+T | fzf (archivos) | television (contextual) |
+| Alt+C | fzf (directorios) | fzf (sin cambio, television no tiene equivalente) |
+
+Television se inicializa DESPUÉS de fzf en .zshrc para que sobrescriba Ctrl+T pero no afecte otros bindings.
+
+### Channel triggers para nuestro stack
+```toml
+[shell_integration.channel_triggers]
+"git-branch" = ["git checkout", "git branch", "git merge", "git rebase"]
+"git-diff" = ["git add", "git restore", "git stash"]
+"git-log" = ["git show", "git revert", "git cherry-pick"]
+"gh-prs" = ["gh pr checkout", "gh pr view", "gh pr merge"]
+"gh-issues" = ["gh issue view", "gh issue close"]
+"docker-containers" = ["docker exec", "docker stop", "docker logs"]
+"bun-scripts" = ["bun run", "br"]
+"brew-packages" = ["brew info", "brew upgrade", "brew uninstall"]
+```
+
+### Canal custom: bun-scripts
+Archivo TOML en `cable/bun-scripts.toml` que lee `package.json` con jq y lista los scripts disponibles. Enter ejecuta el script con `bun run`.
+
+## Risks / Trade-offs
+
+- **[Conflicto Ctrl+T con fzf]** → Mitigación: television se inicializa después de fzf, sobrescribe el binding limpiamente
+- **[television es relativamente nuevo]** → Mitigación: 10k+ stars en GitHub, release frecuente, escrito en Rust
+- **[Canal bun-scripts requiere jq]** → Mitigación: jq ya debería estar instalado; añadir al install script si no lo está
+- **[Funciones custom duplicadas temporalmente]** → Aceptable: se eliminan en un cambio posterior tras validación

--- a/openspec/changes/add-television/proposal.md
+++ b/openspec/changes/add-television/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Actualmente usamos fzf con funciones shell custom (`frg`, `fgco`, `fglog`, `fkill`) para fuzzy finding. Television reemplaza estas funciones ad-hoc con un sistema declarativo de canales en TOML, añadiendo autocomplete contextual (Ctrl+T detecta el comando que estás escribiendo y ofrece las opciones relevantes: branches para `git checkout`, containers para `docker exec`, scripts para `bun run`). Menos código custom en .zshrc, más funcionalidad, todo configurable.
+
+## What Changes
+
+- Instalar television via Homebrew
+- Crear configuración base en `dot_config/television/config.toml`: tema Catppuccin, shell integration (Ctrl+T contextual, Ctrl+R historial)
+- Configurar channel triggers para nuestro stack: git, gh, docker, bun, brew, ssh
+- Crear canal custom `bun-scripts` para fuzzy-ejecutar scripts de package.json
+- Añadir inicialización `eval "$(tv init zsh)"` al .zshrc
+- Evaluar y simplificar funciones de .zshrc que Television reemplaza (`frg`, `fgco`, `fglog`, `fkill`)
+
+## Capabilities
+
+### New Capabilities
+- `television-config`: Configuración de Television (tema, shell integration, keybindings)
+- `television-channels`: Channel triggers y canales custom para el stack del proyecto (git, gh, docker, bun, brew)
+
+### Modified Capabilities
+- `zsh-config`: Añadir inicialización de television y evaluar eliminación de funciones fzf custom reemplazadas
+- `zsh-aliases`: Posible simplificación de aliases relacionados con fzf
+
+## Impact
+
+- **Archivos nuevos:** `dot_config/television/config.toml`, `dot_config/television/cable/bun-scripts.toml`
+- **Archivos modificados:** `dot_zshrc.tmpl`, `run_onchange_install-packages.sh.tmpl`
+- **Dependencias nuevas:** `television` (brew), requiere `fd`, `bat`, `rg` (ya instalados)
+- **Riesgo:** Bajo-medio. fzf sigue funcionando en paralelo. Las funciones custom se pueden eliminar gradualmente tras validar que Television las cubre

--- a/openspec/changes/add-television/specs/television-channels/spec.md
+++ b/openspec/changes/add-television/specs/television-channels/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Channel triggers for project stack
+The television config SHALL define channel triggers mapping command prefixes to appropriate channels.
+
+#### Scenario: git checkout triggers git-branch channel
+- **WHEN** user types `git checkout ` and presses Ctrl+T
+- **THEN** television opens the git-branch channel showing local and remote branches
+
+#### Scenario: git add triggers git-diff channel
+- **WHEN** user types `git add ` and presses Ctrl+T
+- **THEN** television opens the git-diff channel showing changed files
+
+#### Scenario: docker exec triggers docker-containers channel
+- **WHEN** user types `docker exec ` and presses Ctrl+T
+- **THEN** television opens the docker-containers channel showing running containers
+
+#### Scenario: gh pr triggers gh-prs channel
+- **WHEN** user types `gh pr view ` and presses Ctrl+T
+- **THEN** television opens the gh-prs channel showing open pull requests
+
+#### Scenario: brew info triggers brew-packages channel
+- **WHEN** user types `brew info ` and presses Ctrl+T
+- **THEN** television opens the brew-packages channel showing installed packages
+
+#### Scenario: bun run triggers bun-scripts channel
+- **WHEN** user types `bun run ` and presses Ctrl+T
+- **THEN** television opens the bun-scripts custom channel showing package.json scripts
+
+### Requirement: Custom bun-scripts channel
+A cable channel file SHALL exist at `dot_config/television/cable/bun-scripts.toml` that reads scripts from `package.json` using `jq` and allows running them with `bun run`.
+
+#### Scenario: Scripts listed from package.json
+- **WHEN** user activates the bun-scripts channel in a directory with package.json
+- **THEN** all scripts from package.json are listed with their commands
+
+#### Scenario: Selected script executes
+- **WHEN** user selects a script and presses Enter
+- **THEN** `bun run <script-name>` is executed

--- a/openspec/changes/add-television/specs/television-config/spec.md
+++ b/openspec/changes/add-television/specs/television-config/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Television installation
+The install script SHALL include `television` in the brew packages and `jq` as a dependency (if not already present).
+
+#### Scenario: Fresh install includes television
+- **WHEN** user runs the install script and confirms the brew packages group
+- **THEN** `television` and `jq` are installed via Homebrew
+
+### Requirement: Base configuration
+A config file SHALL exist at `dot_config/television/config.toml` with Catppuccin theme and shell integration enabled.
+
+#### Scenario: Theme is Catppuccin
+- **WHEN** television launches
+- **THEN** the UI uses the catppuccin color theme
+
+#### Scenario: Shell integration keybindings
+- **WHEN** user opens a new zsh shell
+- **THEN** Ctrl+T activates television contextual autocomplete
+
+### Requirement: Zsh initialization
+`dot_zshrc.tmpl` SHALL include `eval "$(tv init zsh)"` to enable television shell integration. This line SHALL appear AFTER fzf initialization and BEFORE zoxide initialization.
+
+#### Scenario: Television initializes after fzf
+- **WHEN** a new zsh shell starts
+- **THEN** television's Ctrl+T overrides fzf's Ctrl+T for contextual autocomplete
+
+#### Scenario: Television does not affect atuin
+- **WHEN** a new zsh shell starts
+- **THEN** Ctrl+R is still handled by atuin (not television)

--- a/openspec/changes/add-television/specs/zsh-aliases/spec.md
+++ b/openspec/changes/add-television/specs/zsh-aliases/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: fkill interactive process killer
+The zshrc SHALL define a function `fkill` that uses fzf to interactively select one or more processes and kill them. The default signal SHALL be SIGKILL (9), overridable by passing a signal number as argument. A comment SHALL note this function may be replaced by television's process channel in a future change.
+
+#### Scenario: Kill a process interactively
+- **WHEN** user types `fkill`
+- **THEN** fzf displays a list of running processes, user selects one or more, and selected processes are killed with signal 9
+
+#### Scenario: Kill with custom signal
+- **WHEN** user types `fkill 15`
+- **THEN** selected processes are killed with SIGTERM (15) instead of SIGKILL
+
+### Requirement: frg interactive code search
+The zshrc SHALL define a function `frg` that pipes ripgrep results through fzf with bat-powered preview, and opens the selected result in `$EDITOR` at the matching line number. If `$EDITOR` is unset, it SHALL fall back to `code`. A comment SHALL note this function may be replaced by television's text channel in a future change.
+
+#### Scenario: Search and open result
+- **WHEN** user types `frg "TODO"`
+- **THEN** ripgrep searches for "TODO", fzf displays matches with syntax-highlighted preview via bat, and selecting a result opens it in the editor at the matching line
+
+#### Scenario: No matches found
+- **WHEN** user types `frg "nonexistent_pattern_xyz"`
+- **THEN** ripgrep produces no output and fzf shows an empty list; no editor is opened
+
+### Requirement: fglog interactive git log browser
+The zshrc SHALL define a function `fglog` that displays `git log --oneline` through fzf with a preview pane showing the full commit diff via `git show`. A comment SHALL note this function may be replaced by television's git-log channel in a future change.
+
+#### Scenario: Browse commits interactively
+- **WHEN** user types `fglog` inside a git repository
+- **THEN** fzf displays one-line commit entries with a right-side preview showing the selected commit's full diff
+
+### Requirement: fgco interactive branch checkout
+The zshrc SHALL define a function `fgco` that lists all branches (local and remote) through fzf with a commit history preview, and checks out the selected branch. Remote branches SHALL have their `remotes/<origin>/` prefix stripped to create a local tracking branch. A comment SHALL note this function may be replaced by television's git-branch channel in a future change.
+
+#### Scenario: Checkout a local branch
+- **WHEN** user types `fgco` and selects a local branch
+- **THEN** git checks out that branch
+
+#### Scenario: Checkout a remote branch
+- **WHEN** user types `fgco` and selects `remotes/origin/feature-x`
+- **THEN** git checks out `feature-x`, creating a local tracking branch

--- a/openspec/changes/add-television/specs/zsh-config/spec.md
+++ b/openspec/changes/add-television/specs/zsh-config/spec.md
@@ -1,0 +1,32 @@
+## MODIFIED Requirements
+
+### Requirement: Zsh external plugin sources use OS-conditional paths
+Source paths for zsh-autosuggestions and zsh-syntax-highlighting SHALL use template conditionals for platform differences (e.g., `/usr/local/share/` on Intel macOS vs `/opt/homebrew/share/` on Apple Silicon vs `/usr/share/` on Linux). On macOS, fzf binary PATH SHALL use OS/arch-conditional template paths (`/opt/homebrew/opt/fzf/bin` on ARM, `/usr/local/opt/fzf/bin` on Intel). fzf initialization SHALL be inline via `source <(fzf --zsh)` instead of sourcing an external `~/.fzf.zsh` file. Television initialization SHALL appear after fzf initialization via `eval "$(tv init zsh)"`.
+
+#### Scenario: Correct fzf PATH on Apple Silicon macOS
+- **WHEN** chezmoi apply runs on an Apple Silicon Mac
+- **THEN** `.zshrc` adds `/opt/homebrew/opt/fzf/bin` to PATH if not already present
+
+#### Scenario: Correct fzf PATH on Intel macOS
+- **WHEN** chezmoi apply runs on an Intel Mac
+- **THEN** `.zshrc` adds `/usr/local/opt/fzf/bin` to PATH if not already present
+
+#### Scenario: fzf keybindings and completions loaded inline
+- **WHEN** chezmoi apply completes and user opens a new shell
+- **THEN** fzf keybindings (Alt+C) and completions are available without any external file dependency
+
+#### Scenario: No reference to external fzf file
+- **WHEN** chezmoi apply completes
+- **THEN** `.zshrc` does NOT contain `source ~/.fzf.zsh` or any reference to the `~/.fzf.zsh` file
+
+#### Scenario: Television Ctrl+T overrides fzf Ctrl+T
+- **WHEN** chezmoi apply completes and user opens a new shell
+- **THEN** Ctrl+T opens television contextual autocomplete (not fzf file search)
+
+#### Scenario: Correct plugin path on Apple Silicon macOS
+- **WHEN** chezmoi apply runs on an Apple Silicon Mac
+- **THEN** `.zshrc` sources plugins from `/opt/homebrew/share/`
+
+#### Scenario: Correct plugin path on Intel macOS
+- **WHEN** chezmoi apply runs on an Intel Mac
+- **THEN** `.zshrc` sources plugins from `/usr/local/share/`

--- a/openspec/changes/add-television/tasks.md
+++ b/openspec/changes/add-television/tasks.md
@@ -1,0 +1,29 @@
+## 1. Install script updates
+
+- [ ] 1.1 Add `television` to `BREW_PACKAGES` array in `run_onchange_install-packages.sh.tmpl`
+- [ ] 1.2 Add `jq` to `BREW_PACKAGES` array if not already present
+- [ ] 1.3 Add a step to run `tv update-channels` after television install to populate community channels
+
+## 2. Create television config
+
+- [ ] 2.1 Create `dot_config/television/config.toml` with catppuccin theme
+- [ ] 2.2 Configure shell integration section: disable Ctrl+R (keep atuin), enable Ctrl+T
+- [ ] 2.3 Define channel triggers: git (checkout/branch/merge/rebase → git-branch), git (add/restore/stash → git-diff), git (show/revert/cherry-pick → git-log), gh (pr → gh-prs, issue → gh-issues), docker (exec/stop/logs → docker-containers), bun (run → bun-scripts), brew (info/upgrade/uninstall → brew-packages)
+
+## 3. Create custom bun-scripts channel
+
+- [ ] 3.1 Create `dot_config/television/cable/bun-scripts.toml` with jq-based source reading package.json scripts
+- [ ] 3.2 Configure preview to show the script command
+- [ ] 3.3 Configure enter action to execute `bun run <script>`
+
+## 4. Update zshrc
+
+- [ ] 4.1 Add `eval "$(tv init zsh)"` to `dot_zshrc.tmpl` after fzf init block and before atuin init
+- [ ] 4.2 Add comments to fzf custom functions (frg, fgco, fglog, fkill) noting they may be replaced by television channels in a future change
+
+## 5. Verify
+
+- [ ] 5.1 Verify television loads without errors in a new shell
+- [ ] 5.2 Test Ctrl+T contextual autocomplete works (e.g., `git checkout [Ctrl+T]` shows branches)
+- [ ] 5.3 Verify Ctrl+R still uses atuin
+- [ ] 5.4 Verify bun-scripts channel works in a project with package.json


### PR DESCRIPTION
## Summary
- Add OpenSpec change proposal for integrating Television as declarative fuzzy finder
- Contextual Ctrl+T autocomplete (detects command being typed, shows relevant options)
- Channel triggers for git, gh, docker, bun, brew
- Custom bun-scripts channel for package.json scripts
- Inspired by [omerxx/dotfiles](https://github.com/omerxx/dotfiles)

## Artifacts
- `proposal.md` - Why and what changes
- `design.md` - Technical decisions (fzf coexistence, keybinding strategy)
- `specs/` - 4 spec files (television-config, television-channels, zsh-config, zsh-aliases)
- `tasks.md` - Implementation checklist

## Test plan
- [ ] Review proposal for scope alignment
- [ ] Review design decisions
- [ ] Validate specs are testable
- [ ] Approve for implementation via `/opsx:apply`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added design and specification documentation for Television shell integration.
  * Defined channel-based configuration system for fuzzy command discovery and execution.
  * Documented zsh shell integration with keybinding strategy and Catppuccin theming.
  * Specified custom channels for project tooling and package script execution.
  * Included implementation planning checklist and risk assessment documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->