### PR TITLE
fix(husky): force bun runtime in hooks so TS configs load under any node

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-bunx commitlint --edit $1
+bunx --bun commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-bunx lint-staged --config lint-staged.config.ts
+bunx --bun lint-staged --config lint-staged.config.ts


### PR DESCRIPTION
## What
Force the bun runtime in both husky hooks: `bunx --bun lint-staged` and `bunx --bun commitlint`.

## Why
`bunx lint-staged` honored the bin's `#!/usr/bin/env node` shebang and ran under whatever `node` won the PATH race. In non-interactive/agent shells (e.g. Claude Code), macOS `path_helper` re-prepends the stale `/usr/local/bin/node` v18.12.0 (official installer, 2022) ahead of nvm's v24. lint-staged 16 loads `lint-staged.config.ts` via Node-native type-stripping (engines `node >=20.17`), which node 18 can't do → `✖ Failed to read config` → every commit blocked.

It worked in the interactive terminal only because nvm's node 24 was loaded there. The breakage was latent since the hooks landed (PR #4); it surfaced once commits started running in non-interactive shells.

**Ruled out empirically:** the lint-staged 16.3.0→16.4.0 bump (#134) — every 16.x fails identically under node 18, same loader, same `>=20.17` engine — and any bun upgrade (shebang dispatch unchanged since bun v0.4.0; this machine's bun predates the hooks).

## Fix
`--bun` forces the bun runtime, which strips TS natively, so the hooks no longer depend on which node is on PATH. TS configs preserved; no system/brew changes; bun-only policy intact.

## Verification
- `bunx --bun lint-staged` + staged file → exit 0, oxfmt runs.
- Real `git commit` through husky (no `--no-verify`) under node 18 → both hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tool configurations to optimize git hook execution and improve consistency in the build workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->