### PR TITLE
feat(claude): disable co-author attribution in commits and PRs

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -1,5 +1,9 @@
 {
   "alwaysThinkingEnabled": true,
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
   "effortLevel": "xhigh",
   "enabledPlugins": {
     "beads@beads-marketplace": true,

--- a/openspec/changes/disable-claude-coauthor-signature/.openspec.yaml
+++ b/openspec/changes/disable-claude-coauthor-signature/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-26

--- a/openspec/changes/disable-claude-coauthor-signature/design.md
+++ b/openspec/changes/disable-claude-coauthor-signature/design.md
@@ -1,0 +1,40 @@
+## Context
+
+`dot_claude/settings.json.tmpl` (gestionado por chezmoi, renderiza a `~/.claude/settings.json`) define los flags de usuario de Claude Code bajo la capacidad `claude-user-preferences`. Hoy no fija ninguna opción de atribución, así que Claude Code aplica su default: añade el trailer `Co-Authored-By: Claude …` y la línea `🤖 Generated with [Claude Code]…` a los commits, y la misma línea al cuerpo de las PR.
+
+Restricción: la opción debe vivir en el scope de usuario (esta plantilla), para que aplique a todas las sesiones y repos de la máquina, no por proyecto.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Suprimir la firma de Claude en commits y PR de forma global y versionada.
+- Usar el mecanismo soportado actual, no el legacy deprecado.
+- Cambio mínimo y aislado en la plantilla, sin tocar otros bloques.
+
+**Non-Goals:**
+
+- Reordenar las claves existentes o "arreglar" la divergencia entre el spec de orden canónico y el orden alfabético real del fichero (fuera de alcance).
+- Configurar atribución por proyecto (`.claude/settings.json`) o local (`.claude/settings.local.json`).
+- Cambiar la firma a un texto personalizado: el objetivo es eliminarla, no reemplazarla.
+
+## Decisions
+
+**Decisión 1 — Usar `attribution: {commit:"", pr:""}` en lugar de `includeCoAuthoredBy: false`.**
+`includeCoAuthoredBy` está deprecado en la doc oficial en favor del objeto `attribution`. `attribution` da control independiente de commit y PR; con ambos en cadena vacía se elimina toda la atribución (incluido el trailer `Co-Authored-By`). Elegimos la opción soportada y futura.
+*Alternativa descartada:* `includeCoAuthoredBy: false` — funciona hoy pero puede dejar de hacerlo y la doc desaconseja su uso.
+
+**Decisión 2 — Bloque JSON estático, sin lógica de template.**
+El valor no depende de OS/arch/datos de chezmoi, así que se añade como JSON literal dentro del `.tmpl` (sin directivas `{{ }}`).
+
+**Decisión 3 — Colocación de la clave siguiendo el orden alfabético de nivel superior existente.**
+El fichero actual ordena las claves de nivel superior alfabéticamente. `attribution` se inserta entre `alwaysThinkingEnabled` y `effortLevel` para respetar ese orden de facto. La clave queda fuera del "bloque de preferencias escalares" que regula el requisito de orden canónico, por lo que no entra en conflicto con él.
+
+**Decisión 4 — Verificación por render, no por inspección de un commit real.**
+La comprobación normativa principal es: `chezmoi execute-template` / `chezmoi cat` produce un JSON válido que contiene `"attribution": {"commit":"","pr":""}` y no contiene `includeCoAuthoredBy`. El comportamiento end-to-end (commit/PR sin firma) depende del runtime de Claude Code tras `chezmoi apply` y se valida manualmente en una sesión posterior.
+
+## Risks / Trade-offs
+
+- **El esquema de `attribution` cambia en una versión futura de Claude Code** → Mitigación: el delta spec ancla el contrato; un cambio en el runtime se detecta como divergencia y se trata en un nuevo change.
+- **JSON mal formado tras editar la plantilla rompe todo el settings de usuario** → Mitigación: validar el render con `chezmoi execute-template`/`chezmoi cat` (o `jq`) antes de aplicar.
+- **oxfmt/lint-staged corrompe o reordena el `.tmpl`** (la memoria del proyecto avisa de que oxfmt mancha scripts de chezmoi) → Mitigación: confirmar que `.tmpl` está cubierto por `.oxfmtignore` o que el formateo no altera la directiva; revisar el diff antes de commitear.

--- a/openspec/changes/disable-claude-coauthor-signature/proposal.md
+++ b/openspec/changes/disable-claude-coauthor-signature/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Claude Code, por defecto, añade atribución propia a cada commit (trailer `Co-Authored-By: Claude …` + línea `🤖 Generated with Claude Code`) y al cuerpo de las PR. Queremos commits y PR limpios, sin esa firma, en todas las máquinas gestionadas por estos dotfiles.
+
+## What Changes
+
+- Añadir la clave de nivel superior `attribution` a `dot_claude/settings.json.tmpl` con `commit` y `pr` en cadena vacía, lo que suprime la atribución de Claude tanto en commits como en PR.
+- No usar la opción legacy `includeCoAuthoredBy` (booleana): está **deprecada** en favor de `attribution`.
+- Mantener el resto de la plantilla intacto; el bloque `attribution` es JSON estático (sin lógica de template).
+
+No hay breaking changes: el cambio solo retira texto auto-generado por Claude Code; no altera el contenido escrito por el usuario.
+
+## Capabilities
+
+### New Capabilities
+
+(ninguna)
+
+### Modified Capabilities
+
+- `claude-user-preferences`: nuevo requisito — la plantilla SHALL incluir un objeto `attribution` con `commit` y `pr` vacíos para desactivar la firma de Claude en commits y PR.
+
+## Impact
+
+- **Archivo**: `dot_claude/settings.json.tmpl` (renderiza a `~/.claude/settings.json`).
+- **Efecto**: tras `chezmoi apply`, las futuras sesiones de Claude Code dejan de añadir el trailer `Co-Authored-By` y la línea `🤖 Generated with Claude Code` en commits y PR.
+- **Alcance**: solo settings de usuario; no afecta a permisos, hooks, plugins ni a settings de proyecto/local.
+- **Dependencias**: requiere Claude Code con soporte de `attribution` (sustituye al deprecado `includeCoAuthoredBy`).

--- a/openspec/changes/disable-claude-coauthor-signature/specs/claude-user-preferences/spec.md
+++ b/openspec/changes/disable-claude-coauthor-signature/specs/claude-user-preferences/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Claude attribution is disabled in commits and pull requests
+
+The chezmoi template SHALL include a top-level `attribution` object in `dot_claude/settings.json.tmpl` with both `commit` and `pr` set to the empty string:
+
+```json
+"attribution": {
+  "commit": "",
+  "pr": ""
+}
+```
+
+An empty `commit` string suppresses the entire commit attribution block, eliminating the `Co-Authored-By: Claude …` trailer and the `🤖 Generated with [Claude Code]…` line. An empty `pr` string removes the attribution line from pull request descriptions.
+
+The template SHALL NOT use the deprecated boolean key `includeCoAuthoredBy`; `attribution` is the current, supported mechanism and supersedes it.
+
+#### Scenario: Template includes empty attribution object
+
+- **WHEN** chezmoi applies `dot_claude/settings.json.tmpl`
+- **THEN** `~/.claude/settings.json` SHALL contain an `attribution` object equal to `{"commit": "", "pr": ""}`
+
+#### Scenario: Deprecated includeCoAuthoredBy key is absent
+
+- **WHEN** the rendered output of `chezmoi cat dot_claude/settings.json.tmpl` is parsed
+- **THEN** the JSON SHALL NOT contain a top-level `includeCoAuthoredBy` key
+
+#### Scenario: Commit authored by Claude Code carries no attribution
+
+- **WHEN** a Claude Code session running under the applied settings creates a git commit
+- **THEN** the commit message SHALL NOT contain a `Co-Authored-By: Claude` trailer
+- **AND** the commit message SHALL NOT contain a `🤖 Generated with [Claude Code]` line
+
+#### Scenario: Pull request body carries no attribution
+
+- **WHEN** a Claude Code session running under the applied settings opens a pull request
+- **THEN** the pull request body SHALL NOT contain a `🤖 Generated with [Claude Code]` line

--- a/openspec/changes/disable-claude-coauthor-signature/tasks.md
+++ b/openspec/changes/disable-claude-coauthor-signature/tasks.md
@@ -1,0 +1,16 @@
+## 1. Implementación
+
+- [x] 1.1 Añadir la clave de nivel superior `"attribution": { "commit": "", "pr": "" }` a `dot_claude/settings.json.tmpl`, colocada entre `alwaysThinkingEnabled` y `effortLevel` para respetar el orden alfabético de claves del fichero.
+- [x] 1.2 Confirmar que la plantilla NO contiene la clave deprecada `includeCoAuthoredBy`.
+
+## 2. Verificación del render
+
+- [x] 2.1 Renderizar la plantilla (`chezmoi cat dot_claude/settings.json.tmpl` o `chezmoi execute-template`) y comprobar con `jq` que el resultado es JSON válido y que `.attribution` es exactamente `{"commit":"","pr":""}`.
+- [x] 2.2 Comprobar que el render no contiene `includeCoAuthoredBy` (`jq 'has("includeCoAuthoredBy")'` → `false`).
+- [x] 2.3 Revisar `git diff dot_claude/settings.json.tmpl` para confirmar que solo se añadió el bloque `attribution` y que ningún otro bloque ni el formato se alteró (sanity oxfmt/lint-staged).
+
+## 3. Aplicación y verificación end-to-end
+
+- [ ] 3.1 Sincronizar la fuente y aplicar (`chezmoi update` / `chezmoi apply`); confirmar que `~/.claude/settings.json` contiene el bloque `attribution` con `commit` y `pr` vacíos.
+- [ ] 3.2 En una sesión nueva de Claude Code, crear un commit de prueba y verificar que el mensaje NO incluye el trailer `Co-Authored-By: Claude` ni la línea `🤖 Generated with [Claude Code]`.
+- [ ] 3.3 Verificar que el cuerpo de una PR creada por Claude Code NO incluye la línea `🤖 Generated with [Claude Code]`.


### PR DESCRIPTION
## Summary

Disable Claude Code's self-attribution so commits and PRs are clean — no `Co-Authored-By: Claude` trailer and no `🤖 Generated with Claude Code` line.

## Changes

- Add a top-level `attribution` object to `dot_claude/settings.json.tmpl` with `commit` and `pr` set to empty strings, which suppresses Claude attribution in both commit messages and PR bodies.
- Uses the current `attribution` setting; the legacy boolean `includeCoAuthoredBy` is deprecated and intentionally not used.
- Includes the OpenSpec change `disable-claude-coauthor-signature` (proposal, specs, design, tasks).

## Verification

- `chezmoi cat`/`execute-template` renders valid JSON with `.attribution == {"commit":"","pr":""}`.
- Render contains no `includeCoAuthoredBy` key.
- Diff adds only the `attribution` block — nothing else changed.

## Pending (post-merge, manual)

- `chezmoi update` / `apply`, then confirm `~/.claude/settings.json`.
- Confirm a commit and a PR from a fresh Claude Code session carry no attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for disabling Claude co-author attribution in generated commits and pull requests.
  * Introduced a new settings option that keeps auto-generated Claude signature text out of commit messages and PR bodies.

* **Documentation**
  * Added guidance on how to configure and verify the updated settings.
  * Clarified that the older attribution setting is no longer recommended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->