### PR TITLE
feat: add Linear and Storybook MCP servers

### DIFF
--- a/openspec/changes/add-storybook-linear-mcp/.openspec.yaml
+++ b/openspec/changes/add-storybook-linear-mcp/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-12

--- a/openspec/changes/add-storybook-linear-mcp/design.md
+++ b/openspec/changes/add-storybook-linear-mcp/design.md
@@ -1,0 +1,50 @@
+## Context
+
+El install script (`run_onchange_install-packages.sh.tmpl`) ya registra 10 MCP servers globales en el Group 8.5, usando dos arrays bash: `MCP_STDIO_SERVERS` (7 entries) y `MCP_HTTP_SERVERS` (3 entries). Los servers HTTP se registran con `claude mcp add --scope user --transport http`. El script tiene pre-scan, idempotencia, y manejo de versiones outdated. Al final del script hay una sección de instrucciones manuales que menciona la auth de Atlassian y Figma.
+
+Ambos nuevos servidores (Linear y Storybook) son de tipo HTTP — encajan directamente en el array `MCP_HTTP_SERVERS` sin cambios estructurales al script.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Registrar Linear y Storybook como MCP servers HTTP globales via el install script
+- Documentar auth OAuth para Linear y requisito de addon para Storybook
+- Mantener idempotencia y consistencia con el patrón existente
+
+**Non-Goals:**
+
+- No instalar el addon `@storybook/addon-mcp` automáticamente (es per-project)
+- No configurar auth de Linear automáticamente (requiere browser interactivo)
+- No cambiar la estructura del script ni los helpers existentes
+- No pinear versiones de servidores HTTP remotos (no aplica — son URLs fijas, no paquetes npm)
+
+## Decisions
+
+### Decision 1: Ambos servers van en `MCP_HTTP_SERVERS`
+
+Linear es un servidor remoto (`https://mcp.linear.app/mcp`). Storybook es un servidor HTTP local (`http://localhost:6006/mcp`). Ambos usan transporte HTTP.
+
+**Alternativa descartada**: Registrar Storybook como stdio con un wrapper. No tiene sentido — el MCP de Storybook es un endpoint HTTP del dev server, no un proceso standalone.
+
+### Decision 2: Storybook a nivel de usuario (no proyecto)
+
+Registrar a nivel de usuario significa que cuando Storybook no está corriendo, el server simplemente falla la conexión — sin impacto. Esto ya sucede con el MCP de JetBrains (`jetbrains: ✗ Failed to connect`). Evita tener que configurar `.mcp.json` en cada proyecto.
+
+**Alternativa descartada**: Registrar per-project. Requeriría configuración repetida y no aporta nada — el endpoint siempre es `localhost:6006/mcp`.
+
+### Decision 3: Linear con OAuth (no API key)
+
+OAuth interactivo es el método oficial de Linear para su MCP server. El token se cachea en `~/.mcp-auth` automáticamente.
+
+**Alternativa descartada**: API key personal via env var. Requiere gestión manual del token y es menos seguro que OAuth con refresh.
+
+### Decision 4: Instrucciones manuales al final del script
+
+Añadir notas para Linear (OAuth) y Storybook (addon per-project) junto a las notas existentes de Atlassian y Figma. Mismo patrón, mismo lugar.
+
+## Risks / Trade-offs
+
+- **[Storybook puerto no-estándar]** → Si un proyecto usa un puerto distinto a 6006, el MCP no conecta. Mitigación: documentar en las instrucciones manuales. En la práctica el puerto default rara vez se cambia.
+- **[Linear OAuth expira]** → El token OAuth puede expirar. Mitigación: Linear maneja refresh automáticamente. Si falla, `rm -rf ~/.mcp-auth` y re-autenticar.
+- **[Storybook sin addon]** → Aunque Storybook corra, sin `@storybook/addon-mcp` el endpoint `/mcp` no existe. Mitigación: documentar claramente en instrucciones manuales.

--- a/openspec/changes/add-storybook-linear-mcp/proposal.md
+++ b/openspec/changes/add-storybook-linear-mcp/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+El setup actual tiene 10 MCP servers globales pero falta integración con Linear (gestión de issues/proyectos) y Storybook (documentación y testing de componentes). Linear es un servicio remoto que funciona desde cualquier repo; Storybook es un servidor HTTP local que se activa solo cuando `storybook dev` está corriendo — ambos encajan como servidores globales a nivel de usuario.
+
+## What Changes
+
+- Registrar el MCP server de **Linear** (`https://mcp.linear.app/mcp`) como servidor HTTP global con autenticación OAuth interactiva
+- Registrar el MCP server de **Storybook** (`http://localhost:6006/mcp`) como servidor HTTP global — disponible solo cuando un proyecto tiene Storybook corriendo (falla silenciosamente en caso contrario, igual que el MCP de JetBrains)
+- Actualizar el install script para registrar 12 servers en vez de 10
+- Documentar que Linear requiere OAuth post-registro y que Storybook requiere el addon `@storybook/addon-mcp` por proyecto
+
+## Capabilities
+
+### New Capabilities
+
+_(ninguna — no se introduce una capacidad nueva)_
+
+### Modified Capabilities
+
+- `mcp-global-config`: Se añaden 2 servidores HTTP a la tabla de servidores globales (Linear y Storybook), pasando de 10 a 12 servidores registrados. Se actualizan los scenarios de conteo y las instrucciones de auth manual.
+
+## Impact
+
+- **Install script** (`run_onchange_install-packages.sh.tmpl`): arrays de MCP servers crecen con 2 entradas HTTP adicionales
+- **Spec `mcp-global-config`**: tabla de servidores y scenarios de conteo deben actualizarse
+- **Manual/README**: documentar requisitos de auth (Linear OAuth) y addon por proyecto (Storybook)
+- **No hay breaking changes**: servidores existentes no se modifican

--- a/openspec/changes/add-storybook-linear-mcp/specs/mcp-global-config/spec.md
+++ b/openspec/changes/add-storybook-linear-mcp/specs/mcp-global-config/spec.md
@@ -1,0 +1,70 @@
+## MODIFIED Requirements
+
+### Requirement: Global MCP servers are registered via Claude CLI in install script
+
+`run_onchange_install-packages.sh.tmpl` SHALL register the following 12 MCP servers via `claude mcp add --scope user`, which writes to `~/.claude.json`:
+
+| Name            | Type  | Command/URL                                         |
+| --------------- | ----- | --------------------------------------------------- |
+| eslint          | stdio | `npx -y @eslint/mcp@latest`                         |
+| context7        | stdio | `npx -y @upstash/context7-mcp@latest`               |
+| knip            | stdio | `npx -y @knip/mcp@latest`                           |
+| memory          | stdio | `npx -y @modelcontextprotocol/server-memory@latest` |
+| playwright      | stdio | `npx -y @playwright/mcp@latest`                     |
+| chrome-devtools | stdio | `npx -y chrome-devtools-mcp@latest`                 |
+| expect          | stdio | `npx -y expect-cli@latest mcp`                      |
+| gh_grep         | http  | `https://mcp.grep.app`                              |
+| atlassian       | http  | `https://mcp.atlassian.com/v1/mcp`                  |
+| figma           | http  | `https://mcp.figma.com/mcp`                         |
+| linear          | http  | `https://mcp.linear.app/mcp`                        |
+| storybook       | http  | `http://localhost:6006/mcp`                         |
+
+`dot_claude/settings.json.tmpl` SHALL NOT contain an `mcpServers` key.
+
+#### Scenario: All 12 servers registered after install script runs
+
+- **WHEN** `chezmoi apply` runs the install script on a machine with `claude` CLI available
+- **AND** the user confirms the MCP servers install group
+- **THEN** `claude mcp list --scope user` SHALL list all 12 servers above
+
+#### Scenario: Servers registered to correct file
+
+- **WHEN** a stdio MCP server is registered via the install script
+- **THEN** `~/.claude.json` SHALL contain the server under the `mcpServers` key
+- **AND** `~/.claude/settings.json` SHALL NOT contain an `mcpServers` key
+
+#### Scenario: Settings template has no mcpServers block
+
+- **WHEN** reading `dot_claude/settings.json.tmpl`
+- **THEN** the file SHALL NOT contain an `mcpServers` key at any level
+
+#### Scenario: Stdio servers use pinned versions managed by Renovate
+
+- **WHEN** inspecting registered stdio servers via `claude mcp get <name>`
+- **THEN** all 7 stdio servers SHALL reference pinned versions (not `@latest`)
+- **AND** `renovate.json` SHALL contain a custom regex manager for the install script template
+
+### Requirement: Atlassian, Figma, Linear, and Storybook included as HTTP servers with auth/setup notes
+
+The install script SHALL register `atlassian`, `figma`, `linear`, and `storybook` as HTTP MCP servers. The manual instructions section SHALL note authentication and setup requirements for each.
+
+#### Scenario: HTTP servers registered with correct transport
+
+- **WHEN** the install script registers `atlassian`, `figma`, `linear`, and `storybook`
+- **THEN** it SHALL use `claude mcp add --scope user --transport http <name> <url>`
+
+#### Scenario: Manual auth instructions printed for OAuth servers
+
+- **WHEN** the install script reaches the manual instructions section
+- **THEN** it SHALL include a line noting that `atlassian`, `figma`, and `linear` MCP servers require OAuth authentication via `/mcp` or first use
+
+#### Scenario: Manual setup instructions printed for Storybook
+
+- **WHEN** the install script reaches the manual instructions section
+- **THEN** it SHALL include a line noting that `storybook` MCP requires `@storybook/addon-mcp` installed in each Storybook project and `storybook dev` running on port 6006
+
+#### Scenario: Storybook gracefully fails when not running
+
+- **WHEN** `storybook dev` is NOT running on localhost:6006
+- **THEN** `claude mcp list` SHALL show `storybook` as failed to connect
+- **AND** no error SHALL affect other MCP server connections

--- a/openspec/changes/add-storybook-linear-mcp/specs/mcp-global-config/spec.md
+++ b/openspec/changes/add-storybook-linear-mcp/specs/mcp-global-config/spec.md
@@ -4,20 +4,20 @@
 
 `run_onchange_install-packages.sh.tmpl` SHALL register the following 12 MCP servers via `claude mcp add --scope user`, which writes to `~/.claude.json`:
 
-| Name            | Type  | Command/URL                                         |
-| --------------- | ----- | --------------------------------------------------- |
-| eslint          | stdio | `npx -y @eslint/mcp@latest`                         |
-| context7        | stdio | `npx -y @upstash/context7-mcp@latest`               |
-| knip            | stdio | `npx -y @knip/mcp@latest`                           |
-| memory          | stdio | `npx -y @modelcontextprotocol/server-memory@latest` |
-| playwright      | stdio | `npx -y @playwright/mcp@latest`                     |
-| chrome-devtools | stdio | `npx -y chrome-devtools-mcp@latest`                 |
-| expect          | stdio | `npx -y expect-cli@latest mcp`                      |
-| gh_grep         | http  | `https://mcp.grep.app`                              |
-| atlassian       | http  | `https://mcp.atlassian.com/v1/mcp`                  |
-| figma           | http  | `https://mcp.figma.com/mcp`                         |
-| linear          | http  | `https://mcp.linear.app/mcp`                        |
-| storybook       | http  | `http://localhost:6006/mcp`                         |
+| Name            | Type  | Command/URL                                            |
+| --------------- | ----- | ------------------------------------------------------ |
+| eslint          | stdio | `npx -y @eslint/mcp@0.3.0`                             |
+| context7        | stdio | `npx -y @upstash/context7-mcp@2.1.2`                   |
+| knip            | stdio | `npx -y @knip/mcp@0.0.19`                              |
+| memory          | stdio | `npx -y @modelcontextprotocol/server-memory@2026.1.26` |
+| playwright      | stdio | `npx -y @playwright/mcp@0.0.68`                        |
+| chrome-devtools | stdio | `npx -y chrome-devtools-mcp@0.18.1`                    |
+| expect          | stdio | `npx -y expect-cli@0.1.3 mcp`                          |
+| gh_grep         | http  | `https://mcp.grep.app`                                 |
+| atlassian       | http  | `https://mcp.atlassian.com/v1/mcp`                     |
+| figma           | http  | `https://mcp.figma.com/mcp`                            |
+| linear          | http  | `https://mcp.linear.app/mcp`                           |
+| storybook       | http  | `http://localhost:6006/mcp`                            |
 
 `dot_claude/settings.json.tmpl` SHALL NOT contain an `mcpServers` key.
 

--- a/openspec/changes/add-storybook-linear-mcp/tasks.md
+++ b/openspec/changes/add-storybook-linear-mcp/tasks.md
@@ -1,0 +1,15 @@
+## 1. Install script — add servers to arrays
+
+- [x] 1.1 Add `"linear:https://mcp.linear.app/mcp"` to `MCP_HTTP_SERVERS` array in `run_onchange_install-packages.sh.tmpl`
+- [x] 1.2 Add `"storybook:http://localhost:6006/mcp"` to `MCP_HTTP_SERVERS` array in `run_onchange_install-packages.sh.tmpl`
+
+## 2. Install script — update manual instructions
+
+- [x] 2.1 Add Linear OAuth auth note alongside existing Atlassian/Figma notes in the manual instructions section
+- [x] 2.2 Add Storybook setup note explaining `@storybook/addon-mcp` addon requirement and port 6006
+
+## 3. Verification
+
+- [x] 3.1 Run `chezmoi diff` to verify only expected files changed
+- [x] 3.2 Run `chezmoi execute-template` to confirm template renders correctly
+- [ ] 3.3 Verify `claude mcp list` shows linear and storybook after registration (requires actual `chezmoi apply`)

--- a/run_onchange_install-packages.sh.tmpl
+++ b/run_onchange_install-packages.sh.tmpl
@@ -770,6 +770,8 @@ MCP_HTTP_SERVERS=(
     "gh_grep:https://mcp.grep.app"
     "atlassian:https://mcp.atlassian.com/v1/mcp"
     "figma:https://mcp.figma.com/mcp"
+    "linear:https://mcp.linear.app/mcp"
+    "storybook:http://localhost:6006/mcp"
 )
 
 if command -v claude &>/dev/null; then
@@ -933,6 +935,8 @@ info "  - 1Password for Safari: install from the Mac App Store (Safari extension
 info "  - CodeRabbit: coderabbit auth login (opens browser for authentication)"
 info "  - Atlassian MCP: requires OAuth authentication — run 'claude mcp get atlassian' or use on first invocation"
 info "  - Figma MCP: requires OAuth authentication — run 'claude mcp get figma' or use on first invocation"
+info "  - Linear MCP: requires OAuth authentication — run 'claude mcp get linear' or use on first invocation"
+info "  - Storybook MCP: requires @storybook/addon-mcp installed in each Storybook project and 'storybook dev' running on port 6006"
 info ""
 
 {{ else -}}


### PR DESCRIPTION
## Summary
- Register **Linear** (`https://mcp.linear.app/mcp`) and **Storybook** (`http://localhost:6006/mcp`) as global HTTP MCP servers in the install script
- Add manual instruction notes: Linear requires OAuth auth, Storybook requires `@storybook/addon-mcp` addon per project and `storybook dev` on port 6006
- Include OpenSpec change artifacts (proposal, design, delta spec, tasks)

## Test plan
- [ ] Run `chezmoi execute-template < run_onchange_install-packages.sh.tmpl` and verify `linear` and `storybook` appear in `MCP_HTTP_SERVERS`
- [ ] Run `chezmoi apply` and confirm both servers register via `claude mcp list`
- [ ] Verify Linear OAuth flow works on first use
- [ ] Verify Storybook MCP connects when `storybook dev` is running with `@storybook/addon-mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Linear MCP: global access to Linear via interactive OAuth (token cached locally after auth).
  * Storybook MCP: local Storybook endpoint for interactive component docs — requires @storybook/addon-mcp and running storybook on port 6006.
  * Total MCP registrations increased to 12, adding more integrations.

* **Documentation**
  * Added setup and manual-auth instructions for Linear and Storybook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->