### PR TITLE
fix: pre-seed PATH with nvm node binary for subprocesses

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -72,6 +72,13 @@ zstyle ':omz:plugins:nvm' silent-autoload yes
 
 source $ZSH/oh-my-zsh.sh
 
+# Pre-seed PATH with default nvm node for non-shell subprocesses (Gradle, Xcode)
+if [ -d "$NVM_DIR/versions/node" ]; then
+  _nvm_default_node_dir=$(command ls -1d "$NVM_DIR/versions/node/"v* 2>/dev/null | sort -V | tail -1)
+  [ -n "$_nvm_default_node_dir" ] && export PATH="$_nvm_default_node_dir/bin:$PATH"
+  unset _nvm_default_node_dir
+fi
+
 # User configuration
 export EDITOR="code --wait"
 export VISUAL="code --wait"

--- a/openspec/changes/fix-nvm-lazy-path/.openspec.yaml
+++ b/openspec/changes/fix-nvm-lazy-path/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-08

--- a/openspec/changes/fix-nvm-lazy-path/design.md
+++ b/openspec/changes/fix-nvm-lazy-path/design.md
@@ -1,0 +1,53 @@
+## Context
+
+The oh-my-zsh nvm plugin with `lazy yes` (configured in `dot_zshrc.tmpl`) creates shell function wrappers for `node`, `npm`, `npx`, etc. These functions work in the interactive shell but are **not inherited by subprocesses**. Tools like Gradle (Android), Xcode (iOS), and scripts using `/usr/bin/env node` fail because `$PATH` never includes the nvm-managed node binary directory.
+
+Current state in `dot_zshrc.tmpl`:
+
+- Line 57: `export NVM_DIR="$HOME/.nvm"`
+- Lines 58-60: `zstyle` lazy/autoload/silent-autoload config
+- Line 73: `source $ZSH/oh-my-zsh.sh` (nvm plugin creates function wrappers here)
+- No PATH entry for `$NVM_DIR/versions/node/*/bin`
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Ensure `node` is discoverable via `$PATH` for subprocesses (Gradle, Xcode, `/usr/bin/env node`)
+- Preserve lazy-loading behavior (no full nvm initialization at shell startup)
+- Keep the fix lightweight and self-contained
+
+**Non-Goals:**
+
+- Replacing lazy loading with eager loading
+- Supporting multiple simultaneous node versions in PATH
+- Modifying the nvm plugin itself or upstream behavior
+
+## Decisions
+
+### Decision 1: Pre-seed PATH after oh-my-zsh source
+
+Add a block **after** `source $ZSH/oh-my-zsh.sh` that finds the most recent nvm-installed node version and prepends its `bin/` to `$PATH`.
+
+**Rationale**: Placing it after the oh-my-zsh source keeps all nvm-related config together. The block runs only at shell init (not per-command), so the cost is negligible.
+
+**Alternative considered**: Placing the block in `.zshenv` — rejected because `NVM_DIR` might not be set yet and `.zshenv` runs for non-interactive shells too, adding unnecessary overhead.
+
+### Decision 2: Use `sort -V | tail -1` to find latest version
+
+Use `command ls -1d "$NVM_DIR/versions/node/"v* | sort -V | tail -1` to find the highest-versioned node directory.
+
+**Rationale**: `sort -V` (version sort) correctly handles semver ordering. Using the latest version as default is the safest assumption — it aligns with `nvm alias default lts/*` from the bootstrap script. The `command ls` prefix bypasses any shell aliases.
+
+**Alternative considered**: Reading `$NVM_DIR/alias/default` and resolving to a path — more correct in theory but adds complexity (needs to resolve `lts/*` aliases, handle missing alias file). The version-sort approach is simpler and works for the common case.
+
+### Decision 3: Guard with directory existence check
+
+Wrap in `if [ -d "$NVM_DIR/versions/node" ]` so the block is a no-op on machines without nvm or without any installed node versions.
+
+**Rationale**: Keeps the shell startup clean on machines that don't use nvm.
+
+## Risks / Trade-offs
+
+- **[PATH vs nvm default mismatch]** → If the user has a different default alias, PATH might point to a newer version than `nvm use default` would select. Mitigation: once nvm lazy-loads, it takes over. The PATH pre-seed is only for subprocesses before nvm fully initializes.
+- **[Stale PATH on node upgrade]** → After `nvm install`, the PATH pre-seed won't update until a new shell is opened. Mitigation: this matches existing nvm behavior — users already expect to open a new shell after changing node versions.

--- a/openspec/changes/fix-nvm-lazy-path/proposal.md
+++ b/openspec/changes/fix-nvm-lazy-path/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The oh-my-zsh nvm plugin with `lazy yes` creates shell **functions** for `node`/`npm`/`npx`, but does not add the node binary directory to `$PATH`. This means subprocesses (Gradle for Android builds, Xcode for iOS builds, any non-shell child process) cannot find `node` because they inherit `PATH` but not shell functions. Running `/usr/bin/env node` fails even when `node --version` works in the interactive shell.
+
+## What Changes
+
+- Add a PATH pre-seeding block in `dot_zshrc.tmpl` (after `source $ZSH/oh-my-zsh.sh`) that discovers the most recent nvm-managed node version and prepends its `bin/` directory to `$PATH`
+- This preserves lazy loading for shell startup speed while ensuring subprocesses can resolve `node` via PATH
+- The block is a no-op if nvm has no installed node versions
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `omz-plugins`: Add a new requirement that the nvm lazy-loading configuration must also pre-seed PATH with the default node binary directory so subprocesses can find `node`
+
+## Impact
+
+- **File**: `dot_zshrc.tmpl` — ~5 lines added after the oh-my-zsh source line
+- **Behavior**: `$PATH` will include the nvm default node's `bin/` directory in every shell session, making `node` discoverable by subprocesses (Gradle, Xcode, scripts using `/usr/bin/env node`)
+- **No breaking changes**: Lazy loading still defers full nvm initialization; the PATH addition is lightweight and independent

--- a/openspec/changes/fix-nvm-lazy-path/specs/omz-plugins/spec.md
+++ b/openspec/changes/fix-nvm-lazy-path/specs/omz-plugins/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: nvm lazy loading pre-seeds PATH with default node binary directory
+
+After oh-my-zsh is sourced with the nvm plugin in lazy mode, the `.zshrc` SHALL pre-seed `$PATH` with the `bin/` directory of the most recent nvm-installed node version. This ensures subprocesses that inherit `$PATH` (but not shell functions) can resolve `node`, `npm`, and `npx` as real binaries.
+
+The block SHALL:
+
+1. Check that `$NVM_DIR/versions/node` directory exists
+2. Find the highest-versioned node directory using version-aware sorting
+3. Prepend its `bin/` subdirectory to `$PATH`
+4. Clean up any temporary variables used
+
+#### Scenario: Subprocess can find node via PATH
+
+- **WHEN** a subprocess (e.g., Gradle, Xcode, or `/usr/bin/env node`) looks up `node` via `$PATH`
+- **THEN** the binary SHALL be found at `$NVM_DIR/versions/node/<version>/bin/node`
+
+#### Scenario: No nvm versions installed
+
+- **WHEN** `$NVM_DIR/versions/node` does not exist or contains no version directories
+- **THEN** the block SHALL be a no-op and SHALL NOT modify `$PATH` or produce errors
+
+#### Scenario: Multiple node versions installed
+
+- **WHEN** multiple node versions are installed under `$NVM_DIR/versions/node/`
+- **THEN** the highest version (by semver) SHALL be selected for PATH pre-seeding
+
+#### Scenario: Lazy loading is preserved
+
+- **WHEN** a new shell session starts
+- **THEN** the nvm plugin SHALL still use lazy function wrappers for `node`/`npm`/`npx`
+- **AND** the PATH pre-seed SHALL NOT trigger a full nvm initialization
+
+#### Scenario: Temporary variables are cleaned up
+
+- **WHEN** the PATH pre-seed block completes
+- **THEN** no temporary variables (e.g., `_nvm_default_node_dir`) SHALL remain in the shell environment

--- a/openspec/changes/fix-nvm-lazy-path/tasks.md
+++ b/openspec/changes/fix-nvm-lazy-path/tasks.md
@@ -1,0 +1,10 @@
+## 1. Implementation
+
+- [x] 1.1 Add PATH pre-seed block in `dot_zshrc.tmpl` after `source $ZSH/oh-my-zsh.sh` that discovers the latest nvm node version and prepends its `bin/` to PATH
+- [x] 1.2 Ensure the block guards with `[ -d "$NVM_DIR/versions/node" ]` and cleans up temp variables with `unset`
+
+## 2. Verification
+
+- [x] 2.1 Run `chezmoi diff` to confirm only the expected lines are added
+- [x] 2.2 Apply with `chezmoi apply` and verify `node` is in PATH via `/usr/bin/env node --version`
+- [x] 2.3 Verify lazy loading still works: open new shell, confirm `nvm` is not fully loaded until first `node` invocation


### PR DESCRIPTION
## Summary

- Adds a PATH pre-seeding block after `source $ZSH/oh-my-zsh.sh` that discovers the latest nvm-managed node version and prepends its `bin/` to `$PATH`
- Fixes subprocesses (Gradle, Xcode, `/usr/bin/env node`) failing to find `node` when nvm lazy loading is enabled
- Preserves lazy loading for fast shell startup — no full nvm initialization triggered

Closes #110

## Test plan

- [ ] Open a new shell and verify `node --version` still works (lazy function)
- [ ] Run `/usr/bin/env node --version` to confirm node is discoverable via PATH
- [ ] Verify `echo $PATH` includes `$NVM_DIR/versions/node/<version>/bin`
- [ ] Confirm nvm is not fully loaded until first `node` invocation (lazy preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Node.js discoverability for subprocesses when NVM lazy-loading is enabled, ensuring tools like Gradle and Xcode can locate `node`/`npm`/`npx` without full NVM initialization.

* **Documentation**
  * Added specification and design documentation for NVM lazy-loading behavior and PATH pre-seeding implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->