### PR TITLE
feat: add CodeRabbit CLI skills integration

### DIFF
--- a/openspec/changes/add-coderabbit-cli-skills/.openspec.yaml
+++ b/openspec/changes/add-coderabbit-cli-skills/.openspec.yaml
@@ -1,0 +1,1 @@
+schema: spec-driven

--- a/openspec/changes/add-coderabbit-cli-skills/design.md
+++ b/openspec/changes/add-coderabbit-cli-skills/design.md
@@ -1,0 +1,69 @@
+## Context
+
+The dotfiles repo uses chezmoi with a single install script (`run_onchange_install-packages.sh.tmpl`) that organizes tool installation into numbered groups with interactive confirmation. CLI tools go in `BREW_PACKAGES` (Group 1), GUI apps go in `ALL_CASKS` (Group 4), and agent skills go in Group 9 via `install_skill` helper calls.
+
+CodeRabbit CLI (`coderabbit` / `cr`) is an AI-powered code review tool distributed as a brew cask. It provides two agent skills via the `skills.sh` ecosystem: `code-review` (review uncommitted changes) and `autofix` (fix unresolved PR review comments). Authentication is interactive (browser-based OAuth) and cannot be automated.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Install CodeRabbit CLI idempotently as part of the dotfiles bootstrap
+- Install both agent skills (`code-review`, `autofix`) globally via `skills.sh`
+- Inform the user about the manual auth step post-install
+- Follow existing installation patterns exactly (cask array format, skill helper, manual instruction block)
+
+**Non-Goals:**
+
+- Automating `coderabbit auth login` (requires browser interaction)
+- Adding a global `.coderabbit.yaml` config (CodeRabbit has no filesystem-level global config — config is per-project or per-org via web UI)
+- Adding shell aliases (`cr` is already provided by the CLI)
+- Modifying the non-macOS instruction block (out of scope for this dotfiles setup)
+
+## Decisions
+
+### 1. Install as brew cask, not via curl | sh
+
+CodeRabbit offers two installation methods: brew cask (`brew install --cask coderabbit`) and curl script (`curl -fsSL https://cli.coderabbit.ai/install.sh | sh`).
+
+| Option      | Pros                                                                                             | Cons                                                                   |
+| ----------- | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
+| Brew cask   | Consistent with ALL_CASKS pattern, managed by brew upgrade, idempotent via `/Applications` check | Slightly larger download (includes app bundle)                         |
+| curl script | Lighter, works without brew                                                                      | Different pattern from rest of install script, no brew upgrade support |
+
+**Decision:** Brew cask. It follows the existing `ALL_CASKS` pattern and gets automatic updates via `brew upgrade`.
+
+**Fallback:** If the brew cask is unavailable or broken on a future macOS version, the curl script can be used as a manual install alternative.
+
+### 2. Category: AI (not Dev)
+
+The `ALL_CASKS` array uses a category field for grouping in the fzf picker. CodeRabbit is an AI-powered review tool, placing it alongside Claude, ChatGPT, Ollama, and superwhisper.
+
+**Decision:** Use `AI` category. Format: `"coderabbit|CodeRabbit|AI|AI code review CLI"`.
+
+### 3. Both skills installed globally
+
+The proposal lists two skills: `code-review` and `autofix`. Both are useful independently — `code-review` works on uncommitted changes (no PR needed), while `autofix` works on PR review comments.
+
+**Decision:** Install both via the existing `install_skill` helper in Group 9:
+
+```bash
+install_skill "coderabbitai/skills" "code-review"
+install_skill "coderabbitai/skills" "autofix"
+```
+
+### 4. Auth as manual instruction only
+
+`coderabbit auth login` opens a browser for OAuth. This cannot be scripted or run headlessly.
+
+**Decision:** Add a line to the manual instructions block (alongside 1Password, Adobe, etc.):
+
+```
+info "  - CodeRabbit: coderabbit auth login (opens browser for authentication)"
+```
+
+## Risks / Trade-offs
+
+- **[Free tier rate limit]** — CodeRabbit free tier allows 3 reviews/hour. Heavy usage during development may hit this limit. Mitigation: upgrade to Pro if this becomes a bottleneck; not a dotfiles concern.
+- **[Cask availability]** — The coderabbit brew cask is relatively new (667 installs in 30 days). If it's removed or broken, fallback to curl install. Mitigation: the manual instructions block can include the curl alternative.
+- **[Skills repo stability]** — `coderabbitai/skills` is a third-party skills.sh repo. If it's renamed or removed, `install_skill` will fail gracefully (the `run_claude_step` wrapper catches errors). Mitigation: same error handling as all other Group 9 skills.

--- a/openspec/changes/add-coderabbit-cli-skills/design.md
+++ b/openspec/changes/add-coderabbit-cli-skills/design.md
@@ -58,7 +58,7 @@ install_skill "coderabbitai/skills" "autofix"
 
 **Decision:** Add a line to the manual instructions block (alongside 1Password, Adobe, etc.):
 
-```
+```bash
 info "  - CodeRabbit: coderabbit auth login (opens browser for authentication)"
 ```
 

--- a/openspec/changes/add-coderabbit-cli-skills/proposal.md
+++ b/openspec/changes/add-coderabbit-cli-skills/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The dotfiles already install agent skills from Vercel and Anthropic (Group 9 in the install script), enabling AI coding agents like Claude Code to discover and invoke specialized capabilities. CodeRabbit is an AI-powered code review tool that can catch bugs, security issues, and logic errors before code is committed. Adding its CLI skills lets any AI agent trigger code review directly from the terminal via `coderabbit --agent`, closing the loop between writing code and reviewing it — without leaving the terminal or opening a PR first.
+
+GitHub issue: pabloimrik17/dotfiles#113
+
+## What Changes
+
+- Install `coderabbit` as a brew cask (alongside Claude, Ollama, etc. in the `ALL_CASKS` array)
+- Add two CodeRabbit agent skills via `skills.sh` (Group 9):
+    - `code-review` — triggers full AI review on uncommitted changes
+    - `autofix` — fetches unresolved PR review comments and applies fixes
+- Add `coderabbit auth login` as a manual instruction (alongside Adobe, 1Password, etc.) since authentication is interactive and requires a browser
+
+## Capabilities
+
+### New Capabilities
+
+- `coderabbit-install`: Installation of CodeRabbit CLI via brew cask and agent skills via skills.sh
+- `coderabbit-skills`: Agent skills (code-review, autofix) available globally for AI coding agents
+
+### Modified Capabilities
+
+_None — this is a new tool addition with no changes to existing specs._
+
+## Impact
+
+- **Files modified**: `run_onchange_install-packages.sh.tmpl` only (three insertions: cask entry, two skill installs, one manual instruction line)
+- **Dependencies**: `brew` (already installed), `npx` (already available for Group 9 skills)
+- **No new config files** — CodeRabbit has no global config (`~/.coderabbit.yaml` does not exist); config is per-project only
+- **No new aliases** — `cr` is already provided by the CLI as a built-in shorthand
+- **No breaking changes** to existing configuration

--- a/openspec/changes/add-coderabbit-cli-skills/proposal.md
+++ b/openspec/changes/add-coderabbit-cli-skills/proposal.md
@@ -25,7 +25,7 @@ _None — this is a new tool addition with no changes to existing specs._
 
 ## Impact
 
-- **Files modified**: `run_onchange_install-packages.sh.tmpl` only (three insertions: cask entry, two skill installs, one manual instruction line)
+- **Files modified**: `run_onchange_install-packages.sh.tmpl` only (four insertions: cask entry, two skill installs, one manual instruction line)
 - **Dependencies**: `brew` (already installed), `npx` (already available for Group 9 skills)
 - **No new config files** — CodeRabbit has no global config (`~/.coderabbit.yaml` does not exist); config is per-project only
 - **No new aliases** — `cr` is already provided by the CLI as a built-in shorthand

--- a/openspec/changes/add-coderabbit-cli-skills/specs/coderabbit-install/spec.md
+++ b/openspec/changes/add-coderabbit-cli-skills/specs/coderabbit-install/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: CodeRabbit CLI installed via brew cask
+
+The install script SHALL include `coderabbit` in the `ALL_CASKS` array with category `AI` and description `AI code review CLI`.
+
+#### Scenario: Fresh install on clean machine
+
+- **WHEN** the user runs the install script and confirms GUI app installation
+- **THEN** `coderabbit` SHALL be installed via `brew install --cask coderabbit`
+
+#### Scenario: Already installed
+
+- **WHEN** the user runs the install script and `/Applications/CodeRabbit.app` already exists
+- **THEN** the installer SHALL skip coderabbit and report it as already installed
+
+### Requirement: Manual auth instruction displayed
+
+The install script SHALL print a manual instruction for `coderabbit auth login` in the manual instructions block.
+
+#### Scenario: Install script completes
+
+- **WHEN** the install script reaches the manual instructions section
+- **THEN** it SHALL display a line indicating that `coderabbit auth login` must be run manually for authentication

--- a/openspec/changes/add-coderabbit-cli-skills/specs/coderabbit-skills/spec.md
+++ b/openspec/changes/add-coderabbit-cli-skills/specs/coderabbit-skills/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: code-review skill installed globally
+
+The install script SHALL install the `code-review` skill from `coderabbitai/skills` globally via `skills.sh` in Group 9.
+
+#### Scenario: Skill not yet installed
+
+- **WHEN** the user confirms agent skills installation and `code-review` is not in the installed skills list
+- **THEN** the installer SHALL run `npx -y skills add coderabbitai/skills --skill code-review -g -y`
+
+#### Scenario: Skill already installed
+
+- **WHEN** the user confirms agent skills installation and `code-review` is already in the installed skills list
+- **THEN** the installer SHALL skip installation and report it as already installed
+
+### Requirement: autofix skill installed globally
+
+The install script SHALL install the `autofix` skill from `coderabbitai/skills` globally via `skills.sh` in Group 9.
+
+#### Scenario: Skill not yet installed
+
+- **WHEN** the user confirms agent skills installation and `autofix` is not in the installed skills list
+- **THEN** the installer SHALL run `npx -y skills add coderabbitai/skills --skill autofix -g -y`
+
+#### Scenario: Skill already installed
+
+- **WHEN** the user confirms agent skills installation and `autofix` is already in the installed skills list
+- **THEN** the installer SHALL skip installation and report it as already installed

--- a/openspec/changes/add-coderabbit-cli-skills/tasks.md
+++ b/openspec/changes/add-coderabbit-cli-skills/tasks.md
@@ -1,12 +1,12 @@
 ## 1. Brew Cask
 
-- [ ] 1.1 Add `"coderabbit|CodeRabbit|AI|AI code review CLI"` to the `ALL_CASKS` array in `run_onchange_install-packages.sh.tmpl`
+- [x] 1.1 Add `"coderabbit|CodeRabbit|AI|AI code review CLI"` to the `ALL_CASKS` array in `run_onchange_install-packages.sh.tmpl`
 
 ## 2. Agent Skills
 
-- [ ] 2.1 Add `install_skill "coderabbitai/skills" "code-review"` to Group 9 in `run_onchange_install-packages.sh.tmpl`
-- [ ] 2.2 Add `install_skill "coderabbitai/skills" "autofix"` to Group 9 in `run_onchange_install-packages.sh.tmpl`
+- [x] 2.1 Add `install_skill "coderabbitai/skills" "code-review"` to Group 9 in `run_onchange_install-packages.sh.tmpl`
+- [x] 2.2 Add `install_skill "coderabbitai/skills" "autofix"` to Group 9 in `run_onchange_install-packages.sh.tmpl`
 
 ## 3. Manual Instructions
 
-- [ ] 3.1 Add `coderabbit auth login` line to the manual install instructions block in `run_onchange_install-packages.sh.tmpl`
+- [x] 3.1 Add `coderabbit auth login` line to the manual install instructions block in `run_onchange_install-packages.sh.tmpl`

--- a/openspec/changes/add-coderabbit-cli-skills/tasks.md
+++ b/openspec/changes/add-coderabbit-cli-skills/tasks.md
@@ -1,0 +1,12 @@
+## 1. Brew Cask
+
+- [ ] 1.1 Add `"coderabbit|CodeRabbit|AI|AI code review CLI"` to the `ALL_CASKS` array in `run_onchange_install-packages.sh.tmpl`
+
+## 2. Agent Skills
+
+- [ ] 2.1 Add `install_skill "coderabbitai/skills" "code-review"` to Group 9 in `run_onchange_install-packages.sh.tmpl`
+- [ ] 2.2 Add `install_skill "coderabbitai/skills" "autofix"` to Group 9 in `run_onchange_install-packages.sh.tmpl`
+
+## 3. Manual Instructions
+
+- [ ] 3.1 Add `coderabbit auth login` line to the manual install instructions block in `run_onchange_install-packages.sh.tmpl`

--- a/run_onchange_install-packages.sh.tmpl
+++ b/run_onchange_install-packages.sh.tmpl
@@ -302,6 +302,7 @@ ALL_CASKS=(
     "1password|1Password|Security|Password manager"
     "iina|IINA|Media|Modern media player"
     "superwhisper|superwhisper|AI|Voice-to-text via Whisper"
+    "coderabbit|CodeRabbit|AI|AI code review CLI"
     "adobe-acrobat-reader|Adobe Acrobat Reader|Productivity|PDF reader"
     "telegram|Telegram|Optional|Messaging"
     "whatsapp|WhatsApp|Optional|Messaging"
@@ -785,6 +786,8 @@ if confirm "Install global agent skills via skills.sh?"; then
         install_skill "anthropics/skills" "pptx"
         install_skill "anthropics/skills" "docx"
         install_skill "anthropics/skills" "xlsx"
+        install_skill "coderabbitai/skills" "code-review"
+        install_skill "coderabbitai/skills" "autofix"
     else
         warn "npx is not available — skipping agent skills installation"
     fi
@@ -802,6 +805,7 @@ info "  - Last.fm Scrobbler: https://last.fm/about/trackmymusic"
 info "  - CleanMyMac: requires license — install from https://cleanmymac.com"
 info "  - Adobe Creative Cloud: requires Adobe login — install from https://creativecloud.adobe.com"
 info "  - 1Password for Safari: install from the Mac App Store (Safari extension)"
+info "  - CodeRabbit: coderabbit auth login (opens browser for authentication)"
 info ""
 
 {{ else -}}

--- a/run_onchange_install-packages.sh.tmpl
+++ b/run_onchange_install-packages.sh.tmpl
@@ -317,10 +317,19 @@ ALL_CASKS=(
     "philips-hue-sync|Hue Sync|Optional|Philips Hue screen sync"
 )
 
+is_cask_installed() {
+    local cask="$1"
+    local app_name="$2"
+    if [ -n "$app_name" ] && [ -d "/Applications/$app_name.app" ]; then
+        return 0
+    fi
+    brew list --cask "$cask" &>/dev/null
+}
+
 install_cask() {
     local cask="$1"
     local app_name="$2"
-    if [ -d "/Applications/$app_name.app" ]; then
+    if is_cask_installed "$cask" "$app_name"; then
         info "  $cask — already installed, skipping"
     else
         info "  Installing $cask..."
@@ -334,7 +343,7 @@ install_cask() {
 PENDING_CASKS=()
 for entry in "${ALL_CASKS[@]}"; do
     IFS='|' read -r cask app_name category description <<< "$entry"
-    if [ ! -d "/Applications/$app_name.app" ]; then
+    if ! is_cask_installed "$cask" "$app_name"; then
         PENDING_CASKS+=("$entry")
     fi
 done


### PR DESCRIPTION
## Summary

- Add OpenSpec artifacts (proposal, design, specs, tasks) for integrating CodeRabbit CLI and its agent skills into the dotfiles
- CodeRabbit CLI installed as brew cask (`AI` category)
- Two agent skills (`code-review`, `autofix`) installed globally via `skills.sh`
- Auth (`coderabbit auth login`) added as manual instruction

Closes #113

## Test plan

- [ ] Verify `brew install --cask coderabbit` installs the CLI and `cr` alias is available
- [ ] Verify `install_skill "coderabbitai/skills" "code-review"` installs the skill globally
- [ ] Verify `install_skill "coderabbitai/skills" "autofix"` installs the skill globally
- [ ] Verify manual instruction for `coderabbit auth login` is printed at end of install script
- [ ] Run full install script on a clean machine and confirm no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional CodeRabbit CLI added to the macOS installer with two global agent skills: code-review and autofix.
  * Installer includes a manual post‑install authentication step: run `coderabbit auth login`.

* **Documentation**
  * Adds proposal, design, specs, and task checklist describing installation behavior, idempotency, and non-goals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->