### PR TITLE
fix: use jq for MCP server detection in install script

### DIFF
--- a/run_onchange_install-packages.sh.tmpl
+++ b/run_onchange_install-packages.sh.tmpl
@@ -851,7 +851,11 @@ MCP_HTTP_SERVERS=(
     "storybook:http://localhost:6006/mcp"
 )
 
-if command -v claude &>/dev/null; then
+if ! command -v claude &>/dev/null; then
+    warn "Claude Code is not installed — skipping MCP server registration"
+elif ! command -v jq &>/dev/null; then
+    warn "jq is required for MCP server detection — skipping MCP server registration"
+else
     # Pre-scan: query ~/.claude.json with jq, scoped to .mcpServers
     # (claude mcp list has no --json flag; grep would false-match on per-project mcpServers and other fields)
     mcp_registered() {
@@ -860,8 +864,9 @@ if command -v claude &>/dev/null; then
     }
 
     mcp_config_matches() {
-        local match_string="$1"
-        [ -f "$HOME/.claude.json" ] && jq -e --arg s "$match_string" '.mcpServers | tostring | contains($s)' "$HOME/.claude.json" >/dev/null 2>&1
+        local name="$1"
+        local match_string="$2"
+        [ -f "$HOME/.claude.json" ] && jq -e --arg n "$name" --arg s "$match_string" '.mcpServers[$n] | tostring | contains($s)' "$HOME/.claude.json" >/dev/null 2>&1
     }
 
     # Count new and outdated servers
@@ -879,7 +884,7 @@ if command -v claude &>/dev/null; then
         done
         if ! mcp_registered "$name"; then
             PENDING_MCP=$((PENDING_MCP + 1))
-        elif [ -n "$pkg_version" ] && ! mcp_config_matches "$pkg_version"; then
+        elif [ -n "$pkg_version" ] && ! mcp_config_matches "$name" "$pkg_version"; then
             OUTDATED_MCP=$((OUTDATED_MCP + 1))
         fi
     done
@@ -888,7 +893,7 @@ if command -v claude &>/dev/null; then
         url="${entry#*:}"
         if ! mcp_registered "$name"; then
             PENDING_MCP=$((PENDING_MCP + 1))
-        elif ! mcp_config_matches "$url"; then
+        elif ! mcp_config_matches "$name" "$url"; then
             OUTDATED_MCP=$((OUTDATED_MCP + 1))
         fi
     done
@@ -909,7 +914,7 @@ if command -v claude &>/dev/null; then
                 done
                 if ! mcp_registered "$name"; then
                     run_claude_step "mcp $name" claude mcp add --scope user "$name" -- "${parts[@]}"
-                elif [ -n "$pkg_version" ] && ! mcp_config_matches "$pkg_version"; then
+                elif [ -n "$pkg_version" ] && ! mcp_config_matches "$name" "$pkg_version"; then
                     info "  $name — version changed, updating..."
                     run_claude_step "mcp remove $name" claude mcp remove "$name" -s user
                     # Verify removal before re-adding (remove may fail silently due to Bun PTY issues)
@@ -929,7 +934,7 @@ if command -v claude &>/dev/null; then
                 url="${entry#*:}"
                 if ! mcp_registered "$name"; then
                     run_claude_step "mcp $name" claude mcp add --scope user --transport http "$name" "$url"
-                elif ! mcp_config_matches "$url"; then
+                elif ! mcp_config_matches "$name" "$url"; then
                     info "  $name — URL changed, updating..."
                     run_claude_step "mcp remove $name" claude mcp remove "$name" -s user
                     if mcp_registered "$name"; then
@@ -945,8 +950,6 @@ if command -v claude &>/dev/null; then
             info "Skipping MCP server registration."
         fi
     fi
-else
-    warn "Claude Code is not installed — skipping MCP server registration"
 fi
 
 # ------------------------------------------------------------------

--- a/run_onchange_install-packages.sh.tmpl
+++ b/run_onchange_install-packages.sh.tmpl
@@ -852,15 +852,16 @@ MCP_HTTP_SERVERS=(
 )
 
 if command -v claude &>/dev/null; then
-    # Pre-scan: grep ~/.claude.json directly (claude mcp list has no --json flag)
+    # Pre-scan: query ~/.claude.json with jq, scoped to .mcpServers
+    # (claude mcp list has no --json flag; grep would false-match on per-project mcpServers and other fields)
     mcp_registered() {
         local name="$1"
-        [ -f "$HOME/.claude.json" ] && grep -q "\"$name\"" "$HOME/.claude.json" 2>/dev/null
+        [ -f "$HOME/.claude.json" ] && jq -e --arg n "$name" '.mcpServers[$n] // empty' "$HOME/.claude.json" >/dev/null 2>&1
     }
 
     mcp_config_matches() {
         local match_string="$1"
-        [ -f "$HOME/.claude.json" ] && grep -qF "$match_string" "$HOME/.claude.json" 2>/dev/null
+        [ -f "$HOME/.claude.json" ] && jq -e --arg s "$match_string" '.mcpServers | tostring | contains($s)' "$HOME/.claude.json" >/dev/null 2>&1
     }
 
     # Count new and outdated servers
@@ -912,7 +913,7 @@ if command -v claude &>/dev/null; then
                     info "  $name — version changed, updating..."
                     run_claude_step "mcp remove $name" claude mcp remove "$name" -s user
                     # Verify removal before re-adding (remove may fail silently due to Bun PTY issues)
-                    if [ -f "$HOME/.claude.json" ] && grep -q "\"$name\"" "$HOME/.claude.json" 2>/dev/null; then
+                    if mcp_registered "$name"; then
                         error "  $name — remove failed, skipping update"
                     else
                         run_claude_step "mcp $name" claude mcp add --scope user "$name" -- "${parts[@]}"
@@ -931,7 +932,7 @@ if command -v claude &>/dev/null; then
                 elif ! mcp_config_matches "$url"; then
                     info "  $name — URL changed, updating..."
                     run_claude_step "mcp remove $name" claude mcp remove "$name" -s user
-                    if [ -f "$HOME/.claude.json" ] && grep -q "\"$name\"" "$HOME/.claude.json" 2>/dev/null; then
+                    if mcp_registered "$name"; then
                         error "  $name — remove failed, skipping update"
                     else
                         run_claude_step "mcp $name" claude mcp add --scope user --transport http "$name" "$url"


### PR DESCRIPTION
## Summary

- Replace `grep`-based parsing of `~/.claude.json` with `jq` queries scoped to `.mcpServers` in `run_onchange_install-packages.sh.tmpl` (Group 8.5).
- DRY the two inline post-`claude mcp remove` verifications by reusing `mcp_registered` instead of duplicating the lookup.
- Closes #128.

## Why

The previous helpers grepped the entire `~/.claude.json`, so a substring (a server name, a URL, or a `package@version`) appearing under `.projects[<path>].mcpServers`, `claudeAiMcpEverConnected`, or any cached field would falsely report the server as registered/up-to-date — silently skipping or breaking re-registration. Today no project has its own MCP servers locally so the bug is dormant, but the risk is latent.

## Dependency

Relies on `/usr/bin/jq` shipped with macOS (Sonoma+ ships `jq-1.7.1-apple`). Not added to `BREW_PACKAGES` per maintainer preference.

## Test plan

- [x] Reproduced the bug in a fixture: `linear` only under `.projects[…].mcpServers` — old `grep` returns true (false positive), new `jq` returns false (correct).
- [x] Smoke-tested the new helpers against the real `~/.claude.json`: `MCP servers: 12/12 registered (all up to date)`.
- [x] Substring collision check: `mcp_registered "gh"` does not match `gh_grep`.
- [x] Edge cases verified: missing file → false; empty `.mcpServers` `{}` → false; outdated `package@version` → mismatch detected correctly.
- [ ] After merge: run `chezmoi apply` on a real machine and confirm no servers are re-registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable detection of Claude MCP servers and consistent verification during updates and removals.
  * Clearer, distinct warnings when required tools or Claude Code are missing, reducing misleading messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->