### PR TITLE
docs: add AeroSpace tiling window manager proposal

### DIFF
--- a/openspec/changes/add-aerospace-config/.openspec.yaml
+++ b/openspec/changes/add-aerospace-config/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-02

--- a/openspec/changes/add-aerospace-config/design.md
+++ b/openspec/changes/add-aerospace-config/design.md
@@ -1,0 +1,85 @@
+## Context
+
+Setup actual: Rectangle para window management con layouts fijos manuales. 3 pantallas (laptop + 2 monitores externos), 7 escritorios, ~14 ventanas, apps siempre en el mismo sitio. Se está haciendo manualmente lo que un tiling WM automatiza.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Tiling automático de ventanas (nuevas ventanas se colocan solas)
+- Workspaces propios de AeroSpace (1-7) con cambio instantáneo (sin animación macOS)
+- Navegación vim-style: alt+HJKL entre ventanas, alt+shift+HJKL para mover
+- Asignación automática de apps a workspaces por bundle ID
+- Workspace-to-monitor assignments para 3 pantallas
+- Apps flotantes para Finder, calculadora, dialogs
+- Configuración TOML versionada en dotfiles
+
+**Non-Goals:**
+- SketchyBar u otra status bar custom (puede venir después)
+- Scripting avanzado con AeroSpace commands
+- Gaps estéticos grandes (estilo omerxx con 350px outer)
+- Multi-monitor dynamic reassignment
+
+## Decisions
+
+### AeroSpace sobre otras alternativas
+| Option | Pros | Cons | Decisión |
+|--------|------|------|----------|
+| AeroSpace | Nativo macOS, TOML config, activo, workspaces propios | Relativamente nuevo | ✅ Elegido |
+| yabai | Más maduro, más features | Requiere SIP deshabilitado para full features | Descartado |
+| Amethyst | Simple, no requiere config | Menos configurable, sin workspaces propios | Descartado |
+| Rectangle | Ya lo usamos | Manual, sin tiling auto, sin workspaces rápidos | Se reemplaza |
+
+### Workspace layout
+```
+Monitor izq (externo 1)     Monitor centro (externo 2)     Laptop
+┌─────────────────────┐     ┌─────────────────────────┐    ┌──────────────┐
+│  WS 1: Comunicación │     │  WS 3: Código            │    │ WS 6: Música │
+│  WS 2: Browser      │     │  WS 4: Terminal          │    │ WS 7: Otros  │
+│                     │     │  WS 5: Tools/DB          │    │              │
+└─────────────────────┘     └─────────────────────────┘    └──────────────┘
+```
+
+Nota: este layout es orientativo. El usuario deberá ajustar las asignaciones workspace→monitor según su setup físico real y los identificadores de sus monitores.
+
+### App assignments (orientativo)
+```toml
+# Comunicación → WS 1
+Slack, Teams, Telegram, WhatsApp → workspace 1
+
+# Browser → WS 2
+Chrome, Firefox → workspace 2
+
+# Código → WS 3
+WebStorm, VS Code → workspace 3
+
+# Terminal → WS 4
+Ghostty → workspace 4
+
+# Tools → WS 5
+Docker, DBeaver → workspace 5
+```
+
+El usuario deberá personalizar esto según sus apps y preferencias reales.
+
+### Keybindings
+- `alt+h/j/k/l` → navegar entre ventanas (focus)
+- `alt+shift+h/j/k/l` → mover ventana en dirección
+- `alt+1-7` → cambiar a workspace
+- `alt+shift+1-7` → mover ventana a workspace
+- `alt+f` → toggle floating
+- `alt+m` → toggle fullscreen
+
+Sin conflicto con Karabiner (Karabiner usa Ctrl+HJKL, AeroSpace usa Alt+HJKL).
+
+### Gaps conservadores
+Inner gaps: 8px. Outer gaps: 8px. Funcional sin ser excesivo. Omerxx usa 40px inner y 350px outer — demasiado para productividad.
+
+### Floating apps
+Finder, Calculator, System Preferences, 1Password, Archive Utility, cualquier dialog nativo de macOS.
+
+## Risks / Trade-offs
+
+- **[Curva de aprendizaje ~1-2 semanas]** → Mitigación: Rectangle se puede mantener instalado durante la transición. AeroSpace se puede desactivar temporalmente
+- **[alt+key conflictos con apps]** → Mitigación: alt es el modifier menos usado en macOS (Cmd es el principal). La mayoría de apps no usan alt+hjkl
+- **[Monitor IDs pueden cambiar]** → Mitigación: AeroSpace permite patrones parciales de nombre de monitor. Se documentará cómo identificar monitores
+- **[Tiling agresivo en apps que no lo esperan]** → Mitigación: lista de apps flotantes configurable. Se empieza conservador y se ajusta

--- a/openspec/changes/add-aerospace-config/design.md
+++ b/openspec/changes/add-aerospace-config/design.md
@@ -1,85 +1,85 @@
 ## Context
 
-Setup actual: Rectangle para window management con layouts fijos manuales. 3 pantallas (laptop + 2 monitores externos), 7 escritorios, ~14 ventanas, apps siempre en el mismo sitio. Se está haciendo manualmente lo que un tiling WM automatiza.
+Current setup: Rectangle for window management with manual fixed layouts. 3 screens (laptop + 2 external monitors), 7 desktops, ~14 windows, apps always in the same place. We are doing manually what a tiling WM automates.
 
 ## Goals / Non-Goals
 
 **Goals:**
-- Tiling automático de ventanas (nuevas ventanas se colocan solas)
-- Workspaces propios de AeroSpace (1-7) con cambio instantáneo (sin animación macOS)
-- Navegación vim-style: alt+HJKL entre ventanas, alt+shift+HJKL para mover
-- Asignación automática de apps a workspaces por bundle ID
-- Workspace-to-monitor assignments para 3 pantallas
-- Apps flotantes para Finder, calculadora, dialogs
-- Configuración TOML versionada en dotfiles
+- Automatic window tiling (new windows place themselves)
+- AeroSpace's own workspaces (1-7) with instant switching (no macOS animation)
+- Vim-style navigation: alt+HJKL across windows, alt+shift+HJKL to move
+- Automatic app-to-workspace assignment by bundle ID
+- Workspace-to-monitor assignments for 3 screens
+- Floating apps for Finder, calculator, dialogs
+- TOML configuration versioned in dotfiles
 
 **Non-Goals:**
-- SketchyBar u otra status bar custom (puede venir después)
-- Scripting avanzado con AeroSpace commands
-- Gaps estéticos grandes (estilo omerxx con 350px outer)
+- SketchyBar or another custom status bar (can come later)
+- Advanced scripting with AeroSpace commands
+- Large aesthetic gaps (omerxx-style with 350px outer)
 - Multi-monitor dynamic reassignment
 
 ## Decisions
 
-### AeroSpace sobre otras alternativas
-| Option | Pros | Cons | Decisión |
+### AeroSpace over the alternatives
+| Option | Pros | Cons | Decision |
 |--------|------|------|----------|
-| AeroSpace | Nativo macOS, TOML config, activo, workspaces propios | Relativamente nuevo | ✅ Elegido |
-| yabai | Más maduro, más features | Requiere SIP deshabilitado para full features | Descartado |
-| Amethyst | Simple, no requiere config | Menos configurable, sin workspaces propios | Descartado |
-| Rectangle | Ya lo usamos | Manual, sin tiling auto, sin workspaces rápidos | Se reemplaza |
+| AeroSpace | Native macOS, TOML config, active, own workspaces | Relatively new | ✅ Chosen |
+| yabai | More mature, more features | Requires SIP disabled for full features | Rejected |
+| Amethyst | Simple, no config required | Less configurable, no own workspaces | Rejected |
+| Rectangle | Already in use | Manual, no auto-tiling, no fast workspaces | Replaced |
 
 ### Workspace layout
 ```
-Monitor izq (externo 1)     Monitor centro (externo 2)     Laptop
-┌─────────────────────┐     ┌─────────────────────────┐    ┌──────────────┐
-│  WS 1: Comunicación │     │  WS 3: Código            │    │ WS 6: Música │
-│  WS 2: Browser      │     │  WS 4: Terminal          │    │ WS 7: Otros  │
-│                     │     │  WS 5: Tools/DB          │    │              │
-└─────────────────────┘     └─────────────────────────┘    └──────────────┘
+Left monitor (external 1)    Center monitor (external 2)    Laptop
+┌─────────────────────┐      ┌─────────────────────────┐    ┌──────────────┐
+│  WS 1: Comms        │      │  WS 3: Code             │    │ WS 6: Music  │
+│  WS 2: Browser      │      │  WS 4: Terminal         │    │ WS 7: Other  │
+│                     │      │  WS 5: Tools/DB         │    │              │
+└─────────────────────┘      └─────────────────────────┘    └──────────────┘
 ```
 
-Nota: este layout es orientativo. El usuario deberá ajustar las asignaciones workspace→monitor según su setup físico real y los identificadores de sus monitores.
+Note: this layout is illustrative. The user will need to adjust workspace→monitor assignments based on their actual physical setup and monitor identifiers.
 
-### App assignments (orientativo)
+### App assignments (illustrative)
 ```toml
-# Comunicación → WS 1
+# Comms -> WS 1
 Slack, Teams, Telegram, WhatsApp → workspace 1
 
-# Browser → WS 2
+# Browser -> WS 2
 Chrome, Firefox → workspace 2
 
-# Código → WS 3
+# Code -> WS 3
 WebStorm, VS Code → workspace 3
 
-# Terminal → WS 4
+# Terminal -> WS 4
 Ghostty → workspace 4
 
-# Tools → WS 5
+# Tools -> WS 5
 Docker, DBeaver → workspace 5
 ```
 
-El usuario deberá personalizar esto según sus apps y preferencias reales.
+The user will need to customize this based on their actual apps and preferences.
 
 ### Keybindings
-- `alt+h/j/k/l` → navegar entre ventanas (focus)
-- `alt+shift+h/j/k/l` → mover ventana en dirección
-- `alt+1-7` → cambiar a workspace
-- `alt+shift+1-7` → mover ventana a workspace
+- `alt+h/j/k/l` → navigate between windows (focus)
+- `alt+shift+h/j/k/l` → move window in direction
+- `alt+1-7` → switch to workspace
+- `alt+shift+1-7` → move window to workspace
 - `alt+f` → toggle floating
 - `alt+m` → toggle fullscreen
 
-Sin conflicto con Karabiner (Karabiner usa Ctrl+HJKL, AeroSpace usa Alt+HJKL).
+No conflict with Karabiner (Karabiner uses Ctrl+HJKL, AeroSpace uses Alt+HJKL).
 
-### Gaps conservadores
-Inner gaps: 8px. Outer gaps: 8px. Funcional sin ser excesivo. Omerxx usa 40px inner y 350px outer — demasiado para productividad.
+### Conservative gaps
+Inner gaps: 8px. Outer gaps: 8px. Functional without being excessive. Omerxx uses 40px inner and 350px outer — too much for productivity.
 
 ### Floating apps
-Finder, Calculator, System Preferences, 1Password, Archive Utility, cualquier dialog nativo de macOS.
+Finder, Calculator, System Preferences, 1Password, Archive Utility, any native macOS dialog.
 
 ## Risks / Trade-offs
 
-- **[Curva de aprendizaje ~1-2 semanas]** → Mitigación: Rectangle se puede mantener instalado durante la transición. AeroSpace se puede desactivar temporalmente
-- **[alt+key conflictos con apps]** → Mitigación: alt es el modifier menos usado en macOS (Cmd es el principal). La mayoría de apps no usan alt+hjkl
-- **[Monitor IDs pueden cambiar]** → Mitigación: AeroSpace permite patrones parciales de nombre de monitor. Se documentará cómo identificar monitores
-- **[Tiling agresivo en apps que no lo esperan]** → Mitigación: lista de apps flotantes configurable. Se empieza conservador y se ajusta
+- **[Learning curve ~1-2 weeks]** → Mitigation: Rectangle can stay installed during the transition. AeroSpace can be disabled temporarily.
+- **[alt+key collisions with apps]** → Mitigation: alt is the least-used modifier on macOS (Cmd is the main one). Most apps do not use alt+hjkl.
+- **[Monitor IDs may change]** → Mitigation: AeroSpace supports partial monitor-name patterns. We will document how to identify monitors.
+- **[Aggressive tiling on apps that don't expect it]** → Mitigation: configurable floating apps list. Start conservative and adjust.

--- a/openspec/changes/add-aerospace-config/proposal.md
+++ b/openspec/changes/add-aerospace-config/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Usamos Rectangle para window management con layouts fijos y apps que siempre van en el mismo sitio, en un setup de 3 pantallas (laptop + 2 monitores) con 7 escritorios. AeroSpace automatiza lo que hoy se hace manualmente: tiling automático, asignación de apps a workspaces, workspaces por monitor, y navegación instantánea con alt+hjkl sin animaciones de macOS. Inspirado en el config de omerxx/dotfiles.
+
+## What Changes
+
+- Instalar AeroSpace via brew cask
+- Crear configuración TOML con:
+  - Navegación entre ventanas: alt+HJKL
+  - Mover ventanas: alt+shift+HJKL
+  - Workspaces 1-7 con alt+número (cambio instantáneo)
+  - Reglas de auto-asignación de apps a workspaces
+  - Workspace-to-monitor assignments para 3 pantallas
+  - Lista de apps flotantes (Finder, calculadora, etc.)
+  - Gaps configurables
+- Añadir config al dotfiles gestionado por Chezmoi
+- Añadir AeroSpace al install script
+- Documentar que reemplaza Rectangle
+
+## Capabilities
+
+### New Capabilities
+- `aerospace-config`: Configuración de AeroSpace tiling WM (workspaces, navegación, reglas por app, multi-monitor)
+
+### Modified Capabilities
+
+## Impact
+
+- **Archivos nuevos:** `dot_config/aerospace/aerospace.toml`
+- **Archivos modificados:** `run_onchange_install-packages.sh.tmpl` (añadir brew cask, opcionalmente eliminar Rectangle)
+- **Dependencias nuevas:** `aerospace` (brew cask)
+- **Reemplaza:** Rectangle (se puede desinstalar tras validar AeroSpace)
+- **Riesgo:** Medio. Cambiar de window manager requiere periodo de adaptación (~1-2 semanas). Rectangle se puede mantener instalado mientras se evalúa AeroSpace

--- a/openspec/changes/add-aerospace-config/proposal.md
+++ b/openspec/changes/add-aerospace-config/proposal.md
@@ -1,33 +1,33 @@
 ## Why
 
-Usamos Rectangle para window management con layouts fijos y apps que siempre van en el mismo sitio, en un setup de 3 pantallas (laptop + 2 monitores) con 7 escritorios. AeroSpace automatiza lo que hoy se hace manualmente: tiling automático, asignación de apps a workspaces, workspaces por monitor, y navegación instantánea con alt+hjkl sin animaciones de macOS. Inspirado en el config de omerxx/dotfiles.
+We use Rectangle for window management with fixed layouts and apps that always go to the same place, in a 3-screen setup (laptop + 2 monitors) with 7 desktops. AeroSpace automates what is currently done manually: automatic tiling, app-to-workspace assignment, workspaces per monitor, and instant alt+hjkl navigation without macOS animations. Inspired by the omerxx/dotfiles config.
 
 ## What Changes
 
-- Instalar AeroSpace via brew cask
-- Crear configuración TOML con:
-  - Navegación entre ventanas: alt+HJKL
-  - Mover ventanas: alt+shift+HJKL
-  - Workspaces 1-7 con alt+número (cambio instantáneo)
-  - Reglas de auto-asignación de apps a workspaces
-  - Workspace-to-monitor assignments para 3 pantallas
-  - Lista de apps flotantes (Finder, calculadora, etc.)
-  - Gaps configurables
-- Añadir config al dotfiles gestionado por Chezmoi
-- Añadir AeroSpace al install script
-- Documentar que reemplaza Rectangle
+- Install AeroSpace via brew cask
+- Create a TOML configuration with:
+  - Window navigation: alt+HJKL
+  - Move windows: alt+shift+HJKL
+  - Workspaces 1-7 with alt+number (instant switch)
+  - App-to-workspace auto-assignment rules
+  - Workspace-to-monitor assignments for 3 screens
+  - Floating apps list (Finder, calculator, etc.)
+  - Configurable gaps
+- Add the config to the dotfiles managed by Chezmoi
+- Add AeroSpace to the install script
+- Document that it replaces Rectangle
 
 ## Capabilities
 
 ### New Capabilities
-- `aerospace-config`: Configuración de AeroSpace tiling WM (workspaces, navegación, reglas por app, multi-monitor)
+- `aerospace-config`: AeroSpace tiling WM configuration (workspaces, navigation, per-app rules, multi-monitor)
 
 ### Modified Capabilities
 
 ## Impact
 
-- **Archivos nuevos:** `dot_config/aerospace/aerospace.toml`
-- **Archivos modificados:** `run_onchange_install-packages.sh.tmpl` (añadir brew cask, opcionalmente eliminar Rectangle)
-- **Dependencias nuevas:** `aerospace` (brew cask)
-- **Reemplaza:** Rectangle (se puede desinstalar tras validar AeroSpace)
-- **Riesgo:** Medio. Cambiar de window manager requiere periodo de adaptación (~1-2 semanas). Rectangle se puede mantener instalado mientras se evalúa AeroSpace
+- **New files:** `dot_config/aerospace/aerospace.toml`
+- **Modified files:** `run_onchange_install-packages.sh.tmpl` (add brew cask, optionally remove Rectangle)
+- **New dependencies:** `aerospace` (brew cask)
+- **Replaces:** Rectangle (can be uninstalled once AeroSpace is validated)
+- **Risk:** Medium. Switching window managers requires an adaptation period (~1-2 weeks). Rectangle can stay installed while AeroSpace is being evaluated.

--- a/openspec/changes/add-aerospace-config/specs/aerospace-config/spec.md
+++ b/openspec/changes/add-aerospace-config/specs/aerospace-config/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: AeroSpace installation
+The install script SHALL include `aerospace` in the brew casks group.
+
+#### Scenario: Fresh install includes AeroSpace
+- **WHEN** user runs the install script and confirms the brew casks group
+- **THEN** AeroSpace is installed via `brew install --cask aerospace`
+
+### Requirement: Configuration file managed by Chezmoi
+An AeroSpace config file SHALL exist at `dot_config/aerospace/aerospace.toml` managed by Chezmoi.
+
+#### Scenario: Config applied by chezmoi
+- **WHEN** `chezmoi apply` runs
+- **THEN** `~/.config/aerospace/aerospace.toml` exists with the complete tiling configuration
+
+### Requirement: Window navigation with alt+HJKL
+The config SHALL bind `alt+h`, `alt+j`, `alt+k`, `alt+l` to focus the window in the left, down, up, right direction respectively.
+
+#### Scenario: Navigate to window on the left
+- **WHEN** user presses alt+H with multiple tiled windows
+- **THEN** focus moves to the window on the left
+
+#### Scenario: Navigate to window below
+- **WHEN** user presses alt+J with vertically stacked windows
+- **THEN** focus moves to the window below
+
+### Requirement: Window movement with alt+shift+HJKL
+The config SHALL bind `alt+shift+h`, `alt+shift+j`, `alt+shift+k`, `alt+shift+l` to move the focused window in the respective direction.
+
+#### Scenario: Move window left
+- **WHEN** user presses alt+shift+H
+- **THEN** the focused window swaps position with the window to its left
+
+### Requirement: Workspace switching with alt+number
+The config SHALL bind `alt+1` through `alt+7` to switch to workspaces 1-7.
+
+#### Scenario: Switch to workspace 3
+- **WHEN** user presses alt+3
+- **THEN** workspace 3 is shown immediately (no macOS animation)
+
+### Requirement: Move window to workspace with alt+shift+number
+The config SHALL bind `alt+shift+1` through `alt+shift+7` to move the focused window to the respective workspace.
+
+#### Scenario: Move window to workspace 2
+- **WHEN** user presses alt+shift+2
+- **THEN** the focused window moves to workspace 2
+
+### Requirement: Fullscreen and floating toggles
+The config SHALL bind `alt+m` to toggle fullscreen and `alt+f` to toggle floating for the focused window.
+
+#### Scenario: Toggle fullscreen
+- **WHEN** user presses alt+M on a tiled window
+- **THEN** the window enters fullscreen mode, covering the workspace
+
+#### Scenario: Toggle floating
+- **WHEN** user presses alt+F on a tiled window
+- **THEN** the window becomes floating and can be moved/resized freely
+
+### Requirement: Auto-assign apps to workspaces
+The config SHALL include `on-window-detected` rules that automatically move specific apps to designated workspaces by bundle ID.
+
+#### Scenario: Slack opens in communication workspace
+- **WHEN** Slack window is detected
+- **THEN** it is automatically moved to the communication workspace
+
+#### Scenario: Ghostty opens in terminal workspace
+- **WHEN** Ghostty window is detected
+- **THEN** it is automatically moved to the terminal workspace
+
+### Requirement: Floating app exceptions
+The config SHALL configure specific apps as always-floating: Finder, Calculator, System Settings, 1Password, Archive Utility.
+
+#### Scenario: Finder opens floating
+- **WHEN** a Finder window opens
+- **THEN** it appears as a floating window, not tiled
+
+### Requirement: Workspace-to-monitor assignments
+The config SHALL include `workspace-to-monitor-force-assignment` mapping workspace groups to specific monitors.
+
+#### Scenario: Workspace follows monitor
+- **WHEN** the user switches to a workspace assigned to a specific monitor
+- **THEN** that monitor activates and shows the workspace
+
+### Requirement: Conservative gaps
+The config SHALL set inner and outer gaps to 8 pixels.
+
+#### Scenario: Gaps between windows
+- **WHEN** multiple windows are tiled
+- **THEN** there is an 8px gap between adjacent windows and between windows and screen edges

--- a/openspec/changes/add-aerospace-config/tasks.md
+++ b/openspec/changes/add-aerospace-config/tasks.md
@@ -1,0 +1,32 @@
+## 1. Install script updates
+
+- [ ] 1.1 Add `aerospace` to the brew casks group in `run_onchange_install-packages.sh.tmpl`
+- [ ] 1.2 Add a comment noting AeroSpace replaces Rectangle
+
+## 2. Create AeroSpace config
+
+- [ ] 2.1 Create `dot_config/aerospace/aerospace.toml` with base settings (start-at-login, after-login-command, gaps)
+- [ ] 2.2 Set inner and outer gaps to 8px
+- [ ] 2.3 Add keybindings: alt+h/j/k/l for window focus navigation
+- [ ] 2.4 Add keybindings: alt+shift+h/j/k/l for window movement
+- [ ] 2.5 Add keybindings: alt+1 through alt+7 for workspace switching
+- [ ] 2.6 Add keybindings: alt+shift+1 through alt+shift+7 for moving windows to workspaces
+- [ ] 2.7 Add keybindings: alt+m for fullscreen toggle, alt+f for floating toggle
+
+## 3. App rules and monitor assignments
+
+- [ ] 3.1 Add `on-window-detected` rules for app-to-workspace assignments (Slack, Chrome, WebStorm/VS Code, Ghostty, Docker, DBeaver) with bundle IDs
+- [ ] 3.2 Add floating exceptions: Finder, Calculator, System Settings, 1Password, Archive Utility
+- [ ] 3.3 Add `workspace-to-monitor-force-assignment` with placeholder monitor names (user must customize)
+
+## 4. Chezmoi integration
+
+- [ ] 4.1 Verify Chezmoi manages `dot_config/aerospace/aerospace.toml` correctly
+- [ ] 4.2 Add aerospace directory to `.chezmoiignore.tmpl` for Linux (AeroSpace is macOS-only)
+
+## 5. Verify
+
+- [ ] 5.1 Validate TOML syntax of aerospace.toml
+- [ ] 5.2 Verify AeroSpace loads the config without errors
+- [ ] 5.3 Test workspace switching with alt+number
+- [ ] 5.4 Test window navigation with alt+hjkl


### PR DESCRIPTION
## Summary
- Add OpenSpec change proposal for AeroSpace tiling window manager (replaces Rectangle)
- Alt+HJKL window navigation, alt+number workspace switching (instant, no macOS animation)
- Auto app-to-workspace assignment by bundle ID
- Multi-monitor workspace assignments for 3-screen setup
- Floating exceptions for Finder, Calculator, etc.
- Inspired by [omerxx/dotfiles](https://github.com/omerxx/dotfiles)

## Artifacts
- `proposal.md` - Why and what changes
- `design.md` - Technical decisions (AeroSpace vs yabai/Amethyst, workspace layout, keybindings)
- `specs/aerospace-config/spec.md` - Detailed requirements and scenarios
- `tasks.md` - Implementation checklist

## Test plan
- [ ] Review proposal for scope alignment
- [ ] Review design decisions (especially workspace-to-monitor mapping)
- [ ] Validate specs are testable
- [ ] Approve for implementation via `/opsx:apply`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added design, proposal, specification, and task docs describing migration to AeroSpace: install/upgrade steps, required config layout, workspace-to-monitor mapping for a 3‑screen (7‑desktop) setup, Vim‑style Alt+H/J/K/L navigation and Alt+Shift+H/J/K/L movement, instant Alt+1–7 workspace switching, app-to-workspace auto-assignment, floating‑app exceptions, conservative 8px gap defaults, and verification checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->