### PR TITLE
feat: add expect-cli MCP integration

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -264,6 +264,11 @@
       "command": "npx",
       "args": ["-y", "chrome-devtools-mcp@latest"]
     },
+    "expect": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "expect-cli@latest", "mcp"]
+    },
     "gh_grep": {
       "type": "http",
       "url": "https://mcp.grep.app"

--- a/dot_config/opencode/opencode.jsonc
+++ b/dot_config/opencode/opencode.jsonc
@@ -13,6 +13,13 @@
         "opencode-wakatime",
         "opencode-websearch-cited@1.2.0",
     ],
+    "mcp": {
+        "expect": {
+            "type": "local",
+            "command": ["npx", "-y", "expect-cli@latest", "mcp"],
+            "enabled": true,
+        },
+    },
     "formatter": {
         "oxfmt": {
             "command": ["oxfmt", "$FILE"],

--- a/openspec/changes/add-expect-cli/design.md
+++ b/openspec/changes/add-expect-cli/design.md
@@ -1,0 +1,49 @@
+## Context
+
+The dotfiles manage global MCP server configuration for two AI coding agents: Claude Code (`dot_claude/settings.json.tmpl`) and OpenCode (`dot_config/opencode/opencode.jsonc`). Claude Code currently has 9 global MCP servers; OpenCode has none (it uses plugins instead). Both configs are chezmoi-managed templates deployed to `~/.claude/settings.json` and `~/.config/opencode/opencode.jsonc` respectively.
+
+expect-cli is an npm package that provides browser-based testing via MCP tools. Its `init` command sets up per-project skills and preferences, but the MCP server itself can be registered globally so the tools are available in every session.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Register the expect MCP server globally for Claude Code and OpenCode so browser testing tools are available in every session without per-project setup
+- Follow the established `npx -y <package>@latest` pattern used by all other stdio MCP servers
+
+**Non-Goals:**
+
+- Installing expect-cli as a global npm package (uses npx on-demand instead)
+- Automating per-project `expect init` — that installs the SKILL.md and project preferences, which are project-local concerns
+- Adding shell aliases for expect-cli
+- Modifying the chezmoi install script
+
+## Decisions
+
+### Decision 1: npx on-demand instead of global install
+
+Register the MCP server as `npx -y expect-cli@latest mcp` rather than installing expect-cli globally with `bun add -g`.
+
+**Rationale**: Every other stdio MCP server in the dotfiles uses `npx -y <package>@latest`. This ensures the latest version is always used without manual upgrades. The dotfiles have zero globally-installed npm packages — adding one would break that pattern. The `@latest` tag means no version pinning or maintenance burden.
+
+**Alternative considered**: `bun add -g expect-cli` in the install script, then reference the binary directly. Rejected because it introduces a new installation category, requires manual version updates, and the command name `expect` collides with Tcl Expect (`/usr/bin/expect`).
+
+### Decision 2: OpenCode uses `mcp` config key, not plugins
+
+OpenCode supports MCP servers via a `"mcp"` key in its config, separate from its `"plugin"` array. The expect MCP server will be added as a `"local"` type MCP entry with command array format, matching OpenCode's documented config schema.
+
+**Rationale**: Plugins and MCP servers are different concepts in OpenCode. The MCP entry makes the tools available to the agent directly, which is what we need.
+
+### Decision 3: Global scope only, no per-project config in dotfiles
+
+The MCP server is registered globally. Per-project setup (skill, preferences) is left to `npx -y expect-cli@latest init` run manually by the user.
+
+**Rationale**: The SKILL.md and `.expect/project-preferences.json` are project-local files that don't belong in a global dotfiles repo. The MCP server provides the tools; the skill teaches the agent when to use them. Without the skill, users can still invoke expect explicitly — they just won't get the automatic `/expect` slash command.
+
+## Risks / Trade-offs
+
+**[npx cold start latency]** → First invocation in a session downloads expect-cli via npx, adding a few seconds. Subsequent calls in the same session are cached. This is identical to how eslint, knip, context7, and all other npx-based MCP servers behave — accepted trade-off for always-latest versioning.
+
+**[No automatic /expect command]** → Without running `init` per-project, agents won't have the SKILL.md that enables the `/expect` slash command. Users must explicitly ask the agent to use expect tools, or run `init` themselves. This is intentional — the dotfiles provide the infrastructure, projects opt in to the full experience.
+
+**[OpenCode MCP is a new config section]** → The current `opencode.jsonc` has no `mcp` key. Adding it is the first MCP server for OpenCode in the dotfiles. If OpenCode changes its MCP config format in the future, this entry will need updating.

--- a/openspec/changes/add-expect-cli/proposal.md
+++ b/openspec/changes/add-expect-cli/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The dotfiles already provide AI agents with browser automation via the Playwright MCP server, but that only gives raw browser control — the agent has to decide what to test and how. [expect-cli](https://github.com/millionco/expect) fills a different niche: it scans git diffs, generates a test plan via AI, and executes it in a real browser with Playwright, reusing actual login sessions from Chrome/Firefox/Safari. It's purpose-built for "did my code change break anything?" without writing test files.
+
+Registering the expect MCP server globally means every Claude Code and OpenCode session has access to browser-based verification out of the box. The per-project skill (`expect init`) remains a manual step since it installs project-local files (SKILL.md, preferences) that don't belong in a global dotfiles repo.
+
+GitHub issue: pabloimrik17/dotfiles#94
+
+## What Changes
+
+- Register `expect` as a global MCP server in Claude Code settings (`dot_claude/settings.json.tmpl`) using `npx -y expect-cli@latest mcp`
+- Register `expect` as a global MCP server in OpenCode config (`dot_config/opencode/opencode.jsonc`) using the OpenCode MCP format
+- Update the `mcp-global-config` capability spec to reflect the new server count (9 -> 10)
+
+No install script changes — expect-cli runs via `npx` on demand, matching the pattern of every other MCP server in the dotfiles. No shell aliases, no config files, no chezmoi templates beyond the two config edits.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `mcp-global-config`: Add expect MCP server entry to the global server list (10 servers total)
+
+### New Capabilities
+
+_None — this is adding a server to the existing global MCP config infrastructure._
+
+## Impact
+
+- **Files modified**: `dot_claude/settings.json.tmpl` (add expect to mcpServers), `dot_config/opencode/opencode.jsonc` (add expect to mcp section), `openspec/specs/mcp-global-config/spec.md` (update server count and table)
+- **Dependencies**: Node.js/npx (already available — used by 6 other MCP servers)
+- **No new config files** — expect uses npx on-the-fly, no global state
+- **No breaking changes** to existing configuration
+- **Per-project setup** (`npx -y expect-cli@latest init`) remains the user's responsibility and is not automated by the dotfiles

--- a/openspec/changes/add-expect-cli/specs/mcp-global-config/spec.md
+++ b/openspec/changes/add-expect-cli/specs/mcp-global-config/spec.md
@@ -1,0 +1,44 @@
+## MODIFIED Requirements
+
+### Requirement: Global MCP servers are defined in chezmoi settings template
+
+`dot_claude/settings.json.tmpl` SHALL contain an `mcpServers` key with the following 10 servers:
+
+| Name            | Type  | Command/URL                                         |
+| --------------- | ----- | --------------------------------------------------- |
+| eslint          | stdio | `npx -y @eslint/mcp@latest`                         |
+| context7        | stdio | `npx -y @upstash/context7-mcp@latest`               |
+| knip            | stdio | `npx -y @knip/mcp@latest`                           |
+| memory          | stdio | `npx -y @modelcontextprotocol/server-memory@latest` |
+| playwright      | stdio | `npx -y @playwright/mcp@latest`                     |
+| chrome-devtools | stdio | `npx -y chrome-devtools-mcp@latest`                 |
+| expect          | stdio | `npx -y expect-cli@latest mcp`                      |
+| gh_grep         | http  | `https://mcp.grep.app`                              |
+| atlassian       | http  | `https://mcp.atlassian.com/v1/mcp`                  |
+| figma           | http  | `https://mcp.figma.com/mcp`                         |
+
+#### Scenario: All 10 servers present after chezmoi apply
+
+- **WHEN** `chezmoi apply` is run on a new machine
+- **THEN** `~/.claude/settings.json` SHALL contain an `mcpServers` object with exactly the 10 servers listed above
+
+#### Scenario: Expect server uses npx with @latest tag
+
+- **WHEN** inspecting the deployed `~/.claude/settings.json`
+- **THEN** the `expect` MCP server entry SHALL have command `npx` and args `["-y", "expect-cli@latest", "mcp"]`
+
+## ADDED Requirements
+
+### Requirement: Expect MCP server is registered globally in OpenCode config
+
+`dot_config/opencode/opencode.jsonc` SHALL contain an `mcp` key with an `expect` server entry using the OpenCode local MCP format.
+
+#### Scenario: Expect MCP server present in OpenCode config after chezmoi apply
+
+- **WHEN** `chezmoi apply` is run on a new machine
+- **THEN** `~/.config/opencode/opencode.jsonc` SHALL contain an `mcp` object with an `expect` entry of type `"local"`, command `["npx", "-y", "expect-cli@latest", "mcp"]`, and `enabled: true`
+
+#### Scenario: OpenCode MCP section does not affect existing config keys
+
+- **WHEN** `chezmoi apply` deploys the updated OpenCode config
+- **THEN** the `model`, `tui`, `plugin`, `formatter`, and `permission` keys SHALL remain unchanged

--- a/openspec/changes/add-expect-cli/tasks.md
+++ b/openspec/changes/add-expect-cli/tasks.md
@@ -1,0 +1,11 @@
+## 1. Claude Code MCP Registration
+
+- [ ] 1.1 Add `expect` entry to `mcpServers` in `dot_claude/settings.json.tmpl` with command `npx` and args `["-y", "expect-cli@latest", "mcp"]`
+
+## 2. OpenCode MCP Registration
+
+- [ ] 2.1 Add `mcp` section to `dot_config/opencode/opencode.jsonc` with `expect` entry of type `local`, command `["npx", "-y", "expect-cli@latest", "mcp"]`, and `enabled: true`
+
+## 3. Spec Update
+
+- [ ] 3.1 Update `openspec/specs/mcp-global-config/spec.md` to reflect 10 servers (was 9) and include expect in the server table

--- a/openspec/changes/add-expect-cli/tasks.md
+++ b/openspec/changes/add-expect-cli/tasks.md
@@ -1,11 +1,11 @@
 ## 1. Claude Code MCP Registration
 
-- [ ] 1.1 Add `expect` entry to `mcpServers` in `dot_claude/settings.json.tmpl` with command `npx` and args `["-y", "expect-cli@latest", "mcp"]`
+- [x] 1.1 Add `expect` entry to `mcpServers` in `dot_claude/settings.json.tmpl` with command `npx` and args `["-y", "expect-cli@latest", "mcp"]`
 
 ## 2. OpenCode MCP Registration
 
-- [ ] 2.1 Add `mcp` section to `dot_config/opencode/opencode.jsonc` with `expect` entry of type `local`, command `["npx", "-y", "expect-cli@latest", "mcp"]`, and `enabled: true`
+- [x] 2.1 Add `mcp` section to `dot_config/opencode/opencode.jsonc` with `expect` entry of type `local`, command `["npx", "-y", "expect-cli@latest", "mcp"]`, and `enabled: true`
 
 ## 3. Spec Update
 
-- [ ] 3.1 Update `openspec/specs/mcp-global-config/spec.md` to reflect 10 servers (was 9) and include expect in the server table
+- [x] 3.1 Update `openspec/specs/mcp-global-config/spec.md` to reflect 10 servers (was 9) and include expect in the server table

--- a/openspec/specs/mcp-global-config/spec.md
+++ b/openspec/specs/mcp-global-config/spec.md
@@ -8,7 +8,7 @@ Global MCP server configuration managed by chezmoi — defines which MCP servers
 
 ### Requirement: Global MCP servers are defined in chezmoi settings template
 
-`dot_claude/settings.json.tmpl` SHALL contain an `mcpServers` key with the following 9 servers:
+`dot_claude/settings.json.tmpl` SHALL contain an `mcpServers` key with the following 10 servers:
 
 | Name            | Type  | Command/URL                                         |
 | --------------- | ----- | --------------------------------------------------- |
@@ -18,19 +18,20 @@ Global MCP server configuration managed by chezmoi — defines which MCP servers
 | memory          | stdio | `npx -y @modelcontextprotocol/server-memory@latest` |
 | playwright      | stdio | `npx -y @playwright/mcp@latest`                     |
 | chrome-devtools | stdio | `npx -y chrome-devtools-mcp@latest`                 |
+| expect          | stdio | `npx -y expect-cli@latest mcp`                      |
 | gh_grep         | http  | `https://mcp.grep.app`                              |
 | atlassian       | http  | `https://mcp.atlassian.com/v1/mcp`                  |
 | figma           | http  | `https://mcp.figma.com/mcp`                         |
 
-#### Scenario: All 9 servers present after chezmoi apply
+#### Scenario: All 10 servers present after chezmoi apply
 
 - **WHEN** `chezmoi apply` is run on a new machine
-- **THEN** `~/.claude/settings.json` SHALL contain an `mcpServers` object with exactly the 9 servers listed above
+- **THEN** `~/.claude/settings.json` SHALL contain an `mcpServers` object with exactly the 10 servers listed above
 
 #### Scenario: Stdio servers use @latest versions
 
 - **WHEN** inspecting the deployed `~/.claude/settings.json`
-- **THEN** all 6 stdio servers SHALL reference `@latest` (not pinned versions)
+- **THEN** all 7 stdio servers SHALL reference `@latest` (not pinned versions)
 
 #### Scenario: Existing settings keys are preserved
 

--- a/openspec/specs/mcp-global-config/spec.md
+++ b/openspec/specs/mcp-global-config/spec.md
@@ -49,7 +49,7 @@ The `mcpServers` key in `dot_claude/settings.json.tmpl` SHALL include `atlassian
 
 ### Requirement: Template uses no machine-specific conditionals for MCP
 
-The `mcpServers` block SHALL be plain JSON without chezmoi template conditionals (`{{ if }}`, `{{ else }}`). All 9 servers are deployed identically to every machine.
+The `mcpServers` block SHALL be plain JSON without chezmoi template conditionals (`{{ if }}`, `{{ else }}`). All 10 servers are deployed identically to every machine.
 
 #### Scenario: No conditional logic in mcpServers block
 


### PR DESCRIPTION
## Summary

- Add OpenSpec artifacts (proposal, design, specs, tasks) for registering expect-cli as a global MCP server
- Registers expect-cli in Claude Code (`dot_claude/settings.json.tmpl`) and OpenCode (`dot_config/opencode/opencode.jsonc`) global configs
- Uses `npx -y expect-cli@latest mcp` pattern consistent with all other stdio MCP servers
- Per-project setup (`expect init`) remains a manual user step

Closes #94

## Test plan

- [ ] Verify `chezmoi apply` deploys expect MCP server entry to `~/.claude/settings.json`
- [ ] Verify `chezmoi apply` deploys expect MCP entry to `~/.config/opencode/opencode.jsonc`
- [ ] Confirm expect MCP tools are available in a new Claude Code session
- [ ] Confirm expect MCP tools are available in a new OpenCode session
- [ ] Verify existing MCP servers and config keys are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Globally register an expect-cli MCP server for Claude Code and OpenCode, making the tool available by default (per-project initialization remains manual).

* **Documentation**
  * Added design, proposal, and tasks docs describing registration approach, scope limits, and known trade-offs (first-run latency and no automatic per-project init).

* **Specs**
  * Updated global MCP server count and validation scenarios to include the new server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->