### PR TITLE
fix: remap gh-dash keybindings to avoid collisions with defaults

### DIFF
--- a/dot_config/gh-dash/config.yml
+++ b/dot_config/gh-dash/config.yml
@@ -63,25 +63,25 @@ smartFilteringAtLaunch: true
 
 keybindings:
     universal:
-        - key: g
+        - key: L
           name: Lazygit
           command: cd {{.RepoPath}} && lazygit
     prs:
         # Direct execution (suspends TUI)
-        - key: C
+        - key: b
           name: Code review with Claude
           command: wt -C {{.RepoPath}} switch pr:{{.PrNumber}} -x "claude /code-review:code-review {{.RepoName}}#{{.PrNumber}}"
-        - key: W
+        - key: i
           name: Worktree + Claude
           command: wt -C {{.RepoPath}} switch pr:{{.PrNumber}} -x claude
         - key: t
           name: CI checks (inline)
           command: ENHANCE_THEME=catppuccin_mocha gh enhance -R {{.RepoName}} {{.PrNumber}}
         # Tmux variants (opens in split pane)
-        - key: R
+        - key: B
           name: Code review (tmux)
           command: tmux split-window -h 'wt -C {{.RepoPath}} switch pr:{{.PrNumber}} -x "claude /code-review:code-review {{.RepoName}}#{{.PrNumber}}"'
-        - key: E
+        - key: I
           name: Worktree + Claude (tmux)
           command: tmux split-window -h 'wt -C {{.RepoPath}} switch pr:{{.PrNumber}} -x claude'
         - key: T

--- a/openspec/changes/fix-ghd-keybinding-collisions/design.md
+++ b/openspec/changes/fix-ghd-keybinding-collisions/design.md
@@ -1,0 +1,56 @@
+## Context
+
+gh-dash custom keybindings (`g`, `C`, `W`, `R`) override built-in defaults for navigation, PR checkout, mark-ready-for-review, and refresh-all. This happened incrementally across `add-gh-dash` and `fix-ghd-repo-paths` changes — keys were chosen for mnemonics without cross-referencing the full default keymap.
+
+The current config at `dot_config/gh-dash/config.yml` defines 7 custom keybindings (1 universal, 6 PR). CI checks (`t`/`T`) have no collisions. The remaining 5 need reassignment.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Reassign all custom keybindings that collide with built-in defaults to free keys
+- Restore `g`, `C`, `W`, `R` to their built-in functions
+- Adopt consistent lowercase/UPPERCASE pattern: lowercase = direct execution, UPPERCASE = tmux variant
+- Keep the dual execution approach (direct + tmux) unchanged
+
+**Non-Goals:**
+
+- Adding new keybindings for issue view or notifications
+- Changing the commands themselves (only the key assignments change)
+- Conditional tmux detection or automatic mode switching
+
+## Decisions
+
+### Use `b`/`B` for Claude code review, `i`/`I` for worktree + Claude
+
+Available free key pairs (both cases unused in PR view): `b`/`B`, `f`/`F`, `i`/`I`, `n`/`N`, `z`/`Z`.
+
+Chosen: `b`/`B` for code review ("re**b**iew"), `i`/`I` for worktree + Claude ("**i**mplement"). Alternatives considered:
+
+- `f`/`F` — no mnemonic connection to either action
+- `n`/`N` — could mean "new" but doesn't map well to review
+- `z`/`Z` — too obscure, hard to remember
+
+The `b`/`i` pairing groups Claude operations on adjacent keys while keeping CI checks at `t`/`T`.
+
+### Use `L` for Lazygit (universal)
+
+`L` is free in all views and is mnemonic for **L**azygit. The collision with `g` (go to first item) is minor since `Home` is an alternative, but reassigning to `L` eliminates the collision entirely.
+
+Alternatives considered:
+
+- Keep `g` and accept the collision — violates the goal of zero collisions
+- `G` — would collide with "go to last item"
+
+### Consistent lowercase/UPPERCASE pattern
+
+All custom PR keybindings follow: lowercase = direct execution (suspends TUI), UPPERCASE = tmux split pane. This aligns with the existing `t`/`T` pattern for CI checks and makes the system predictable.
+
+Before: `C`/`R` (review), `W`/`E` (worktree) — no discernible pattern.
+After: `b`/`B` (review), `i`/`I` (worktree), `t`/`T` (CI) — consistent.
+
+## Risks / Trade-offs
+
+- [Muscle memory] → Users accustomed to `C`/`W`/`R`/`E` need to relearn. Acceptable since the config is personal and the previous keys were chosen recently.
+- [Weak mnemonics for `b`] → "re**b**iew" is a stretch. Mitigated by `name` field in keybindings showing the action in the help menu (`?`).
+- [`L` requires shift key] → Lazygit now needs Shift+L instead of just `g`. Acceptable trade-off to restore navigation.

--- a/openspec/changes/fix-ghd-keybinding-collisions/proposal.md
+++ b/openspec/changes/fix-ghd-keybinding-collisions/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+Custom keybindings in gh-dash override useful built-in defaults without realizing it:
+
+- `g` (universal, Lazygit) overrides "go to first item" navigation
+- `C` (PR, Code review Claude) overrides "Checkout PR" (`gh pr checkout`)
+- `W` (PR, Worktree + Claude) overrides "Mark ready for review" (`gh pr ready`)
+- `R` (PR, Code review tmux) overrides "Refresh all sections"
+
+Checkout and mark-ready are common PR workflows that become inaccessible. The fix is reassigning custom keybindings to free keys while restoring all built-in defaults.
+
+## What Changes
+
+Remap all custom keybindings that collide with built-in defaults to unused keys. Adopt a consistent pattern: lowercase = direct execution, uppercase = tmux variant.
+
+| Before          | After           | Action                         |
+| --------------- | --------------- | ------------------------------ |
+| `g` (universal) | `L` (universal) | Lazygit                        |
+| `C` (PR)        | `b` (PR)        | Code review Claude (direct)    |
+| `R` (PR)        | `B` (PR)        | Code review Claude (tmux)      |
+| `W` (PR)        | `i` (PR)        | Worktree + Claude (direct)     |
+| `E` (PR)        | `I` (PR)        | Worktree + Claude (tmux)       |
+| `t` (PR)        | `t` (PR)        | CI checks (direct) — no change |
+| `T` (PR)        | `T` (PR)        | CI checks (tmux) — no change   |
+
+Restored built-in defaults:
+
+- `g`/`G` — first/last item navigation
+- `C` — checkout PR
+- `W` — mark ready for review
+- `R` — refresh all sections
+
+## Capabilities
+
+### Modified Capabilities
+
+- `gh-dash-keybindings`: reassign keys to avoid collisions with built-in defaults
+
+## Impact
+
+- `dot_config/gh-dash/config.yml`: keybindings section updated (key values and names only, commands unchanged)
+- No new dependencies or tools
+- Help menu (`?`) will reflect the new key assignments

--- a/openspec/changes/fix-ghd-keybinding-collisions/specs/gh-dash-keybindings/spec.md
+++ b/openspec/changes/fix-ghd-keybinding-collisions/specs/gh-dash-keybindings/spec.md
@@ -1,0 +1,83 @@
+## MODIFIED Requirements
+
+### Requirement: Universal lazygit keybinding
+
+The universal keybindings SHALL include an `L` key that opens lazygit in the repo directory using direct execution (no tmux).
+
+#### Scenario: Lazygit opens in repo directory
+
+- **WHEN** user presses `L` on any item
+- **THEN** gh-dash suspends TUI, runs `cd {{.RepoPath}} && lazygit`, and resumes TUI on exit
+
+### Requirement: PR code review keybinding (direct)
+
+The PR keybindings SHALL include a `b` key that checks out a worktree for the PR and launches Claude with a code review prompt using direct execution.
+
+#### Scenario: Code review launches for a PR (direct)
+
+- **WHEN** user presses `b` on a PR
+- **THEN** gh-dash suspends TUI and runs `wt -C {{.RepoPath}} switch pr:{{.PrNumber}} -x "claude /code-review:code-review {{.RepoName}}#{{.PrNumber}}"`
+
+### Requirement: PR worktree + Claude keybinding (direct)
+
+The PR keybindings SHALL include an `i` key that checks out a worktree for the PR and launches Claude without a specific prompt using direct execution.
+
+#### Scenario: Claude opens in PR worktree (direct)
+
+- **WHEN** user presses `i` on a PR
+- **THEN** gh-dash suspends TUI and runs `wt -C {{.RepoPath}} switch pr:{{.PrNumber}} -x claude`
+
+### Requirement: PR code review keybinding (tmux)
+
+The PR keybindings SHALL include a `B` key that checks out a worktree for the PR and launches Claude with a code review prompt in a side-by-side tmux pane.
+
+#### Scenario: Code review launches in tmux pane
+
+- **WHEN** user presses `B` on a PR while inside a tmux session
+- **THEN** a horizontal split pane opens running `wt -C {{.RepoPath}} switch pr:{{.PrNumber}} -x "claude /code-review:code-review {{.RepoName}}#{{.PrNumber}}"` alongside gh-dash
+
+### Requirement: PR worktree + Claude keybinding (tmux)
+
+The PR keybindings SHALL include an `I` key that checks out a worktree for the PR and launches Claude without a specific prompt in a side-by-side tmux pane.
+
+#### Scenario: Claude opens in tmux pane
+
+- **WHEN** user presses `I` on a PR while inside a tmux session
+- **THEN** a horizontal split pane opens running `wt -C {{.RepoPath}} switch pr:{{.PrNumber}} -x claude` alongside gh-dash
+
+### Requirement: RepoPath passed to worktrunk via -C flag
+
+All keybinding commands that use `wt` SHALL pass `-C {{.RepoPath}}` to specify the target repository directory.
+
+#### Scenario: wt receives correct repo path
+
+- **WHEN** user presses `b`, `i`, `B`, or `I` on a PR from repo `owner/my-repo`
+- **THEN** the command includes `-C {{.RepoPath}}` where `{{.RepoPath}}` resolves to the local repo path
+
+## ADDED Requirements
+
+### Requirement: Custom keybindings SHALL NOT collide with built-in defaults
+
+No custom keybinding SHALL use a key that is assigned to a built-in gh-dash function in the same view context. Specifically, the following keys are reserved for built-ins:
+
+- Universal/Navigation: `g`, `G`, `j`, `k`, `h`, `l`, `r`, `R`, `s`, `q`, `?`, `/`, `p`, `o`, `y`, `Y`
+- PR view: `a`, `A`, `c`, `C`, `d`, `e`, `m`, `u`, `v`, `w`, `W`, `x`, `X`, `[`, `]`
+
+#### Scenario: No collision with navigation defaults
+
+- **WHEN** the config is loaded by gh-dash
+- **THEN** the built-in `g` (first item), `G` (last item), `R` (refresh all) navigation keys function as documented
+
+#### Scenario: No collision with PR defaults
+
+- **WHEN** user is in PR view
+- **THEN** the built-in `C` (checkout), `W` (mark ready for review) keys function as documented
+
+### Requirement: Lowercase/uppercase pattern for direct/tmux variants
+
+All custom PR keybindings that have both a direct and tmux variant SHALL use lowercase for direct execution and uppercase for the tmux variant of the same action.
+
+#### Scenario: Pattern is consistent across all custom PR keybindings
+
+- **WHEN** inspecting the keybindings config
+- **THEN** `b`/`B` (review), `i`/`I` (worktree), and `t`/`T` (CI checks) all follow the lowercase=direct, UPPERCASE=tmux pattern

--- a/openspec/changes/fix-ghd-keybinding-collisions/tasks.md
+++ b/openspec/changes/fix-ghd-keybinding-collisions/tasks.md
@@ -1,0 +1,12 @@
+## 1. Remap keybindings in config
+
+- [x] 1.1 Change universal lazygit key from `g` to `L` in `dot_config/gh-dash/config.yml`
+- [x] 1.2 Change PR code review (direct) key from `C` to `b` and update name
+- [x] 1.3 Change PR code review (tmux) key from `R` to `B` and update name
+- [x] 1.4 Change PR worktree + Claude (direct) key from `W` to `i` and update name
+- [x] 1.5 Change PR worktree + Claude (tmux) key from `E` to `I` and update name
+
+## 2. Verify no collisions
+
+- [x] 2.1 Confirm keys `g`, `G`, `C`, `W`, `R` are no longer used by custom keybindings
+- [x] 2.2 Confirm all custom keys (`L`, `b`, `B`, `i`, `I`, `t`, `T`) are not in the built-in default set

--- a/openspec/changes/fix-ghd-keybinding-collisions/tasks.md
+++ b/openspec/changes/fix-ghd-keybinding-collisions/tasks.md
@@ -8,5 +8,5 @@
 
 ## 2. Verify no collisions
 
-- [x] 2.1 Confirm keys `g`, `G`, `C`, `W`, `R` are no longer used by custom keybindings
+- [x] 2.1 Confirm keys `g`, `G`, `C`, `W`, `R`, `E` are no longer used by custom keybindings
 - [x] 2.2 Confirm all custom keys (`L`, `b`, `B`, `i`, `I`, `t`, `T`) are not in the built-in default set


### PR DESCRIPTION
## Summary

- Remap custom gh-dash keybindings (`g`, `C`, `W`, `R`, `E`) to free keys (`L`, `b`, `i`, `B`, `I`) to restore built-in defaults for navigation, checkout, mark-ready, and refresh-all
- Adopt consistent lowercase=direct / UPPERCASE=tmux pattern across all custom PR keybindings
- CI checks keybindings (`t`/`T`) unchanged — already collision-free

Closes #104

## Test plan

- [ ] Open gh-dash and verify `?` help menu shows new key assignments
- [ ] Press `g` in PR list — should jump to first item (restored default)
- [ ] Press `C` on a PR — should checkout PR (restored default)
- [ ] Press `b` on a PR — should launch Claude code review (direct)
- [ ] Press `B` on a PR in tmux — should open Claude review in split pane
- [ ] Press `i` on a PR — should open worktree + Claude (direct)
- [ ] Press `I` on a PR in tmux — should open worktree + Claude in split pane
- [ ] Press `L` on any item — should open lazygit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated gh-dash keybindings: Lazygit (g → L); PR code review direct/tmux (C → b, R → B); PR worktree + Claude direct/tmux (W → i, E → I).

* **Documentation**
  * Added specification, design guidance, proposal, and task checklist documenting the keybinding remapping and collision-resolution plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->