### PR TITLE
fix: add COLUMNS=200 to claude-hud statusline chezmoi template

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -4,7 +4,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "bash -c '\"{{ .chezmoi.homeDir }}/.bun/bin/bun\" \"$(ls -td ~/.claude/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | head -1)src/index.ts\"'"
+    "command": "bash -c 'COLUMNS=200 \"{{ .chezmoi.homeDir }}/.bun/bin/bun\" \"$(ls -td ~/.claude/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | head -1)src/index.ts\"'"
   },
   "enabledPlugins": {
     "claude-hud@claude-hud": true,

--- a/openspec/changes/fix-claude-hud-columns/.openspec.yaml
+++ b/openspec/changes/fix-claude-hud-columns/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-08

--- a/openspec/changes/fix-claude-hud-columns/design.md
+++ b/openspec/changes/fix-claude-hud-columns/design.md
@@ -25,13 +25,13 @@ Currently the template does not include `COLUMNS=200`, so every `chezmoi apply` 
 
 **Current command**:
 
-```
+```bash
 bash -c '"{{ .chezmoi.homeDir }}/.bun/bin/bun" "$(ls -td ~/.claude/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | head -1)src/index.ts"'
 ```
 
 **New command**:
 
-```
+```bash
 bash -c 'COLUMNS=200 "{{ .chezmoi.homeDir }}/.bun/bin/bun" "$(ls -td ~/.claude/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | head -1)src/index.ts"'
 ```
 

--- a/openspec/changes/fix-claude-hud-columns/design.md
+++ b/openspec/changes/fix-claude-hud-columns/design.md
@@ -1,0 +1,45 @@
+## Context
+
+The `dot_claude/settings.json.tmpl` chezmoi template defines the `statusLine.command` that Claude Code uses to invoke the claude-hud plugin. The plugin runs as a subprocess where `process.stdout.columns` is unavailable, causing it to fall back to 40 characters and wrap the output across multiple lines. Setting `COLUMNS=200` in the command's environment fixes the wrapping.
+
+Currently the template does not include `COLUMNS=200`, so every `chezmoi apply` reverts the manual fix.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Persist the `COLUMNS=200` workaround in the chezmoi template so it survives `chezmoi apply`
+- Minimal, single-line change to `dot_claude/settings.json.tmpl`
+
+**Non-Goals:**
+
+- Fixing the upstream plugin (tracked at jarrodwatts/claude-hud#404)
+- Changing the claude-hud plugin configuration or thresholds
+- Modifying any other chezmoi-managed settings
+
+## Decisions
+
+### Inject COLUMNS=200 via bash -c wrapper
+
+**Choice**: Prefix the bun invocation with `COLUMNS=200` inside the existing `bash -c` wrapper.
+
+**Current command**:
+
+```
+bash -c '"{{ .chezmoi.homeDir }}/.bun/bin/bun" "$(ls -td ~/.claude/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | head -1)src/index.ts"'
+```
+
+**New command**:
+
+```
+bash -c 'COLUMNS=200 "{{ .chezmoi.homeDir }}/.bun/bin/bun" "$(ls -td ~/.claude/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | head -1)src/index.ts"'
+```
+
+**Rationale**: This is the simplest approach — a single environment variable prefix. It requires no extra shell wrapper, no chezmoi template logic, and matches the exact workaround documented in the issue.
+
+**Alternative considered**: Using `env COLUMNS=200 ...` — functionally identical but more verbose; the bash inline variable assignment is idiomatic and shorter.
+
+## Risks / Trade-offs
+
+- **[Upstream fix makes this redundant]** → Once jarrodwatts/claude-hud#404 is resolved, the `COLUMNS=200` prefix becomes dead weight. Mitigation: low-cost removal (single line edit), and the prefix is harmless if present after a fix.
+- **[Hardcoded 200 may not suit all terminals]** → 200 is generous enough for any reasonable statusline. The plugin truncates output to fit, so overshooting is harmless.

--- a/openspec/changes/fix-claude-hud-columns/proposal.md
+++ b/openspec/changes/fix-claude-hud-columns/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The claude-hud statusline plugin wraps to multiple rows when `COLUMNS` is not set, because `process.stdout.columns` is unavailable in subprocess mode and the fallback is only 40 characters. The workaround (`COLUMNS=200` in the statusline command) must be applied in `~/.claude/settings.json`, but `chezmoi apply` overwrites it from `dot_claude/settings.json.tmpl` which lacks the fix. This forces manual re-application after every `chezmoi apply`.
+
+## What Changes
+
+- Add `COLUMNS=200` to the statusline command in `dot_claude/settings.json.tmpl` so chezmoi preserves the workaround across applies
+- This is a temporary fix until the upstream issue (jarrodwatts/claude-hud#404) resolves the 40-char fallback
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `claude-hud-config`: Add requirement that the statusline command sets `COLUMNS=200` to prevent line wrapping in subprocess mode
+
+## Impact
+
+- **File**: `dot_claude/settings.json.tmpl` — the `statusLine.command` value changes to include `COLUMNS=200`
+- **Effect**: All machines managed by chezmoi will get the fix on next `chezmoi apply`
+- **Upstream**: Temporary until jarrodwatts/claude-hud#404 is resolved; the `COLUMNS=200` prefix can be removed once the plugin handles missing terminal width gracefully

--- a/openspec/changes/fix-claude-hud-columns/specs/claude-hud-config/spec.md
+++ b/openspec/changes/fix-claude-hud-columns/specs/claude-hud-config/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Statusline command sets COLUMNS for subprocess mode
+
+The chezmoi template for `statusLine.command` in `dot_claude/settings.json.tmpl` SHALL prefix the bun invocation with `COLUMNS=200` to prevent line wrapping when the plugin runs as a subprocess without terminal width information.
+
+#### Scenario: COLUMNS is present in the rendered command
+
+- **WHEN** `chezmoi cat ~/.claude/settings.json` is executed
+- **THEN** the `statusLine.command` value SHALL contain `COLUMNS=200` before the bun binary path
+
+#### Scenario: Statusline does not wrap after chezmoi apply
+
+- **WHEN** `chezmoi apply` is run on a machine with the claude-hud plugin installed
+- **AND** the statusline command is invoked by Claude Code
+- **THEN** the output SHALL render on a single line without wrapping
+
+#### Scenario: Fix is removed after upstream resolution
+
+- **WHEN** jarrodwatts/claude-hud#404 is resolved and the plugin handles missing terminal width gracefully
+- **THEN** the `COLUMNS=200` prefix MAY be removed from the template without functional impact

--- a/openspec/changes/fix-claude-hud-columns/tasks.md
+++ b/openspec/changes/fix-claude-hud-columns/tasks.md
@@ -1,0 +1,8 @@
+## 1. Template Fix
+
+- [x] 1.1 Add `COLUMNS=200` prefix to the `statusLine.command` in `dot_claude/settings.json.tmpl`
+
+## 2. Verification
+
+- [x] 2.1 Run `chezmoi cat ~/.claude/settings.json` and confirm `COLUMNS=200` appears in the statusline command
+- [x] 2.2 Run `chezmoi diff` to verify only the expected change in `settings.json`


### PR DESCRIPTION
## Summary

- Adds `COLUMNS=200` to the `statusLine.command` in `dot_claude/settings.json.tmpl` so the claude-hud plugin doesn't wrap to multiple rows when running as a subprocess
- Temporary workaround until jarrodwatts/claude-hud#404 is resolved upstream

Closes #109

## Test plan

- [ ] Run `chezmoi cat ~/.claude/settings.json` and confirm `COLUMNS=200` appears in the statusline command
- [ ] Run `chezmoi apply` and verify the claude-hud statusline renders on a single line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed status line wrapping so the status line no longer breaks into multiple rows when terminal width info is unavailable — it now renders on a single line.

* **Documentation**
  * Added design, proposal, specification, and task documentation describing the persistent workaround and verification steps for the status line behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->