### PR TITLE
docs: add Karabiner keyboard remapping proposal

### DIFF
--- a/openspec/changes/add-karabiner-config/.openspec.yaml
+++ b/openspec/changes/add-karabiner-config/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-02

--- a/openspec/changes/add-karabiner-config/design.md
+++ b/openspec/changes/add-karabiner-config/design.md
@@ -1,42 +1,42 @@
 ## Context
 
-No existe ningún remapping de teclado en el dotfiles actual. macOS soporta Caps Lock → modifier nativo en System Settings, pero para remaps avanzados (Ctrl+HJKL → arrows) se necesita Karabiner-Elements. Referencia: omerxx/dotfiles incluye config de Karabiner con exactamente estos remaps.
+There is no keyboard remapping in the current dotfiles. macOS natively supports Caps Lock → modifier in System Settings, but advanced remaps (Ctrl+HJKL → arrows) require Karabiner-Elements. Reference: omerxx/dotfiles includes a Karabiner config with exactly these remaps.
 
 ## Goals / Non-Goals
 
 **Goals:**
-- Remap Caps Lock → Left Control (para todo el sistema)
-- Remap Ctrl+HJKL → Arrow keys (vim-style navigation en todas las apps)
-- Configuración JSON versionada en dotfiles, gestionada por Chezmoi
-- Instalación automatizada via brew cask
+- Remap Caps Lock → Left Control (system-wide)
+- Remap Ctrl+HJKL → Arrow keys (vim-style navigation across all apps)
+- JSON configuration versioned in dotfiles, managed by Chezmoi
+- Automated install via brew cask
 
 **Non-Goals:**
-- Remaps complejos tipo Hyper key (Caps Lock como Ctrl+Shift+Cmd+Alt)
-- Remaps específicos por aplicación
-- Backslash → Delete (de omerxx, demasiado opinado)
-- Sistema de capas tipo QMK
+- Complex Hyper-key style remaps (Caps Lock as Ctrl+Shift+Cmd+Alt)
+- App-specific remaps
+- Backslash → Delete (from omerxx, too opinionated)
+- QMK-style layer system
 
 ## Decisions
 
 ### Config structure
-Karabiner usa `~/.config/karabiner/karabiner.json`. En Chezmoi será `dot_config/karabiner/karabiner.json`. No es template (no necesita variables de Chezmoi).
+Karabiner uses `~/.config/karabiner/karabiner.json`. In Chezmoi this becomes `dot_config/karabiner/karabiner.json`. It is not a template (no Chezmoi variables needed).
 
 ### Remap 1: Caps Lock → Left Control
-Implementado como `simple_modification` en Karabiner (el más básico). Caps Lock pierde su función original por completo.
-- **Alternativa:** macOS nativo (System Settings → Keyboard → Modifier Keys) → descartado porque no es versionable en dotfiles y no se puede combinar con Karabiner rules.
-- **Alternativa:** Dual-role (Caps solo = Escape, Caps+key = Ctrl) → descartado por complejidad y latencia perceptible.
+Implemented as a `simple_modification` in Karabiner (the most basic kind). Caps Lock loses its original function entirely.
+- **Alternative:** native macOS (System Settings → Keyboard → Modifier Keys) → rejected because it is not versionable in dotfiles and cannot be combined with Karabiner rules.
+- **Alternative:** Dual-role (Caps alone = Escape, Caps+key = Ctrl) → rejected for complexity and perceptible latency.
 
 ### Remap 2: Ctrl+HJKL → Arrow keys
-Implementado como `complex_modification` con rules. Se mapea tanto Left Control como Right Control + HJKL. Esto permite:
-- Con Caps Lock (ahora Ctrl) + HJKL → arrows (el flujo principal)
-- Con Ctrl original + HJKL → arrows (por si acaso)
+Implemented as a `complex_modification` with rules. Both Left Control and Right Control + HJKL are mapped. This enables:
+- Caps Lock (now Ctrl) + HJKL → arrows (the primary flow)
+- Original Ctrl + HJKL → arrows (just in case)
 
-### Alcance: solo HJKL, no JK para scroll
-Solo flechas de dirección. No añadimos Ctrl+D/U para Page Down/Up ni otros remaps vim. KISS.
+### Scope: only HJKL, not JK for scrolling
+Arrow keys only. We do not add Ctrl+D/U for Page Down/Up or other vim remaps. KISS.
 
 ## Risks / Trade-offs
 
-- **[Caps Lock desaparece]** → Riesgo bajo: casi nadie la usa. Si se necesita, Shift+Caps Lock sigue funcionando en Karabiner
-- **[Ctrl+H conflicto en apps]** → Algunos apps usan Ctrl+H (backspace en terminal, help en algunos programas). Mitigación: la mayoría de apps modernas usan Cmd+H. Si hay conflicto real, se puede excluir apps específicas por bundle ID
-- **[Karabiner requiere permisos de accesibilidad]** → Esperado; se documenta en el install script como paso manual post-instalación
-- **[Latencia de input]** → Karabiner opera a nivel de kernel; latencia imperceptible (<1ms)
+- **[Caps Lock disappears]** → Low risk: almost no one uses it. If needed, Shift+Caps Lock still works in Karabiner.
+- **[Ctrl+H conflict in apps]** → Some apps use Ctrl+H (backspace in terminal, help in some programs). Mitigation: most modern apps use Cmd+H. If a real conflict appears, specific apps can be excluded by bundle ID.
+- **[Karabiner requires accessibility permissions]** → Expected; documented in the install script as a manual post-install step.
+- **[Input latency]** → Karabiner operates at the kernel level; latency is imperceptible (<1ms).

--- a/openspec/changes/add-karabiner-config/design.md
+++ b/openspec/changes/add-karabiner-config/design.md
@@ -1,0 +1,42 @@
+## Context
+
+No existe ningún remapping de teclado en el dotfiles actual. macOS soporta Caps Lock → modifier nativo en System Settings, pero para remaps avanzados (Ctrl+HJKL → arrows) se necesita Karabiner-Elements. Referencia: omerxx/dotfiles incluye config de Karabiner con exactamente estos remaps.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Remap Caps Lock → Left Control (para todo el sistema)
+- Remap Ctrl+HJKL → Arrow keys (vim-style navigation en todas las apps)
+- Configuración JSON versionada en dotfiles, gestionada por Chezmoi
+- Instalación automatizada via brew cask
+
+**Non-Goals:**
+- Remaps complejos tipo Hyper key (Caps Lock como Ctrl+Shift+Cmd+Alt)
+- Remaps específicos por aplicación
+- Backslash → Delete (de omerxx, demasiado opinado)
+- Sistema de capas tipo QMK
+
+## Decisions
+
+### Config structure
+Karabiner usa `~/.config/karabiner/karabiner.json`. En Chezmoi será `dot_config/karabiner/karabiner.json`. No es template (no necesita variables de Chezmoi).
+
+### Remap 1: Caps Lock → Left Control
+Implementado como `simple_modification` en Karabiner (el más básico). Caps Lock pierde su función original por completo.
+- **Alternativa:** macOS nativo (System Settings → Keyboard → Modifier Keys) → descartado porque no es versionable en dotfiles y no se puede combinar con Karabiner rules.
+- **Alternativa:** Dual-role (Caps solo = Escape, Caps+key = Ctrl) → descartado por complejidad y latencia perceptible.
+
+### Remap 2: Ctrl+HJKL → Arrow keys
+Implementado como `complex_modification` con rules. Se mapea tanto Left Control como Right Control + HJKL. Esto permite:
+- Con Caps Lock (ahora Ctrl) + HJKL → arrows (el flujo principal)
+- Con Ctrl original + HJKL → arrows (por si acaso)
+
+### Alcance: solo HJKL, no JK para scroll
+Solo flechas de dirección. No añadimos Ctrl+D/U para Page Down/Up ni otros remaps vim. KISS.
+
+## Risks / Trade-offs
+
+- **[Caps Lock desaparece]** → Riesgo bajo: casi nadie la usa. Si se necesita, Shift+Caps Lock sigue funcionando en Karabiner
+- **[Ctrl+H conflicto en apps]** → Algunos apps usan Ctrl+H (backspace en terminal, help en algunos programas). Mitigación: la mayoría de apps modernas usan Cmd+H. Si hay conflicto real, se puede excluir apps específicas por bundle ID
+- **[Karabiner requiere permisos de accesibilidad]** → Esperado; se documenta en el install script como paso manual post-instalación
+- **[Latencia de input]** → Karabiner opera a nivel de kernel; latencia imperceptible (<1ms)

--- a/openspec/changes/add-karabiner-config/proposal.md
+++ b/openspec/changes/add-karabiner-config/proposal.md
@@ -1,27 +1,27 @@
 ## Why
 
-No tenemos ningún remapping de teclado. Dos cambios ergonómicos de alto impacto: Caps Lock → Control (la tecla más usada en un sitio accesible en vez de la esquina) y Ctrl+HJKL → flechas de dirección (navegación vim-style en todas las apps de macOS sin mover las manos del home row). Inspirado en el config de Karabiner de omerxx/dotfiles.
+We have no keyboard remapping. Two high-impact ergonomic changes: Caps Lock → Control (the most-used key in an accessible spot instead of the corner) and Ctrl+HJKL → arrow keys (vim-style navigation across all macOS apps without leaving the home row). Inspired by the Karabiner config from omerxx/dotfiles.
 
 ## What Changes
 
-- Instalar Karabiner-Elements via brew cask
-- Crear configuración JSON con los remaps:
-  - Caps Lock → Left Control (para todo el sistema)
-  - Right Cmd + HJKL → Arrow keys (navegación vim)
-  - Left Ctrl + HJKL → Arrow keys (navegación vim, complementario con Caps→Ctrl)
-- Añadir config de Karabiner al dotfiles gestionado por Chezmoi
-- Añadir Karabiner-Elements al install script
+- Install Karabiner-Elements via brew cask
+- Create a JSON configuration with the remaps:
+  - Caps Lock → Left Control (system-wide)
+  - Right Cmd + HJKL → Arrow keys (vim navigation)
+  - Left Ctrl + HJKL → Arrow keys (vim navigation, complementary to Caps→Ctrl)
+- Add the Karabiner config to the dotfiles managed by Chezmoi
+- Add Karabiner-Elements to the install script
 
 ## Capabilities
 
 ### New Capabilities
-- `karabiner-config`: Configuración de Karabiner-Elements con remaps de teclado (Caps→Ctrl, vim arrows)
+- `karabiner-config`: Karabiner-Elements configuration with keyboard remaps (Caps→Ctrl, vim arrows)
 
 ### Modified Capabilities
 
 ## Impact
 
-- **Archivos nuevos:** `dot_config/karabiner/karabiner.json` (o estructura equivalente de Chezmoi)
-- **Archivos modificados:** `run_onchange_install-packages.sh.tmpl` (añadir brew cask)
-- **Dependencias nuevas:** `karabiner-elements` (brew cask)
-- **Riesgo:** Bajo. Karabiner solo actúa cuando está corriendo. Si se desactiva, el teclado vuelve a su comportamiento normal. No afecta a ningún otro archivo del dotfiles
+- **New files:** `dot_config/karabiner/karabiner.json` (or the equivalent Chezmoi structure)
+- **Modified files:** `run_onchange_install-packages.sh.tmpl` (add brew cask)
+- **New dependencies:** `karabiner-elements` (brew cask)
+- **Risk:** Low. Karabiner only acts while it is running. If disabled, the keyboard returns to its default behavior. It does not affect any other dotfile.

--- a/openspec/changes/add-karabiner-config/proposal.md
+++ b/openspec/changes/add-karabiner-config/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+No tenemos ningún remapping de teclado. Dos cambios ergonómicos de alto impacto: Caps Lock → Control (la tecla más usada en un sitio accesible en vez de la esquina) y Ctrl+HJKL → flechas de dirección (navegación vim-style en todas las apps de macOS sin mover las manos del home row). Inspirado en el config de Karabiner de omerxx/dotfiles.
+
+## What Changes
+
+- Instalar Karabiner-Elements via brew cask
+- Crear configuración JSON con los remaps:
+  - Caps Lock → Left Control (para todo el sistema)
+  - Right Cmd + HJKL → Arrow keys (navegación vim)
+  - Left Ctrl + HJKL → Arrow keys (navegación vim, complementario con Caps→Ctrl)
+- Añadir config de Karabiner al dotfiles gestionado por Chezmoi
+- Añadir Karabiner-Elements al install script
+
+## Capabilities
+
+### New Capabilities
+- `karabiner-config`: Configuración de Karabiner-Elements con remaps de teclado (Caps→Ctrl, vim arrows)
+
+### Modified Capabilities
+
+## Impact
+
+- **Archivos nuevos:** `dot_config/karabiner/karabiner.json` (o estructura equivalente de Chezmoi)
+- **Archivos modificados:** `run_onchange_install-packages.sh.tmpl` (añadir brew cask)
+- **Dependencias nuevas:** `karabiner-elements` (brew cask)
+- **Riesgo:** Bajo. Karabiner solo actúa cuando está corriendo. Si se desactiva, el teclado vuelve a su comportamiento normal. No afecta a ningún otro archivo del dotfiles

--- a/openspec/changes/add-karabiner-config/specs/karabiner-config/spec.md
+++ b/openspec/changes/add-karabiner-config/specs/karabiner-config/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Karabiner installation
+The install script SHALL include `karabiner-elements` in the brew casks group.
+
+#### Scenario: Fresh install includes Karabiner
+- **WHEN** user runs the install script and confirms the brew casks group
+- **THEN** Karabiner-Elements is installed via `brew install --cask karabiner-elements`
+
+### Requirement: Configuration file managed by Chezmoi
+A Karabiner config file SHALL exist at `dot_config/karabiner/karabiner.json` managed by Chezmoi. The file SHALL be valid JSON conforming to Karabiner-Elements configuration schema.
+
+#### Scenario: Config applied by chezmoi
+- **WHEN** `chezmoi apply` runs
+- **THEN** `~/.config/karabiner/karabiner.json` exists with the correct remaps
+
+### Requirement: Caps Lock remapped to Left Control
+The Karabiner config SHALL include a `simple_modification` that maps `caps_lock` to `left_control` for all devices.
+
+#### Scenario: Caps Lock acts as Control
+- **WHEN** user presses Caps Lock + C
+- **THEN** the system receives Ctrl+C
+
+#### Scenario: Caps Lock no longer toggles caps
+- **WHEN** user presses Caps Lock alone
+- **THEN** nothing happens (no caps lock toggle)
+
+### Requirement: Ctrl+HJKL mapped to arrow keys
+The Karabiner config SHALL include `complex_modifications` rules that map Left Control + H/J/K/L to Left/Down/Up/Right arrow keys respectively. The rules SHALL also work with modifier combinations (Shift, Alt, Cmd) for selection and word navigation.
+
+#### Scenario: Ctrl+H produces left arrow
+- **WHEN** user presses Control + H in any application
+- **THEN** the system receives Left Arrow
+
+#### Scenario: Ctrl+J produces down arrow
+- **WHEN** user presses Control + J in any application
+- **THEN** the system receives Down Arrow
+
+#### Scenario: Ctrl+K produces up arrow
+- **WHEN** user presses Control + K in any application
+- **THEN** the system receives Up Arrow
+
+#### Scenario: Ctrl+L produces right arrow
+- **WHEN** user presses Control + L in any application
+- **THEN** the system receives Right Arrow
+
+#### Scenario: Shift+Ctrl+L selects text rightward
+- **WHEN** user presses Shift + Control + L in a text field
+- **THEN** the system receives Shift + Right Arrow (extending selection)
+
+#### Scenario: Alt+Ctrl+H moves word left
+- **WHEN** user presses Alt + Control + H in a text field
+- **THEN** the system receives Alt + Left Arrow (move cursor one word left)

--- a/openspec/changes/add-karabiner-config/tasks.md
+++ b/openspec/changes/add-karabiner-config/tasks.md
@@ -1,0 +1,23 @@
+## 1. Install script updates
+
+- [ ] 1.1 Add `karabiner-elements` to the brew casks group in `run_onchange_install-packages.sh.tmpl`
+
+## 2. Create Karabiner config
+
+- [ ] 2.1 Create `dot_config/karabiner/karabiner.json` with valid Karabiner-Elements schema
+- [ ] 2.2 Add simple_modification: caps_lock → left_control (all devices)
+- [ ] 2.3 Add complex_modification rule: left_control+h → left_arrow
+- [ ] 2.4 Add complex_modification rule: left_control+j → down_arrow
+- [ ] 2.5 Add complex_modification rule: left_control+k → up_arrow
+- [ ] 2.6 Add complex_modification rule: left_control+l → right_arrow
+- [ ] 2.7 Ensure all complex_modification rules pass through additional modifiers (shift, alt, cmd) for text selection and word navigation
+
+## 3. Chezmoi integration
+
+- [ ] 3.1 Verify Chezmoi manages `dot_config/karabiner/karabiner.json` correctly (no template needed, plain JSON)
+- [ ] 3.2 Add karabiner directory to `.chezmoiignore.tmpl` for Linux (Karabiner is macOS-only)
+
+## 4. Verify
+
+- [ ] 4.1 Validate JSON syntax of karabiner.json
+- [ ] 4.2 Verify Karabiner loads the config without errors after chezmoi apply


### PR DESCRIPTION
## Summary
- Add OpenSpec change proposal for Karabiner-Elements keyboard remapping
- Caps Lock → Control (ergonomic modifier placement)
- Ctrl+HJKL → Arrow keys (vim-style navigation in all macOS apps)
- Supports modifier passthrough (Shift, Alt, Cmd) for text selection and word navigation
- Inspired by [omerxx/dotfiles](https://github.com/omerxx/dotfiles)

## Artifacts
- `proposal.md` - Why and what changes
- `design.md` - Technical decisions (remap strategy, scope)
- `specs/karabiner-config/spec.md` - Detailed requirements and scenarios
- `tasks.md` - Implementation checklist

## Test plan
- [ ] Review proposal for scope alignment
- [ ] Review design decisions
- [ ] Validate specs are testable
- [ ] Approve for implementation via `/opsx:apply`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added design, proposal, specification and task documents describing Karabiner-Elements keyboard remapping (Caps Lock → Control and vim-style H/J/K/L → arrow keys), installation notes, acceptance criteria, and verification steps.
* **Chores**
  * Added planning items to integrate the Karabiner configuration into the dotfiles install workflow and post-install accessibility guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->