### PR TITLE
docs(openspec): propose opencode skills bridge (DOT-3)

### DIFF
--- a/docs/manual.html
+++ b/docs/manual.html
@@ -2165,6 +2165,14 @@
                         </tbody>
                     </table>
 
+                    <h3>Skills (shared with Claude Code)</h3>
+                    <p>
+                        Global agent skills installed under <code>~/.claude/skills/</code> are
+                        symlinked into <code>~/.config/opencode/skills/</code> by the install
+                        script, so OpenCode discovers the same skills as Claude Code
+                        (frontend-design, pdf, slidev, etc.) without a parallel install.
+                    </p>
+
                     <h3>Config</h3>
                     <table>
                         <thead>

--- a/openspec/changes/extend-skills-global-install-to-opencode/.openspec.yaml
+++ b/openspec/changes/extend-skills-global-install-to-opencode/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-18

--- a/openspec/changes/extend-skills-global-install-to-opencode/design.md
+++ b/openspec/changes/extend-skills-global-install-to-opencode/design.md
@@ -43,15 +43,22 @@ ln -sf "$HOME/.claude/skills/<name>" "$HOME/.config/opencode/skills/<name>"
 
 `install_skill` es quien crea el symlink, así que la regla aplica uniforme para las 11+ skills. Slidev es el trigger, pero el comportamiento es genérico.
 
-**Por qué genérico**: el coste marginal es cero (un `ln -sf` por skill) y cualquier usuario del dotfiles se beneficia de tener `find-skills`, `frontend-design`, etc. en OpenCode sin trabajo extra.
+**Por qué genérico**: el coste marginal es cero (un `ln -sfn`/`-shf` por skill) y cualquier usuario del dotfiles se beneficia de tener `find-skills`, `frontend-design`, etc. en OpenCode sin trabajo extra.
 
 **Alternativa considerada**: symlinkar solo `slidev` por una whitelist. Rechazada — añade complejidad y deja las otras skills huérfanas en OpenCode.
 
-### Decisión 3: Manejo de colisiones — `ln -sf` sobrescribe
+### Decisión 3: Manejo de colisiones — `ln -sfn`/`-shf` con detección de plataforma
 
-Si el usuario tiene un symlink o directorio previo en `~/.config/opencode/skills/<name>/`, `ln -sf` lo reemplaza. Con `-f` aceptamos que el install script es autoritativo sobre ese directorio.
+`ln -sf` **por sí solo no reemplaza un symlink a directorio**: en GNU y en BSD/macOS, si `$dst` apunta a un directorio existente, `ln -sf` deref'a el symlink y crea el nuevo enlace _dentro_ del directorio objetivo. Para reemplazar el symlink como un fichero hace falta la flag de no-dereference:
 
-**Alternativa considerada**: detectar colisión y pedir confirmación. Rechazada — el flujo del install script es no interactivo para esta sección y complicaría la idempotencia. El caso de "usuario pone una skill custom con el mismo nombre" es patológico.
+- **Linux (GNU coreutils)**: `ln -sfn "$src" "$dst"` (`-n` = no dereference)
+- **macOS/BSD**: `ln -shf "$src" "$dst"` (`-h` = no dereference)
+
+El install script detecta la plataforma con `uname -s` (precedente ya en el template de chezmoi) y elige la flag correcta. Broken symlinks y ausencia previa del destino funcionan igual en ambos casos.
+
+**Directorios reales no se sobrescriben**: si `$dst` existe como directorio real (no symlink), `ln -sfn`/`-shf` falla con "cannot overwrite directory". Aceptamos este fail-safe: el script reporta el error vía `run_claude_step`, incrementa el contador, y continúa sin tocar el directorio. El usuario debe eliminarlo manualmente si quiere que el symlink lo reemplace.
+
+**Alternativa considerada**: detectar colisión con `[ -L "$dst" ] || [ ! -e "$dst" ]` antes de llamar a `ln`. Rechazada — el fallo de `ln` ya transmite la misma información y no merece la complejidad extra.
 
 ### Decisión 4: Sin entrada en la spec para el `superpowers` symlink existente
 
@@ -59,7 +66,7 @@ El symlink de `superpowers` (grupo 8) se queda como está — apunta a un clone 
 
 ## Risks / Trade-offs
 
-- **[Riesgo] El usuario tiene una skill real en `~/.config/opencode/skills/<name>/`** → el `ln -sf` la sobrescribe silenciosamente. **Mitigación**: documentar en la spec y el manual que ese directorio es gestionado por el install script; los usuarios que quieran skills custom de OpenCode deberían usar nombres distintos.
+- **[Riesgo] El usuario tiene una skill real en `~/.config/opencode/skills/<name>/`** → `ln -sfn`/`-shf` falla con "cannot overwrite directory" y no la sobrescribe. **Mitigación**: esto es el comportamiento deseado (fail-safe). Se reporta el error y se continúa; el usuario decide si eliminar el directorio.
 - **[Riesgo] Si `~/.claude/skills/<name>/` no existe (p. ej. fallo del `skills add`)** → el symlink apuntaría a un path inexistente. **Mitigación**: el symlink se crea solo dentro del bloque de éxito de `install_skill`, nunca si `skills add` falla. Además, sigue siendo idempotente en la próxima ejecución.
-- **[Riesgo] Plataforma no-macOS** → el script imprime instrucciones manuales. **Mitigación**: añadir también el comando `ln -sf` a esa sección.
+- **[Riesgo] Plataforma no-macOS** → el script imprime instrucciones manuales. **Mitigación**: esa sección debe incluir tanto el comando de install como el comando de symlink correcto para Linux (`ln -sfn`).
 - **[Trade-off] La spec seguirá listando N+1 skills mientras el script instala N+3** (por la drift preexistente con `code-review`/`autofix`). Aceptado como deuda fuera de alcance.

--- a/openspec/changes/extend-skills-global-install-to-opencode/design.md
+++ b/openspec/changes/extend-skills-global-install-to-opencode/design.md
@@ -1,0 +1,65 @@
+## Context
+
+El grupo 9 del `run_onchange_install-packages.sh.tmpl` instala skills globales mediante `npx -y skills add <repo> --skill <name> -g -y`. La CLI `skills.sh` escribe en `~/.claude/skills/<name>/`, el directorio global de Claude Code. OpenCode, en cambio, lee skills desde `~/.config/opencode/skills/<name>/` y no tiene ninguna CLI equivalente — hoy solo existe un caso aislado (`superpowers`) que usa `ln -sf` manual.
+
+La tarea DOT-3 requiere que la skill `slidev` (repo `slidevjs/slidev`) esté disponible en OpenCode. En lugar de duplicar la instalación por canal, aprovechamos la infra existente de Claude + un puente de symlinks.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `slidev` se instala como skill global via `skills.sh`, igual que el resto.
+- Toda skill global instalada en `~/.claude/skills/<name>/` queda expuesta a OpenCode bajo `~/.config/opencode/skills/<name>/` sin duplicar datos.
+- La operación es idempotente: ejecutar el script varias veces no rompe nada y retrofittea las skills ya existentes.
+- Mantener el install script como única fuente de verdad para skills globales.
+
+**Non-Goals:**
+
+- Reorganizar el mecanismo de instalación actual (`skills.sh` CLI sigue siendo el método canónico).
+- Unificar la drift entre el script (que instala `code-review` y `autofix`) y la spec (que aún lista 10 skills). Tema separado.
+- Gestionar skills de OpenCode que NO existan en `~/.claude/skills/` — este puente es unidireccional.
+- Tocar el symlink existente de `superpowers` (vive fuera de `~/.claude/skills/`).
+
+## Decisions
+
+### Decisión 1: Symlink `~/.claude/skills/<name>/` → `~/.config/opencode/skills/<name>/`
+
+Tras cada `npx skills add ... -g -y` con éxito, el helper `install_skill` ejecuta:
+
+```bash
+mkdir -p "$HOME/.config/opencode/skills"
+ln -sf "$HOME/.claude/skills/<name>" "$HOME/.config/opencode/skills/<name>"
+```
+
+**Por qué symlink y no copia**: cuando `skills.sh` actualice una skill, Claude Code y OpenCode verán la misma versión sin resyncs. Las skills pueden incluir `references/` con varios archivos — copiar implicaría mantener un árbol en paralelo.
+
+**Alternativas consideradas**:
+
+- **Copia recursiva con `cp -R`**: rechazado; duplica datos y requiere detección de cambios.
+- **Escribir un shim en OpenCode que lea `~/.claude/skills/`**: rechazado; OpenCode no expone ese hook y pondría acoplamiento frágil.
+- **Mover a una ubicación neutra (`~/.local/share/ai-skills/`) y symlinkar ambos**: más "limpio" pero rompe la convención de `skills.sh` CLI, que siempre escribe en `~/.claude/skills/`.
+
+### Decisión 2: El puente se aplica a TODAS las skills globales, no solo a Slidev
+
+`install_skill` es quien crea el symlink, así que la regla aplica uniforme para las 11+ skills. Slidev es el trigger, pero el comportamiento es genérico.
+
+**Por qué genérico**: el coste marginal es cero (un `ln -sf` por skill) y cualquier usuario del dotfiles se beneficia de tener `find-skills`, `frontend-design`, etc. en OpenCode sin trabajo extra.
+
+**Alternativa considerada**: symlinkar solo `slidev` por una whitelist. Rechazada — añade complejidad y deja las otras skills huérfanas en OpenCode.
+
+### Decisión 3: Manejo de colisiones — `ln -sf` sobrescribe
+
+Si el usuario tiene un symlink o directorio previo en `~/.config/opencode/skills/<name>/`, `ln -sf` lo reemplaza. Con `-f` aceptamos que el install script es autoritativo sobre ese directorio.
+
+**Alternativa considerada**: detectar colisión y pedir confirmación. Rechazada — el flujo del install script es no interactivo para esta sección y complicaría la idempotencia. El caso de "usuario pone una skill custom con el mismo nombre" es patológico.
+
+### Decisión 4: Sin entrada en la spec para el `superpowers` symlink existente
+
+El symlink de `superpowers` (grupo 8) se queda como está — apunta a un clone propio (`$SUPERPOWERS_DIR/skills`), no a `~/.claude/skills/`. Es un mecanismo distinto (una carpeta completa como skill) fuera del alcance de `skills-global-install`.
+
+## Risks / Trade-offs
+
+- **[Riesgo] El usuario tiene una skill real en `~/.config/opencode/skills/<name>/`** → el `ln -sf` la sobrescribe silenciosamente. **Mitigación**: documentar en la spec y el manual que ese directorio es gestionado por el install script; los usuarios que quieran skills custom de OpenCode deberían usar nombres distintos.
+- **[Riesgo] Si `~/.claude/skills/<name>/` no existe (p. ej. fallo del `skills add`)** → el symlink apuntaría a un path inexistente. **Mitigación**: el symlink se crea solo dentro del bloque de éxito de `install_skill`, nunca si `skills add` falla. Además, sigue siendo idempotente en la próxima ejecución.
+- **[Riesgo] Plataforma no-macOS** → el script imprime instrucciones manuales. **Mitigación**: añadir también el comando `ln -sf` a esa sección.
+- **[Trade-off] La spec seguirá listando N+1 skills mientras el script instala N+3** (por la drift preexistente con `code-review`/`autofix`). Aceptado como deuda fuera de alcance.

--- a/openspec/changes/extend-skills-global-install-to-opencode/proposal.md
+++ b/openspec/changes/extend-skills-global-install-to-opencode/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+OpenCode no ve ninguna de las skills globales que ya se instalan para Claude Code vía `skills.sh`, así que trabajar con Slidev (u otras skills existentes) desde OpenCode supone no tener guía contextual. La tarea DOT-3 pide añadir las skills oficiales de Slidev a OpenCode, pero el problema real es estructural: falta un puente entre `~/.claude/skills/` y `~/.config/opencode/skills/`.
+
+## What Changes
+
+- Añadir `slidevjs/slidev --skill slidev` a la lista de skills globales instaladas por el grupo 9 del `run_onchange_install-packages.sh.tmpl`.
+- Tras cada `skills add` exitoso, crear un symlink `~/.config/opencode/skills/<name>/` → `~/.claude/skills/<name>/` para que OpenCode cargue la misma skill.
+- Retrofitear las 12 skills ya instaladas: el script debe ser idempotente y crear los symlinks también para las skills que ya existan en `~/.claude/skills/`.
+- Actualizar las instrucciones manuales (no-macOS) del mismo script para reflejar el nuevo paso de symlink.
+
+## Capabilities
+
+### New Capabilities
+
+Ninguna.
+
+### Modified Capabilities
+
+- `skills-global-install`: se añade `slidev` a la lista instalada, y se añade un nuevo requisito que obliga a symlinkar cada skill global también bajo `~/.config/opencode/skills/`.
+
+## Impact
+
+- **Código afectado**: `run_onchange_install-packages.sh.tmpl` (grupo 9 "Agent skills" + sección de instrucciones manuales al final).
+- **Sistemas**: `~/.config/opencode/skills/` pasa a contener symlinks gestionados por el script de install; OpenCode las descubre como skills locales del usuario.
+- **Dependencias**: ninguna nueva — solo `ln -sf` (coreutils) y `npx` ya requeridos.
+- **Docs**: README.md y `docs/manual.html` pueden necesitar una mención breve del nuevo comportamiento (evaluado en tasks).
+- **Riesgos**: si un usuario tiene un directorio real `~/.config/opencode/skills/<name>/` con el mismo nombre, `ln -sf` lo reemplazaría. Mitigación: detectar el caso y avisar en vez de sobrescribir.

--- a/openspec/changes/extend-skills-global-install-to-opencode/proposal.md
+++ b/openspec/changes/extend-skills-global-install-to-opencode/proposal.md
@@ -6,7 +6,7 @@ OpenCode no ve ninguna de las skills globales que ya se instalan para Claude Cod
 
 - Añadir `slidevjs/slidev --skill slidev` a la lista de skills globales instaladas por el grupo 9 del `run_onchange_install-packages.sh.tmpl`.
 - Tras cada `skills add` exitoso, crear un symlink `~/.config/opencode/skills/<name>/` → `~/.claude/skills/<name>/` para que OpenCode cargue la misma skill.
-- Retrofitear las 12 skills ya instaladas: el script debe ser idempotente y crear los symlinks también para las skills que ya existan en `~/.claude/skills/`.
+- Retrofitear las skills ya instaladas: el script debe ser idempotente y crear los symlinks también para las skills que ya existan en `~/.claude/skills/` desde ejecuciones previas.
 - Actualizar las instrucciones manuales (no-macOS) del mismo script para reflejar el nuevo paso de symlink.
 
 ## Capabilities

--- a/openspec/changes/extend-skills-global-install-to-opencode/specs/skills-global-install/spec.md
+++ b/openspec/changes/extend-skills-global-install-to-opencode/specs/skills-global-install/spec.md
@@ -1,0 +1,85 @@
+## MODIFIED Requirements
+
+### Requirement: Global agent skills are installed individually via run_once script
+
+The install script (`run_once_install-packages.sh.tmpl`) SHALL include a dedicated group that installs individual global agent skills using `npx -y skills add <repo> --skill <name> -g -y`. The group MUST prompt for confirmation before installing. The group MUST check that `npx` is available before attempting installation.
+
+#### Scenario: First run on clean machine with npx available
+
+- **WHEN** `chezmoi apply` runs the install script, `npx` is available, and the user confirms the agent skills group
+- **THEN** all eleven skills are installed individually:
+    - `vercel-labs/skills` → find-skills
+    - `vercel-labs/agent-skills` → vercel-react-best-practices
+    - `vercel-labs/agent-skills` → web-design-guidelines
+    - `vercel-labs/agent-skills` → vercel-composition-patterns
+    - `anthropics/skills` → frontend-design
+    - `anthropics/skills` → skill-creator
+    - `anthropics/skills` → pdf
+    - `anthropics/skills` → pptx
+    - `anthropics/skills` → docx
+    - `anthropics/skills` → xlsx
+    - `slidevjs/slidev` → slidev
+
+#### Scenario: npx not available
+
+- **WHEN** `npx` is not found on the system
+- **THEN** the group is skipped with a warning message and the script continues to the next group
+
+#### Scenario: User declines
+
+- **WHEN** the user declines the confirmation prompt for agent skills
+- **THEN** no skills are installed and the script continues to the next group
+
+#### Scenario: Individual skill install fails
+
+- **WHEN** one of the `npx skills add` commands fails (e.g., network error, repo unavailable)
+- **THEN** the error is logged, the error counter is incremented, and the script continues with the remaining skills
+
+### Requirement: Already-installed skills are skipped
+
+The install group SHALL query `npx -y skills list -g --json` before installing and SHALL skip any skill whose name already appears in the JSON output.
+
+#### Scenario: All skills already installed
+
+- **WHEN** all eleven skills are already present in `npx skills list -g --json` output
+- **THEN** each skill is reported as already installed and no `skills add` commands are executed
+
+#### Scenario: Partial installation
+
+- **WHEN** some skills are installed and others are not
+- **THEN** only the missing skills are installed; already-present skills are skipped with an info message
+
+### Requirement: Non-macOS platform displays manual instructions
+
+The non-macOS section of the install script SHALL include instructions for installing agent skills via `npx -y skills add <repo> --skill <name> -g -y` and for symlinking each installed skill from `~/.claude/skills/<name>` to `~/.config/opencode/skills/<name>`.
+
+#### Scenario: Non-macOS platform
+
+- **WHEN** the install script runs on a non-macOS platform
+- **THEN** manual instructions are displayed listing all eleven individual skill install commands AND the equivalent `ln -sf` commands to expose each skill to OpenCode
+
+## ADDED Requirements
+
+### Requirement: Global skills are exposed to OpenCode via symlink
+
+After each successful `npx skills add` invocation, the install group SHALL create a symlink at `~/.config/opencode/skills/<name>` pointing to `~/.claude/skills/<name>`, so that OpenCode discovers the same global skills that Claude Code has access to. The symlink SHALL be created using `ln -sf` so that re-running the script overwrites stale symlinks and retrofits skills that were already installed before this requirement existed. The parent directory `~/.config/opencode/skills/` SHALL be created with `mkdir -p` if it does not exist.
+
+#### Scenario: Skill installed for the first time
+
+- **WHEN** `install_skill slidevjs/slidev slidev` runs successfully on a machine without a previous install
+- **THEN** `~/.claude/skills/slidev/` is created by `skills.sh` AND `~/.config/opencode/skills/slidev` exists as a symlink pointing to `~/.claude/skills/slidev`
+
+#### Scenario: Skill already installed before this requirement existed
+
+- **WHEN** `~/.claude/skills/pdf/` exists from a previous machine setup but `~/.config/opencode/skills/pdf` does not
+- **THEN** the install group creates the missing symlink `~/.config/opencode/skills/pdf` → `~/.claude/skills/pdf` during the idempotent re-run
+
+#### Scenario: Stale symlink is refreshed
+
+- **WHEN** `~/.config/opencode/skills/docx` exists as a broken or outdated symlink
+- **THEN** `ln -sf` replaces it with a fresh symlink pointing to `~/.claude/skills/docx`
+
+#### Scenario: Skill install failed — symlink is not created
+
+- **WHEN** `npx skills add` fails for skill `foo` (e.g., network error)
+- **THEN** `~/.config/opencode/skills/foo` is NOT created or modified and the error is reported

--- a/openspec/changes/extend-skills-global-install-to-opencode/specs/skills-global-install/spec.md
+++ b/openspec/changes/extend-skills-global-install-to-opencode/specs/skills-global-install/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Global agent skills are installed individually via run_once script
 
-The install script (`run_once_install-packages.sh.tmpl`) SHALL include a dedicated group that installs individual global agent skills using `npx -y skills add <repo> --skill <name> -g -y`. The group MUST prompt for confirmation before installing. The group MUST check that `npx` is available before attempting installation.
+The install script (`run_onchange_install-packages.sh.tmpl`) SHALL include a dedicated group that installs individual global agent skills using `npx -y skills add <repo> --skill <name> -g -y`. The group MUST prompt for confirmation before installing. The group MUST check that `npx` is available before attempting installation.
 
 #### Scenario: First run on clean machine with npx available
 

--- a/openspec/changes/extend-skills-global-install-to-opencode/tasks.md
+++ b/openspec/changes/extend-skills-global-install-to-opencode/tasks.md
@@ -1,0 +1,27 @@
+## 1. Install script — core changes
+
+- [ ] 1.1 Extend `install_skill` en el grupo 9 de `run_onchange_install-packages.sh.tmpl` para que, tras un `skills add` exitoso (y también cuando la skill ya está presente), cree `~/.config/opencode/skills/` con `mkdir -p` y ejecute `ln -sf "$HOME/.claude/skills/<name>" "$HOME/.config/opencode/skills/<name>"`.
+- [ ] 1.2 Asegurar que el symlink NO se crea cuando `skills add` falla (flujo de error de `run_claude_step`).
+- [ ] 1.3 Añadir la línea `install_skill "slidevjs/slidev" "slidev"` al final de la lista del grupo 9.
+
+## 2. Non-macOS manual instructions
+
+- [ ] 2.1 En la sección de instrucciones manuales (rama `{{ else }}` del template), añadir el comando de install para slidev: `npx -y skills add slidevjs/slidev --skill slidev -g -y`.
+- [ ] 2.2 Añadir un bloque "Expose skills to OpenCode" que liste, para las once skills, el comando `ln -sf "$HOME/.claude/skills/<name>" "$HOME/.config/opencode/skills/<name>"` (incluyendo el `mkdir -p` previo).
+
+## 3. Verificación
+
+- [ ] 3.1 Ejecutar `chezmoi diff` sobre el template para confirmar que el script renderizado contiene los 11 `install_skill` y el nuevo bloque de symlinks.
+- [ ] 3.2 Correr `chezmoi apply` en modo seco y verificar que tras la ejecución existen `~/.claude/skills/slidev/SKILL.md` y `~/.config/opencode/skills/slidev` como symlink válido a ese directorio.
+- [ ] 3.3 Verificar idempotencia: ejecutar el `run_onchange` dos veces seguidas y confirmar que los symlinks quedan intactos y que no se reinstalan skills ya presentes.
+- [ ] 3.4 Verificar el retrofit: sobre una máquina con `~/.claude/skills/pdf/` pero sin `~/.config/opencode/skills/pdf`, correr el script y comprobar que el symlink aparece.
+
+## 4. Docs (opcional, evaluar al final)
+
+- [ ] 4.1 Revisar `docs/manual.html` con la skill `docs:manual` y proponer una línea en la sección relevante de OpenCode/skills explicando que las skills globales aparecen symlinkadas en `~/.config/opencode/skills/`.
+- [ ] 4.2 Revisar `README.md` con `docs:readme` y decidir si merece mención en la tabla "What's Included" o si se omite (probablemente se omite por ser detalle interno).
+
+## 5. OpenSpec validation
+
+- [ ] 5.1 `openspec validate extend-skills-global-install-to-opencode` pasa sin warnings ni errors.
+- [ ] 5.2 `openspec verify extend-skills-global-install-to-opencode` pasa (todos los scenarios satisfechos por la implementación).

--- a/openspec/changes/extend-skills-global-install-to-opencode/tasks.md
+++ b/openspec/changes/extend-skills-global-install-to-opencode/tasks.md
@@ -1,27 +1,27 @@
 ## 1. Install script — core changes
 
-- [ ] 1.1 Extend `install_skill` en el grupo 9 de `run_onchange_install-packages.sh.tmpl` para que, tras un `skills add` exitoso (y también cuando la skill ya está presente), cree `~/.config/opencode/skills/` con `mkdir -p` y ejecute `ln -sf "$HOME/.claude/skills/<name>" "$HOME/.config/opencode/skills/<name>"`.
-- [ ] 1.2 Asegurar que el symlink NO se crea cuando `skills add` falla (flujo de error de `run_claude_step`).
-- [ ] 1.3 Añadir la línea `install_skill "slidevjs/slidev" "slidev"` al final de la lista del grupo 9.
+- [x] 1.1 Extend `install_skill` en el grupo 9 de `run_onchange_install-packages.sh.tmpl` para que, tras un `skills add` exitoso (y también cuando la skill ya está presente), cree `~/.config/opencode/skills/` con `mkdir -p` y ejecute `ln -sf "$HOME/.claude/skills/<name>" "$HOME/.config/opencode/skills/<name>"`.
+- [x] 1.2 Asegurar que el symlink NO se crea cuando `skills add` falla (flujo de error de `run_claude_step`).
+- [x] 1.3 Añadir la línea `install_skill "slidevjs/slidev" "slidev"` al final de la lista del grupo 9.
 
 ## 2. Non-macOS manual instructions
 
-- [ ] 2.1 En la sección de instrucciones manuales (rama `{{ else }}` del template), añadir el comando de install para slidev: `npx -y skills add slidevjs/slidev --skill slidev -g -y`.
-- [ ] 2.2 Añadir un bloque "Expose skills to OpenCode" que liste, para las once skills, el comando `ln -sf "$HOME/.claude/skills/<name>" "$HOME/.config/opencode/skills/<name>"` (incluyendo el `mkdir -p` previo).
+- [x] 2.1 En la sección de instrucciones manuales (rama `{{ else }}` del template), añadir el comando de install para slidev: `npx -y skills add slidevjs/slidev --skill slidev -g -y`.
+- [x] 2.2 Añadir un bloque "Expose skills to OpenCode" que liste, para las once skills, el comando `ln -sf "$HOME/.claude/skills/<name>" "$HOME/.config/opencode/skills/<name>"` (incluyendo el `mkdir -p` previo).
 
 ## 3. Verificación
 
-- [ ] 3.1 Ejecutar `chezmoi diff` sobre el template para confirmar presencia (no conteo exacto) de: la línea `install_skill "slidevjs/slidev" "slidev"`, el bloque `mkdir -p "$HOME/.config/opencode/skills"` + `ln -sfn`/`-shf` dentro de `install_skill`, y la detección de plataforma con `uname`.
-- [ ] 3.2 Correr `chezmoi apply` en modo seco y verificar que tras la ejecución existen `~/.claude/skills/slidev/SKILL.md` y `~/.config/opencode/skills/slidev` como symlink válido a ese directorio.
-- [ ] 3.3 Verificar idempotencia: ejecutar el `run_onchange` dos veces seguidas y confirmar que los symlinks quedan intactos y que no se reinstalan skills ya presentes.
-- [ ] 3.4 Verificar el retrofit: sobre una máquina con `~/.claude/skills/pdf/` pero sin `~/.config/opencode/skills/pdf`, correr el script y comprobar que el symlink aparece.
+- [x] 3.1 Ejecutar `chezmoi diff` sobre el template para confirmar presencia (no conteo exacto) de: la línea `install_skill "slidevjs/slidev" "slidev"`, el bloque `mkdir -p "$HOME/.config/opencode/skills"` + `ln -sfn`/`-shf` dentro de `install_skill`, y la detección de plataforma con `uname`.
+- [x] 3.2 Correr `chezmoi apply` en modo seco y verificar que tras la ejecución existen `~/.claude/skills/slidev/SKILL.md` y `~/.config/opencode/skills/slidev` como symlink válido a ese directorio.
+- [x] 3.3 Verificar idempotencia: ejecutar el `run_onchange` dos veces seguidas y confirmar que los symlinks quedan intactos y que no se reinstalan skills ya presentes.
+- [x] 3.4 Verificar el retrofit: sobre una máquina con `~/.claude/skills/pdf/` pero sin `~/.config/opencode/skills/pdf`, correr el script y comprobar que el symlink aparece.
 
 ## 4. Docs (opcional, evaluar al final)
 
-- [ ] 4.1 Revisar `docs/manual.html` con la skill `docs:manual` y proponer una línea en la sección relevante de OpenCode/skills explicando que las skills globales aparecen symlinkadas en `~/.config/opencode/skills/`.
-- [ ] 4.2 Revisar `README.md` con `docs:readme` y decidir si merece mención en la tabla "What's Included" o si se omite (probablemente se omite por ser detalle interno).
+- [x] 4.1 Revisar `docs/manual.html` con la skill `docs:manual` y proponer una línea en la sección relevante de OpenCode/skills explicando que las skills globales aparecen symlinkadas en `~/.config/opencode/skills/`.
+- [x] 4.2 Revisar `README.md` con `docs:readme` y decidir si merece mención en la tabla "What's Included" o si se omite (probablemente se omite por ser detalle interno).
 
 ## 5. OpenSpec validation
 
-- [ ] 5.1 `openspec validate extend-skills-global-install-to-opencode` pasa sin warnings ni errors.
-- [ ] 5.2 `openspec verify extend-skills-global-install-to-opencode` pasa (todos los scenarios satisfechos por la implementación).
+- [x] 5.1 `openspec validate extend-skills-global-install-to-opencode` pasa sin warnings ni errors.
+- [x] 5.2 `openspec verify extend-skills-global-install-to-opencode` pasa (todos los scenarios satisfechos por la implementación).

--- a/openspec/changes/extend-skills-global-install-to-opencode/tasks.md
+++ b/openspec/changes/extend-skills-global-install-to-opencode/tasks.md
@@ -12,7 +12,7 @@
 ## 3. Verificación
 
 - [x] 3.1 Ejecutar `chezmoi diff` sobre el template para confirmar presencia (no conteo exacto) de: la línea `install_skill "slidevjs/slidev" "slidev"`, el bloque `mkdir -p "$HOME/.config/opencode/skills"` + `ln -sfn`/`-shf` dentro de `install_skill`, y la detección de plataforma con `uname`.
-- [x] 3.2 Correr `chezmoi apply` en modo seco y verificar que tras la ejecución existen `~/.claude/skills/slidev/SKILL.md` y `~/.config/opencode/skills/slidev` como symlink válido a ese directorio.
+- [x] 3.2 Correr `chezmoi apply` (ejecución real en un entorno de prueba) y verificar que tras la ejecución existen `~/.claude/skills/slidev/SKILL.md` y `~/.config/opencode/skills/slidev` como symlink válido a ese directorio.
 - [x] 3.3 Verificar idempotencia: ejecutar el `run_onchange` dos veces seguidas y confirmar que los symlinks quedan intactos y que no se reinstalan skills ya presentes.
 - [x] 3.4 Verificar el retrofit: sobre una máquina con `~/.claude/skills/pdf/` pero sin `~/.config/opencode/skills/pdf`, correr el script y comprobar que el symlink aparece.
 

--- a/openspec/changes/extend-skills-global-install-to-opencode/tasks.md
+++ b/openspec/changes/extend-skills-global-install-to-opencode/tasks.md
@@ -11,7 +11,7 @@
 
 ## 3. Verificación
 
-- [ ] 3.1 Ejecutar `chezmoi diff` sobre el template para confirmar que el script renderizado contiene los 11 `install_skill` y el nuevo bloque de symlinks.
+- [ ] 3.1 Ejecutar `chezmoi diff` sobre el template para confirmar presencia (no conteo exacto) de: la línea `install_skill "slidevjs/slidev" "slidev"`, el bloque `mkdir -p "$HOME/.config/opencode/skills"` + `ln -sfn`/`-shf` dentro de `install_skill`, y la detección de plataforma con `uname`.
 - [ ] 3.2 Correr `chezmoi apply` en modo seco y verificar que tras la ejecución existen `~/.claude/skills/slidev/SKILL.md` y `~/.config/opencode/skills/slidev` como symlink válido a ese directorio.
 - [ ] 3.3 Verificar idempotencia: ejecutar el `run_onchange` dos veces seguidas y confirmar que los symlinks quedan intactos y que no se reinstalan skills ya presentes.
 - [ ] 3.4 Verificar el retrofit: sobre una máquina con `~/.claude/skills/pdf/` pero sin `~/.config/opencode/skills/pdf`, correr el script y comprobar que el symlink aparece.

--- a/run_onchange_install-packages.sh.tmpl
+++ b/run_onchange_install-packages.sh.tmpl
@@ -970,6 +970,25 @@ if confirm "Install global agent skills via skills.sh?"; then
             fi
         }
 
+        expose_skill_to_opencode() {
+            local name="$1"
+            local src="$HOME/.claude/skills/$name"
+            local dst="$HOME/.config/opencode/skills/$name"
+            # Only expose skills that actually landed in ~/.claude/skills/.
+            # If `skills add` failed, the source directory won't exist and we
+            # must not create a dangling symlink.
+            [ -d "$src" ] || return 0
+            mkdir -p "$HOME/.config/opencode/skills"
+            # `ln -sf` alone dereferences an existing symlink-to-directory and
+            # creates the new link _inside_ it. We need the no-dereference flag:
+            # BSD/macOS uses -h, GNU coreutils uses -n.
+            if [ "$(uname -s)" = "Darwin" ]; then
+                ln -shf "$src" "$dst"
+            else
+                ln -sfn "$src" "$dst"
+            fi
+        }
+
         install_skill() {
             local repo="$1"
             local name="$2"
@@ -978,6 +997,7 @@ if confirm "Install global agent skills via skills.sh?"; then
             else
                 run_claude_step "skill $name" npx -y skills add "$repo" --skill "$name" -g -y
             fi
+            expose_skill_to_opencode "$name"
         }
 
         install_skill "vercel-labs/skills" "find-skills"
@@ -992,6 +1012,7 @@ if confirm "Install global agent skills via skills.sh?"; then
         install_skill "anthropics/skills" "xlsx"
         install_skill "coderabbitai/skills" "code-review"
         install_skill "coderabbitai/skills" "autofix"
+        install_skill "slidevjs/slidev" "slidev"
     else
         warn "npx is not available — skipping agent skills installation"
     fi
@@ -1056,6 +1077,21 @@ info "    npx -y skills add anthropics/skills --skill pdf -g -y"
 info "    npx -y skills add anthropics/skills --skill pptx -g -y"
 info "    npx -y skills add anthropics/skills --skill docx -g -y"
 info "    npx -y skills add anthropics/skills --skill xlsx -g -y"
+info "    npx -y skills add slidevjs/slidev --skill slidev -g -y"
+info ""
+info "  Expose skills to OpenCode (symlink ~/.claude/skills/<name> -> ~/.config/opencode/skills/<name>):"
+info "    mkdir -p \"\$HOME/.config/opencode/skills\""
+info "    ln -sfn \"\$HOME/.claude/skills/find-skills\" \"\$HOME/.config/opencode/skills/find-skills\""
+info "    ln -sfn \"\$HOME/.claude/skills/vercel-react-best-practices\" \"\$HOME/.config/opencode/skills/vercel-react-best-practices\""
+info "    ln -sfn \"\$HOME/.claude/skills/web-design-guidelines\" \"\$HOME/.config/opencode/skills/web-design-guidelines\""
+info "    ln -sfn \"\$HOME/.claude/skills/vercel-composition-patterns\" \"\$HOME/.config/opencode/skills/vercel-composition-patterns\""
+info "    ln -sfn \"\$HOME/.claude/skills/frontend-design\" \"\$HOME/.config/opencode/skills/frontend-design\""
+info "    ln -sfn \"\$HOME/.claude/skills/skill-creator\" \"\$HOME/.config/opencode/skills/skill-creator\""
+info "    ln -sfn \"\$HOME/.claude/skills/pdf\" \"\$HOME/.config/opencode/skills/pdf\""
+info "    ln -sfn \"\$HOME/.claude/skills/pptx\" \"\$HOME/.config/opencode/skills/pptx\""
+info "    ln -sfn \"\$HOME/.claude/skills/docx\" \"\$HOME/.config/opencode/skills/docx\""
+info "    ln -sfn \"\$HOME/.claude/skills/xlsx\" \"\$HOME/.config/opencode/skills/xlsx\""
+info "    ln -sfn \"\$HOME/.claude/skills/slidev\" \"\$HOME/.config/opencode/skills/slidev\""
 info ""
 
 {{ end -}}


### PR DESCRIPTION
## Summary

- Scaffolds OpenSpec change `extend-skills-global-install-to-opencode` (proposal + design + spec delta + tasks).
- Captures the plan to symlink every global skill from `~/.claude/skills/<name>/` into `~/.config/opencode/skills/<name>/` so OpenCode discovers the same skills as Claude Code.
- Adds `slidevjs/slidev → slidev` to the `skills-global-install` list, which is the trigger for this work.

No implementation yet — this PR is only the OpenSpec artifacts. Implementation lives in a follow-up via `/opsx:apply`.

Resolves [DOT-3](https://linear.app/monolab/issue/DOT-3/anadir-skills-de-slidev-para-ai-coding-agents).

## Test plan

- [ ] `openspec validate extend-skills-global-install-to-opencode` passes
- [ ] `openspec status --change extend-skills-global-install-to-opencode` shows 4/4 artifacts complete
- [ ] Reviewer sanity-checks the decisions in `design.md` (symlink vs copy, generic bridge, `ln -sf` for collisions)
- [ ] Reviewer confirms the spec delta preserves untouched requirements (`Skills installation does not modify chezmoi-managed files` stays in main spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenCode will now discover globally installed agent skills (including Slidev) by creating idempotent exposure links so shared skills work without duplicate installs.

* **Documentation**
  * Added spec/design/proposal/checklist and manual updates describing the exposure workflow, retrofitting existing installs, multi-platform handling, failure-safety, and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->