### PR TITLE
feat(claude): nvm-aware launch shim selects project Node

### DIFF
--- a/docs/manual.html
+++ b/docs/manual.html
@@ -2263,6 +2263,67 @@
                             </tr>
                         </tbody>
                     </table>
+
+                    <h3>Node version on launch (nvm-aware shim)</h3>
+                    <p>
+                        A shim named <code>claude</code> at
+                        <code>~/.local/bin/shims/claude</code> sits ahead of the real
+                        <code>~/.local/bin/claude</code> on <code>PATH</code>. It reads the
+                        project's <code>.nvmrc</code> (walking up from the launch dir, then a
+                        bounded search down), activates that Node by prepending its
+                        <code>bin/</code> to <code>PATH</code>, then <code>exec</code>s the real
+                        binary. So claude and its subprocesses (Bash tool, hooks,
+                        <code>node</code>/<code>bun</code>/<code>npm</code>) run under the project's
+                        Node &mdash; through every launcher (<code>wsc</code>, <code>wsh</code>,
+                        gh-dash, AoE) with nothing new to type.
+                    </p>
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Behavior</th>
+                                <th>Detail</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>PATH ordering</td>
+                                <td>
+                                    <code>~/.local/bin/shims</code> must precede
+                                    <code>~/.local/bin</code> (set in <code>.zshrc</code>). If
+                                    bypassed, the shim is skipped and the real claude runs unchanged
+                                    &mdash; no breakage, just no Node selection.
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Fast path</td>
+                                <td>
+                                    Installed version &rarr; <code>PATH</code>-prepend only
+                                    (~0.4&nbsp;ms). Never sources <code>nvm.sh</code>
+                                    (~0.8&nbsp;s).
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Cold / alias fallback</td>
+                                <td>
+                                    Version not installed yet, or an alias (<code>lts/*</code>,
+                                    <code>node</code>) &rarr; one-time <code>nvm install</code>/
+                                    <code>use</code>, then back to the fast path.
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>No <code>.nvmrc</code></td>
+                                <td>Near-zero-cost passthrough; <code>PATH</code> untouched.</td>
+                            </tr>
+                            <tr>
+                                <td>AoE sandbox</td>
+                                <td>
+                                    <code>NVM_DIR</code> is in AoE's
+                                    <code>[sandbox].environment</code> passthrough so the shim
+                                    resolves versions from the filesystem inside the sandbox.
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             </details>
 

--- a/dot_local/bin/shims/executable_claude
+++ b/dot_local/bin/shims/executable_claude
@@ -1,0 +1,98 @@
+#!/bin/sh
+# claude-node-launch — PATH shim for `claude` (OpenSpec: nvm-aware-claude-launch).
+#
+# Installed at ~/.local/bin/shims/claude, AHEAD of the real ~/.local/bin/claude
+# on PATH (see dot_zshrc.tmpl), so every launcher — the `wsc`/`wsh` aliases,
+# gh-dash `-x claude`, AoE, or a typed `claude` — flows through it unchanged.
+# It resolves the project's Node version from .nvmrc, activates it, then execs
+# the real claude by absolute path. claude's child processes (the Bash tool,
+# hooks, node/npm/bun) then inherit the project's Node via the prepended PATH.
+#
+# Why a shim and not a chpwd/worktrunk hook: launchers use `wt switch -x claude`
+# (chdir+exec, not a shell `cd`), so no `chpwd` autoload fires; a post-start hook
+# runs in a throwaway subprocess that never touches claude's env. The only point
+# that runs *in the process that becomes claude* is the launch command itself.
+#
+# Performance: steady state NEVER sources nvm.sh (~0.8s); it only PATH-prepends
+# the resolved version's bin/ dir (~0.4ms). nvm.sh is sourced ONLY in the cold/
+# alias fallback (version not installed yet, or an alias like lts/*) — one-time.
+
+set -u
+
+REAL_CLAUDE="$HOME/.local/bin/claude"
+NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+NODES="$NVM_DIR/versions/node"
+
+# 1) Locate .nvmrc: walk UP from $PWD (builtin path manipulation, no `dirname`
+#    forks), then, if nothing above, a bounded search DOWN.
+nvmrc=""
+d=$PWD
+while :; do
+  [ -f "$d/.nvmrc" ] && { nvmrc="$d/.nvmrc"; break; }
+  [ -z "$d" ] && break # just tested "/.nvmrc" (d="" => "$d/.nvmrc" == "/.nvmrc")
+  d=${d%/*}
+done
+
+if [ -z "$nvmrc" ]; then
+  # Bounded walk-down, skipping node_modules/ and .git/.
+  found=$(find "$PWD" -maxdepth 4 \( -name node_modules -o -name .git \) -prune \
+    -o -type f -name .nvmrc -print 2>/dev/null)
+  if [ -n "$found" ]; then
+    # Shallowest wins (fewest path separators); warn if more than one matched.
+    nvmrc=$(printf '%s\n' "$found" | awk '{ print gsub(/\//, "/") "\t" $0 }' \
+      | sort -n | head -n1 | cut -f2-)
+    if [ "$(printf '%s\n' "$found" | grep -c .)" -gt 1 ]; then
+      printf 'claude shim: multiple .nvmrc below %s; using %s\n' "$PWD" "$nvmrc" >&2
+    fi
+  fi
+fi
+
+# 2) With a .nvmrc in hand, resolve and activate the version. No .nvmrc => skip
+#    straight to delegation (near-zero-cost passthrough, no PATH change).
+if [ -n "$nvmrc" ]; then
+  ver=""
+  IFS= read -r ver <"$nvmrc" || : # keep ver even when the file lacks a trailing \n
+  ver=${ver#"${ver%%[![:space:]]*}"} # ltrim whitespace/CR
+  ver=${ver%"${ver##*[![:space:]]}"} # rtrim whitespace/CR
+
+  if [ -n "$ver" ]; then
+    matched=""
+    case "$ver" in
+      v[0-9]* | [0-9]*)
+        want=${ver#v}
+        if [ -d "$NODES/v$want/bin" ]; then
+          matched="v$want" # exact pin: 24.12.0 / v24.12.0
+        elif [ -d "$NODES" ]; then
+          # Major/minor prefix: 24 -> highest v24.* ; 24.12 -> highest v24.12.*
+          matched=$(for cand in "$NODES/v$want".*/; do
+            [ -d "$cand" ] && { cand=${cand%/}; printf '%s\n' "${cand##*/}"; }
+          done | sort -V | tail -n1)
+        fi
+        ;;
+    esac
+
+    if [ -n "$matched" ] && [ -d "$NODES/$matched/bin" ]; then
+      # Fast path: PATH-prepend only, never source nvm.sh.
+      PATH="$NODES/$matched/bin:$PATH"
+      export PATH
+    elif [ -s "$NVM_DIR/nvm.sh" ]; then
+      # Cold/alias fallback: a numeric pin not installed yet, or an alias form
+      # (lts/*, node, stable, ...) that can't be resolved from the filesystem.
+      # Source nvm + install/use (one-time); steady state returns to the fast path.
+      # shellcheck disable=SC1090,SC1091
+      . "$NVM_DIR/nvm.sh" >/dev/null 2>&1 || :
+      if command -v nvm >/dev/null 2>&1; then
+        nvm use "$ver" >/dev/null 2>&1 || nvm install "$ver" >/dev/null 2>&1 || :
+      fi
+    fi
+  fi
+fi
+
+# 3) Delegate to the real claude by absolute path — never via PATH (that would
+#    re-enter this shim). exec replaces the process, so the exit status passes
+#    through unchanged.
+if [ ! -x "$REAL_CLAUDE" ]; then
+  printf 'claude shim: real claude not found at %s\n' "$REAL_CLAUDE" >&2
+  exit 127
+fi
+exec "$REAL_CLAUDE" "$@"

--- a/dot_local/bin/shims/executable_claude
+++ b/dot_local/bin/shims/executable_claude
@@ -84,6 +84,15 @@ if [ -n "$nvmrc" ]; then
       if command -v nvm >/dev/null 2>&1; then
         nvm use "$ver" >/dev/null 2>&1 || nvm install "$ver" >/dev/null 2>&1 || :
       fi
+    else
+      # A version is pinned but unsatisfiable: no installed match AND no nvm.sh
+      # to install/resolve it (broken or nvm-less machine). Warn — don't fall
+      # through silently — but still launch: refusing to start would brick every
+      # claude invocation here, including worktrunk's `claude -p` commit-message
+      # generation. claude itself is Node-independent; only its subprocesses are
+      # affected, and the warning surfaces the misconfiguration.
+      printf 'claude shim: cannot activate %s (no installed match, missing %s); launching under ambient Node\n' \
+        "$ver" "$NVM_DIR/nvm.sh" >&2
     fi
   fi
 fi

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -295,6 +295,15 @@ command -v direnv &>/dev/null && eval "$(direnv hook zsh)"
 # User-local binaries (Claude Code, plannotator, etc.)
 export PATH="$HOME/.local/bin:$PATH"
 
+# claude-node-launch shim — MUST sit ahead of ~/.local/bin so `command -v claude`
+# resolves ~/.local/bin/shims/claude (the nvm-aware launcher) before the real
+# ~/.local/bin/claude. Prepended AFTER the line above precisely so it lands in
+# front of it. Every launcher (wsc/wsh, gh-dash -x claude, AoE) then runs claude
+# under the project's .nvmrc Node. If this ordering is ever bypassed the shim is
+# simply skipped and the real claude runs unchanged — no breakage, just no nvm
+# selection. See openspec change nvm-aware-claude-launch.
+export PATH="$HOME/.local/bin/shims:$PATH"
+
 # opencode (installed via its official script to ~/.opencode/bin, not brew)
 export PATH="$HOME/.opencode/bin:$PATH"
 

--- a/openspec/changes/nvm-aware-claude-launch/.openspec.yaml
+++ b/openspec/changes/nvm-aware-claude-launch/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-26

--- a/openspec/changes/nvm-aware-claude-launch/README.md
+++ b/openspec/changes/nvm-aware-claude-launch/README.md
@@ -1,0 +1,3 @@
+# nvm-aware-claude-launch
+
+Launch claude under the project's required Node version (.nvmrc) via a PATH shim, so claude and its child processes inherit the right node — independent of the launcher (wsc/wsh/gh-dash/AoE).

--- a/openspec/changes/nvm-aware-claude-launch/design.md
+++ b/openspec/changes/nvm-aware-claude-launch/design.md
@@ -1,0 +1,68 @@
+## Context
+
+Worktrees are launched into `claude` through several entry points — the `wsc` alias and `wsh` tmux fn (`dot_zshrc.tmpl`), gh-dash bindings (`dot_config/gh-dash/config.yml`), and AoE (`aoe add`). All of them ultimately run `wt switch … -x claude` (or AoE launches claude itself). `wt switch --execute` does `chdir()` + `exec()` — it **replaces** the `wt` process with claude; it is not a shell `cd`, so no zsh `chpwd` hook fires. `claude` is a Node-independent native binary at `~/.local/bin/claude`, but its child processes (Bash tool, hooks, `node`/`bun`/`npm`) inherit its `$PATH`. When the active Node is the nvm default but the project pins a different version (`.nvmrc`, often strict), those child commands run under the wrong Node.
+
+Two consequences shape the design: (1) a worktrunk lifecycle hook cannot help — it runs in a subprocess that exits before claude starts; (2) the shell's nvm `autoload` cannot help — `-x` bypasses `chpwd` entirely (and separately, the `~/.oh-my-zsh` clone is from 2018 and its nvm plugin is a 2-line stub that ignores the `autoload` zstyles, so autoload is dead even for manual `cd`). The only point in the chain that runs *in the process that becomes claude* is the launch command itself.
+
+## Goals / Non-Goals
+
+**Goals:**
+- claude (and its subprocesses) start under the project's `.nvmrc` Node version, automatically, regardless of launcher.
+- Zero change to muscle memory or launcher configs — keep typing `wsc` / `claude`.
+- Negligible per-launch latency.
+
+**Non-Goals:**
+- Reviving the dead OMZ nvm `autoload` for manual `cd` (related but separate; out unless explicitly folded in).
+- Changing how nvm/Node is installed (`node-env-bootstrap`).
+- Supporting version signals other than `.nvmrc` (no `.node-version`, no `package.json` `engines.node`).
+
+## Decisions
+
+### D1 — A launch shim, not a worktrunk hook or a chpwd hook
+The node selection must happen in the process that becomes claude. A `post-start` hook is a dead subprocess; `chpwd` is bypassed by `exec`. Only wrapping the launch command works. **Alternative rejected:** worktrunk `post-start nvm use` — runs in a throwaway subprocess, never touches claude's env.
+
+### D2 — Activate via PATH-prepend, never source nvm in steady state
+Benchmark (60 iters, macOS, single installed version; `exec true` stand-in for the real binary):
+
+| Variant | median | overhead |
+|---|--:|--:|
+| `/bin/sh` floor | ~11 ms | — |
+| finder, no `.nvmrc` (builtin walk) | ~12.5 ms | +1.6 ms |
+| PATH-prepend, `.nvmrc` present | ~17.5 ms | +0.4 ms |
+| `source nvm.sh` only | ~385 ms | +367 ms |
+| `source nvm.sh` + `nvm use` | ~791 ms | +773 ms |
+
+Sourcing `nvm.sh` (4448 lines) costs ~0.8 s per launch — unacceptable on every claude open. Prepending the resolved version's `bin/` to `$PATH` is free. **`source nvm.sh` is therefore confined to the cold fallback only.** **Alternative rejected:** always `source nvm.sh && nvm use` (the "obvious" form) — 0.8 s tax per launch.
+
+### D3 — The shim is named `claude` and shadows the binary on PATH
+A real executable `claude` placed on `$PATH` ahead of `~/.local/bin/claude` is intercepted by **every** resolution of the command — typed, `wt -x` (which does a PATH `exec`, not a shell function lookup), and AoE — so no launcher needs editing. It `exec`s `$HOME/.local/bin/claude` by absolute path (the installer-maintained symlink), avoiding recursion. **Alternatives rejected:** (a) a zsh function `claude()` — not seen by `-x`'s PATH `exec` nor by AoE; (b) a separately-named `claude-nvm` wired into each launcher — more surface, a new name to remember, and the manually-typed `claude` case stays broken.
+
+### D4 — Finder: builtin walk-up, then bounded walk-down; `.nvmrc` only
+Walk up with shell parameter expansion (`${d%/*}`), not `$(dirname)` per level (the fork form cost +29 ms vs +1.6 ms). Up-walk covers root + ancestors. If nothing above, search down (bounded depth; skip `node_modules/`, `.git/`) for the single `.nvmrc` — the confirmed real case (one `.nvmrc` in a subdir like `apps/web/`). If >1 found, pick shallowest and warn (defensive; not the expected case). **Alternative rejected:** walk-up only — would never find a subdir `.nvmrc`, failing the stated requirement.
+
+### D5 — chezmoi layout and PATH ordering
+Ship the shim as a chezmoi `executable_` source so the exec bit is preserved, in a dedicated shims dir (e.g. `~/.local/bin/shims/claude`) that does **not** collide with the installer's `~/.local/bin/claude`. `dot_zshrc.tmpl` prepends that shims dir to `$PATH` ahead of `~/.local/bin` (today `~/.local/bin` is PATH position 14). The shim itself stays POSIX `sh` for fast startup; only the cold-fallback branch needs bash/zsh semantics for `nvm.sh`.
+
+### D6 — AoE via NVM_DIR passthrough
+AoE sandboxes the agent with an env allowlist and does not run the user's rc. The shim needs only `NVM_DIR` + filesystem (no `nvm` function), so adding `NVM_DIR` to AoE's `[sandbox].environment` lets the shim resolve inside the sandbox. Whether AoE also exposes an agent-command override (as it does for `[tools.lazygit].command`) is a verification task; the passthrough is the robust baseline either way.
+
+## Risks / Trade-offs
+
+- **[Risk] The shim intercepts every `claude`, including worktrunk's commit-message generation (`claude -p --model=haiku …`).** → The no-`.nvmrc` and prepend paths add single-digit ms; in a pinned repo it harmlessly prepends. Keep the shim cheap; if measured cost ever matters, short-circuit on `-p`.
+- **[Risk] PATH ordering regressions** — if the shims dir is not ahead of `~/.local/bin`, the shim is bypassed silently. → Assert ordering in the zshrc block and document it; the shim is a no-op if not first (real claude still runs).
+- **[Risk] AoE sandbox filesystem-isolates `~/.nvm`** — then the shim cannot read versions even with `NVM_DIR` set. → Verification task D6; fallback is to accept default Node inside AoE and document the limitation.
+- **[Trade-off] Multiple `.nvmrc` below root** is resolved heuristically (shallowest + warn), not configurably. Acceptable for the confirmed single-subdir case.
+- **[Trade-off] Alias `.nvmrc` (`lts/*`, `node`) pays the slow path** every launch (can't prepend without resolving the alias). Acceptable — pinned numeric versions are the norm; alias users can pin.
+
+## Migration Plan
+
+1. Add the shim source + the `dot_zshrc.tmpl` PATH prepend; `chezmoi apply`.
+2. Verify ordering (`command -v claude` resolves the shim) and a pinned worktree (`node --version` inside a shim-launched claude matches `.nvmrc`).
+3. Add `NVM_DIR` to AoE `[sandbox].environment`; verify an AoE session.
+- **Rollback:** remove the shim file and the PATH line; `chezmoi apply`. Launchers fall back to the real `claude` with zero residue.
+
+## Open Questions
+
+- Does AoE support an agent-command override for the `claude` tool, or is `NVM_DIR` passthrough the only lever? (verification task)
+- Fold the dead-OMZ-`autoload` fix (manual-`cd` auto-switch) into this change, or track it separately?
+- Sequencing vs `improve-aoe-config`: both touch `agent-manager`; this change's `agent-manager` delta assumes that change is archived/synced first, or the two are co-sequenced.

--- a/openspec/changes/nvm-aware-claude-launch/proposal.md
+++ b/openspec/changes/nvm-aware-claude-launch/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+When a worktree's project pins a strict Node version via `.nvmrc` that differs from the nvm default, `claude` starts under the wrong Node. `claude` itself is a Node-independent native binary, but its child processes (the Bash tool, hooks, `node`/`bun`/`npm`) inherit its `PATH` — so every project command runs under the wrong Node, forcing per-session workarounds. The usual fix (nvm's `chpwd` autoload) never fires: every launcher uses `wt switch -x claude` (or AoE), which is `chdir`+`exec`, not a shell `cd`, so no `chpwd` hook runs. There is no point in the chain that corrects the Node version today.
+
+## What Changes
+
+- Add a launch **shim named `claude`** on `PATH` *ahead* of the real binary (`~/.local/bin/claude`). It selects the project's Node version, then `exec`s the real claude by absolute path. Every existing launcher (`wsc`, `wsh`, gh-dash, AoE) flows through it **unchanged** — no per-launcher edits, nothing new to type.
+- Activation by **PATH-prepend** of the resolved version's `bin/` dir. Benchmarked: ~0.4 ms vs **~0.8 s** for `source nvm.sh && nvm use`. The shim does **not** source nvm in steady state.
+- `.nvmrc` **finder**: walk *up* from the worktree root (covers root + ancestors); if none found, search *down* (bounded depth, skipping `node_modules`/`.git`) for the single `.nvmrc`. If more than one is found, pick the shallowest and warn on stderr.
+- **Cold fallback** (only path that touches nvm): if the pinned version isn't installed yet (strict project, first run) or `.nvmrc` is an alias form (`lts/*`, `node`), fall back to sourcing nvm + `nvm install`/`use`. One-time cost; steady state stays on the fast path.
+- **No-`.nvmrc` fast path**: builtin walk-up (no `dirname` forks) → straight `exec`. Benchmarked at +~1.6 ms over the bare-process floor.
+- **AoE integration**: ensure AoE launches claude through the shim — via an agent-command override if AoE supports one, else by adding `NVM_DIR` to AoE's `[sandbox].environment` so the shim resolves the version by filesystem inside the sandbox (it needs no nvm *function*, only `$NVM_DIR/versions/node/`). Exact mechanism pending a verification task.
+
+## Capabilities
+
+### New Capabilities
+- `claude-node-launch`: a PATH shim that resolves the project's Node version from `.nvmrc` (up-then-down finder) and launches `claude` under it via PATH-prepend, with a cold fallback to nvm install/use; plus the `PATH` ordering that makes the shim intercept every `claude` invocation regardless of launcher.
+
+### Modified Capabilities
+- `agent-manager`: AoE must launch `claude` through the shim — either an agent-command override or `NVM_DIR` added to `[sandbox].environment`. **Sequencing**: `agent-manager` is mid-change in `improve-aoe-config` (not yet synced to `openspec/specs/` in final form); this delta depends on that change being archived/synced first, or the two being co-sequenced.
+
+## Impact
+
+- **Code touched**: a new chezmoi-managed shim (e.g. `~/.local/bin/shims/claude` via `executable_` source), `dot_zshrc.tmpl` (prepend the shims dir to `PATH`, ahead of `~/.local/bin`), and possibly AoE config (`private_dot_agent-of-empires/…` `[sandbox].environment`).
+- **Launchers unchanged**: `wsc`/`wsh` aliases, `wsh` tmux fn, and gh-dash `-x claude`/`-x 'aoe add …'` keep referencing `claude`.
+- **Latency**: +~2–7 ms per claude launch in steady state (imperceptible vs claude's own startup); one-time `nvm install` only when a pinned version is missing.
+- **External deps**: none new — reuses the existing nvm install (`node-env-bootstrap`).
+- **Non-goals**: (a) reviving the dead OMZ nvm `autoload` (the `~/.oh-my-zsh` clone is from 2018; its 2-line nvm stub ignores the `autoload`/`silent-autoload` zstyles) for manual `cd` — a related but separate defect; folded in only if explicitly chosen. (b) changing how Node/nvm is installed (`node-env-bootstrap`).

--- a/openspec/changes/nvm-aware-claude-launch/specs/agent-manager/spec.md
+++ b/openspec/changes/nvm-aware-claude-launch/specs/agent-manager/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: AoE launches claude under the project Node version
+
+AoE-launched claude sessions SHALL pick up the project's Node version through the `claude-node-launch` shim. Because AoE runs the agent in a sandbox with an environment passthrough allowlist (not the user's interactive shell), the AoE config managed by chezmoi SHALL include `NVM_DIR` in its sandbox `environment` passthrough so the shim can resolve the version from the filesystem (`$NVM_DIR/versions/node/`) without needing the `nvm` shell function. AoE SHALL invoke `claude` such that the PATH shim intercepts it — either by preserving the shim's PATH ordering inside the sandbox, or via an agent-command override pointing at the shim if AoE supports one. The exact mechanism SHALL be confirmed by a verification task during implementation.
+
+#### Scenario: NVM_DIR is in the AoE sandbox environment passthrough
+
+- **WHEN** the AoE `config.toml` is rendered by chezmoi
+- **THEN** the sandbox `environment` passthrough list names `NVM_DIR` (in addition to the existing `CLAUDE_CONFIG_DIR`, `EDITOR`, `TERM`, `COLORTERM`)
+
+#### Scenario: AoE-launched claude uses the project Node
+
+- **WHEN** a worktree pinned to a non-default Node version (via `.nvmrc`) is launched as an AoE session
+- **THEN** the claude process started by AoE, and its subprocesses, resolve the project's pinned Node version rather than the nvm default

--- a/openspec/changes/nvm-aware-claude-launch/specs/claude-node-launch/spec.md
+++ b/openspec/changes/nvm-aware-claude-launch/specs/claude-node-launch/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: Shim shadows `claude` on PATH and delegates to the real binary
+
+A chezmoi-managed executable named `claude` SHALL be installed in a directory that appears on `$PATH` **before** the real claude binary (`~/.local/bin/claude`). The shim SHALL invoke the real binary by absolute path so it never re-invokes itself, and SHALL forward all arguments and the exit status unchanged.
+
+#### Scenario: PATH resolves the shim first
+
+- **WHEN** any context resolves the command `claude` via `$PATH` (typed interactively, `wt switch -x claude`, gh-dash, or AoE)
+- **THEN** the shim is resolved before `~/.local/bin/claude`
+
+#### Scenario: Shim delegates to the real binary without recursion
+
+- **WHEN** the shim finishes selecting the Node version
+- **THEN** it SHALL `exec "$HOME/.local/bin/claude"` (the installer-maintained symlink) by absolute path, forwarding all arguments
+- **AND** the shim SHALL NOT resolve `claude` via `$PATH` (which would re-enter the shim)
+
+#### Scenario: Exit status is preserved
+
+- **WHEN** the real claude binary exits with status N
+- **THEN** the invoking process observes status N
+
+### Requirement: Project Node is activated by PATH-prepend without sourcing nvm
+
+When a version file resolves to an already-installed Node version, the shim SHALL prepend that version's `bin/` directory (`$NVM_DIR/versions/node/<version>/bin`) to `$PATH` and SHALL NOT source `nvm.sh` or invoke the `nvm` function. This keeps per-launch overhead negligible (benchmarked at ~0.4 ms, versus ~0.8 s for `source nvm.sh && nvm use`).
+
+#### Scenario: Exact version pin
+
+- **WHEN** the resolved `.nvmrc` contains an installed exact version (e.g. `24.12.0` or `v24.12.0`)
+- **THEN** the shim prepends `$NVM_DIR/versions/node/v24.12.0/bin` to `$PATH`
+- **AND** does not source `nvm.sh`
+
+#### Scenario: Major-version prefix
+
+- **WHEN** the resolved `.nvmrc` contains a prefix (e.g. `24`) that matches one or more installed versions
+- **THEN** the shim selects the highest installed version matching that prefix and prepends its `bin/` directory
+
+### Requirement: Version file discovery walks up then down
+
+The shim SHALL read the project's Node version from a `.nvmrc` file only. It SHALL first walk **up** from the launch directory to the filesystem root (covering the worktree root and any ancestor). If no `.nvmrc` is found above, it SHALL search **down** (bounded depth, skipping `node_modules/` and `.git/`) for a `.nvmrc`. Discovery SHALL use shell builtin path manipulation, not per-level `dirname` subprocesses.
+
+#### Scenario: `.nvmrc` at the worktree root
+
+- **WHEN** the shim launches in a worktree whose root contains `.nvmrc`
+- **THEN** the walk-up finds it and that version is selected
+
+#### Scenario: `.nvmrc` in a single subdirectory
+
+- **WHEN** the worktree root has no `.nvmrc` but exactly one exists in a subdirectory (e.g. `apps/web/.nvmrc`)
+- **THEN** the downward search finds that single file and selects its version
+
+#### Scenario: Multiple `.nvmrc` below the root
+
+- **WHEN** the worktree root has no `.nvmrc` but more than one exists in subdirectories
+- **THEN** the shim selects the shallowest one and prints a disambiguation warning to stderr
+
+### Requirement: Absent `.nvmrc` is a near-zero-cost passthrough
+
+When no `.nvmrc` is discovered, the shim SHALL `exec` the real claude binary unchanged without touching `$PATH`. The discovery probe SHALL add negligible overhead (benchmarked at ~+1.6 ms over the bare-process floor; the dirname-fork form added ~+29 ms and SHALL NOT be used).
+
+#### Scenario: Non-Node directory
+
+- **WHEN** the shim launches where neither the directory tree above nor a bounded search below contains a `.nvmrc`
+- **THEN** it execs the real claude binary without modifying `$PATH`
+
+### Requirement: Cold and alias cases fall back to nvm install/use
+
+When the resolved version is not yet installed (a strict project's pinned version on first use) or the `.nvmrc` is an alias form (`lts/*`, `lts/<name>`, `node`, `stable`) that PATH-prepend cannot resolve from the filesystem, the shim SHALL fall back to sourcing `nvm.sh` and running `nvm install` / `nvm use` before delegating. This slow path is a one-time cost; subsequent launches use the fast PATH-prepend path.
+
+#### Scenario: Pinned version not yet installed
+
+- **WHEN** `.nvmrc` resolves to a version with no directory under `$NVM_DIR/versions/node/`
+- **THEN** the shim sources `nvm.sh`, runs `nvm install` for that version, then delegates with the new version active
+
+#### Scenario: Alias version specifier
+
+- **WHEN** `.nvmrc` contains an alias form such as `lts/*` or `node`
+- **THEN** the shim sources `nvm.sh` and uses `nvm` to resolve and activate the version before delegating
+
+### Requirement: claude child processes inherit the project Node
+
+After the shim selects the project's Node version, the launched claude process and the subprocesses it spawns (the Bash tool, hooks, and any `node`/`npm`/`bun` invocation) SHALL resolve the project's Node version via the inherited `$PATH`.
+
+#### Scenario: Tool subprocess resolves project Node
+
+- **WHEN** claude (launched via the shim in a worktree pinned to a non-default version) spawns a subprocess that runs `node --version`
+- **THEN** the reported version is the project's pinned version, not the nvm default

--- a/openspec/changes/nvm-aware-claude-launch/tasks.md
+++ b/openspec/changes/nvm-aware-claude-launch/tasks.md
@@ -1,0 +1,31 @@
+## 1. Shim script (`claude-node-launch`)
+
+- [ ] 1.1 Add the shim as a chezmoi `executable_` source at a dedicated shims dir that does not collide with `~/.local/bin/claude` (e.g. `dot_local/bin/shims/executable_claude` → `~/.local/bin/shims/claude`)
+- [ ] 1.2 Implement the no-`.nvmrc` fast path: builtin walk-up (`${d%/*}`, no `dirname` forks); if nothing found above and below, `exec "$HOME/.local/bin/claude" "$@"` unchanged
+- [ ] 1.3 Implement the up-then-down `.nvmrc` finder: walk up to filesystem root; if none, bounded walk-down skipping `node_modules/` and `.git/`; on >1 match pick shallowest and warn to stderr
+- [ ] 1.4 Implement PATH-prepend activation for installed versions: exact pin (`24.12.0`/`v24.12.0`) and major-prefix (`24` → highest matching `$NVM_DIR/versions/node/v24*`), prepend `…/bin` to `$PATH`, no `nvm.sh` sourcing
+- [ ] 1.5 Implement the cold/alias fallback: when the resolved version is not installed, or `.nvmrc` is an alias (`lts/*`, `node`, `stable`), source `nvm.sh` + `nvm install`/`nvm use`, then delegate
+- [ ] 1.6 Delegate via `exec "$HOME/.local/bin/claude" "$@"` by absolute path (no recursion); confirm exit status passes through
+
+## 2. PATH wiring
+
+- [ ] 2.1 In `dot_zshrc.tmpl`, prepend the shims dir to `$PATH` ahead of `~/.local/bin` (document why ordering matters; no-op if bypassed)
+- [ ] 2.2 `chezmoi apply` and confirm `command -v claude` resolves the shim, not `~/.local/bin/claude`
+
+## 3. AoE integration
+
+- [ ] 3.1 Verify whether AoE supports an agent-command override for the `claude` tool (inspect `aoe agents` / config schema, mirror the `[tools.lazygit].command` precedent)
+- [ ] 3.2 Add `NVM_DIR` to AoE `[sandbox].environment` in the chezmoi-managed AoE config (`private_dot_agent-of-empires/…`)
+- [ ] 3.3 Confirm the shim resolves the version inside AoE's sandbox (i.e. `~/.nvm` is readable there); if filesystem-isolated, document the limitation
+
+## 4. Verification
+
+- [ ] 4.1 Pinned-version worktree: launch claude via `wsc`/`wt switch -x claude` in a worktree whose `.nvmrc` pins a non-default version; confirm a subprocess `node --version` reports the pinned version
+- [ ] 4.2 Subdir case: worktree with `.nvmrc` only in `apps/web/`; confirm the downward search selects it
+- [ ] 4.3 Non-Node dir: confirm passthrough with no `$PATH` change and negligible overhead
+- [ ] 4.4 Cold install: a pinned version not yet installed triggers the one-time `nvm install` fallback, then steady-state fast path
+- [ ] 4.5 Re-run the prelude benchmark on the final shim to confirm steady-state overhead stays in the single-digit-ms range
+
+## 5. Docs
+
+- [ ] 5.1 Update `docs/manual.html` (via the manual skill) to document the shim, PATH ordering, and the AoE `NVM_DIR` passthrough

--- a/openspec/changes/nvm-aware-claude-launch/tasks.md
+++ b/openspec/changes/nvm-aware-claude-launch/tasks.md
@@ -1,31 +1,33 @@
 ## 1. Shim script (`claude-node-launch`)
 
-- [ ] 1.1 Add the shim as a chezmoi `executable_` source at a dedicated shims dir that does not collide with `~/.local/bin/claude` (e.g. `dot_local/bin/shims/executable_claude` → `~/.local/bin/shims/claude`)
-- [ ] 1.2 Implement the no-`.nvmrc` fast path: builtin walk-up (`${d%/*}`, no `dirname` forks); if nothing found above and below, `exec "$HOME/.local/bin/claude" "$@"` unchanged
-- [ ] 1.3 Implement the up-then-down `.nvmrc` finder: walk up to filesystem root; if none, bounded walk-down skipping `node_modules/` and `.git/`; on >1 match pick shallowest and warn to stderr
-- [ ] 1.4 Implement PATH-prepend activation for installed versions: exact pin (`24.12.0`/`v24.12.0`) and major-prefix (`24` → highest matching `$NVM_DIR/versions/node/v24*`), prepend `…/bin` to `$PATH`, no `nvm.sh` sourcing
-- [ ] 1.5 Implement the cold/alias fallback: when the resolved version is not installed, or `.nvmrc` is an alias (`lts/*`, `node`, `stable`), source `nvm.sh` + `nvm install`/`nvm use`, then delegate
-- [ ] 1.6 Delegate via `exec "$HOME/.local/bin/claude" "$@"` by absolute path (no recursion); confirm exit status passes through
+- [x] 1.1 Add the shim as a chezmoi `executable_` source at a dedicated shims dir that does not collide with `~/.local/bin/claude` (e.g. `dot_local/bin/shims/executable_claude` → `~/.local/bin/shims/claude`)
+- [x] 1.2 Implement the no-`.nvmrc` fast path: builtin walk-up (`${d%/*}`, no `dirname` forks); if nothing found above and below, `exec "$HOME/.local/bin/claude" "$@"` unchanged
+- [x] 1.3 Implement the up-then-down `.nvmrc` finder: walk up to filesystem root; if none, bounded walk-down skipping `node_modules/` and `.git/`; on >1 match pick shallowest and warn to stderr
+- [x] 1.4 Implement PATH-prepend activation for installed versions: exact pin (`24.12.0`/`v24.12.0`) and major-prefix (`24` → highest matching `$NVM_DIR/versions/node/v24*`), prepend `…/bin` to `$PATH`, no `nvm.sh` sourcing
+- [x] 1.5 Implement the cold/alias fallback: when the resolved version is not installed, or `.nvmrc` is an alias (`lts/*`, `node`, `stable`), source `nvm.sh` + `nvm install`/`nvm use`, then delegate
+- [x] 1.6 Delegate via `exec "$HOME/.local/bin/claude" "$@"` by absolute path (no recursion); confirm exit status passes through
 
 ## 2. PATH wiring
 
 - [ ] 2.1 In `dot_zshrc.tmpl`, prepend the shims dir to `$PATH` ahead of `~/.local/bin` (document why ordering matters; no-op if bypassed)
-- [ ] 2.2 `chezmoi apply` and confirm `command -v claude` resolves the shim, not `~/.local/bin/claude`
+- [ ] 2.2 `chezmoi apply` and confirm `command -v claude` resolves the shim, not `~/.local/bin/claude` — _deferred to post-merge (user choice). Static check done: `chezmoi diff/managed --source <worktree>` confirms the shim installs at `.local/bin/shims/claude` and the PATH line lands ahead of `.local/bin`. Live `command -v` confirmation pending the normal `chezmoi update`→`apply` after merge._
 
 ## 3. AoE integration
 
-- [ ] 3.1 Verify whether AoE supports an agent-command override for the `claude` tool (inspect `aoe agents` / config schema, mirror the `[tools.lazygit].command` precedent)
-- [ ] 3.2 Add `NVM_DIR` to AoE `[sandbox].environment` in the chezmoi-managed AoE config (`private_dot_agent-of-empires/…`)
-- [ ] 3.3 Confirm the shim resolves the version inside AoE's sandbox (i.e. `~/.nvm` is readable there); if filesystem-isolated, document the limitation
+- [x] 3.1 Verify whether AoE supports an agent-command override for the `claude` tool (inspect `aoe agents` / config schema, mirror the `[tools.lazygit].command` precedent) — AoE 1.9.5 exposes `aoe add --cmd-override <CMD>` and `--tool <named-custom-agent>` (CLI-level override). More importantly `[sandbox].enabled_by_default = false`: by default claude runs outside the sandbox and inherits the launch shell's PATH, so the shim is hit with no override needed; `NVM_DIR` passthrough is the baseline for when the sandbox is enabled.
+- [x] 3.2 Add `NVM_DIR` to AoE `[sandbox].environment` in the chezmoi-managed AoE config (`private_dot_agent-of-empires/…`)
+- [ ] 3.3 Confirm the shim resolves the version inside AoE's sandbox (i.e. `~/.nvm` is readable there); if filesystem-isolated, document the limitation — _deferred to post-merge. Note: `[sandbox].enabled_by_default = false`, so by default claude runs outside the sandbox and inherits the launch shell's PATH (shim works with no passthrough). The `NVM_DIR` passthrough (3.2) is the baseline for when the sandbox is enabled; live sandbox-on confirmation pending._
 
 ## 4. Verification
 
-- [ ] 4.1 Pinned-version worktree: launch claude via `wsc`/`wt switch -x claude` in a worktree whose `.nvmrc` pins a non-default version; confirm a subprocess `node --version` reports the pinned version
-- [ ] 4.2 Subdir case: worktree with `.nvmrc` only in `apps/web/`; confirm the downward search selects it
-- [ ] 4.3 Non-Node dir: confirm passthrough with no `$PATH` change and negligible overhead
-- [ ] 4.4 Cold install: a pinned version not yet installed triggers the one-time `nvm install` fallback, then steady-state fast path
-- [ ] 4.5 Re-run the prelude benchmark on the final shim to confirm steady-state overhead stays in the single-digit-ms range
+> Verification §4 deferred to post-merge (user choice). All cases below were proven against a sandboxed test harness (fake `$HOME`/`$NVM_DIR`/real-claude stub, 15 scenarios); what remains is confirming the same behavior in a live, shim-launched claude after `chezmoi apply`.
+
+- [ ] 4.1 Pinned-version worktree: launch claude via `wsc`/`wt switch -x claude` in a worktree whose `.nvmrc` pins a non-default version; confirm a subprocess `node --version` reports the pinned version — _harness: exact/bare/major/minor pins + walk-up all activate the right `bin/`. Live launch pending._
+- [ ] 4.2 Subdir case: worktree with `.nvmrc` only in `apps/web/`; confirm the downward search selects it — _harness: walk-down selects the single subdir `.nvmrc`; multiple → shallowest + stderr warn. Live launch pending._
+- [ ] 4.3 Non-Node dir: confirm passthrough with no `$PATH` change and negligible overhead — _harness: no/empty `.nvmrc` and `node_modules`-only matches → passthrough, PATH untouched. Live launch + timing pending._
+- [ ] 4.4 Cold install: a pinned version not yet installed triggers the one-time `nvm install` fallback, then steady-state fast path — _harness (fake nvm): uninstalled pin → `nvm use`→`nvm install`; installed pin never sources nvm.sh. Live `nvm install` pending._
+- [ ] 4.5 Re-run the prelude benchmark on the final shim to confirm steady-state overhead stays in the single-digit-ms range — _deferred: needs live timing on real hardware after apply._
 
 ## 5. Docs
 
-- [ ] 5.1 Update `docs/manual.html` (via the manual skill) to document the shim, PATH ordering, and the AoE `NVM_DIR` passthrough
+- [x] 5.1 Update `docs/manual.html` (via the manual skill) to document the shim, PATH ordering, and the AoE `NVM_DIR` passthrough

--- a/private_dot_agent-of-empires/modify_private_config.toml
+++ b/private_dot_agent-of-empires/modify_private_config.toml
@@ -54,8 +54,13 @@ MANAGED = [
      'terminal-notifier -title "aoe: $AOE_SESSION_TITLE" -message "done"', True),
     (("status_hooks", "on_error"),
      'terminal-notifier -title "aoe: $AOE_SESSION_TITLE" -message "errored" -sound Basso', True),
+    # NVM_DIR lets the claude-node-launch shim resolve the project's Node from
+    # $NVM_DIR/versions/node/ when AoE runs claude inside the sandbox (the shim
+    # needs the dir, not the nvm shell function). Outside the sandbox (the
+    # default — sandbox.enabled_by_default = false) claude inherits the launch
+    # shell's PATH and hits the shim regardless. See nvm-aware-claude-launch.
     (("sandbox", "environment"),
-     ["CLAUDE_CONFIG_DIR", "EDITOR", "TERM", "COLORTERM"], False),
+     ["CLAUDE_CONFIG_DIR", "EDITOR", "TERM", "COLORTERM", "NVM_DIR"], False),
     (("tools", "lazygit", "command"), "lazygit", False),
     (("tools", "lazygit", "hotkey"), "Alt+g", False),
 ]


### PR DESCRIPTION
## Summary

Implements the OpenSpec change **`nvm-aware-claude-launch`**: a PATH shim named `claude` at `~/.local/bin/shims/claude` that sits ahead of the real `~/.local/bin/claude`, so every launcher (`wsc`/`wsh`, gh-dash `-x claude`, AoE, or a typed `claude`) runs claude — and its subprocesses (Bash tool, hooks, `node`/`bun`/`npm`) — under the project's `.nvmrc` Node, with no per-launcher edits.

### Why
`wt switch -x claude` is `chdir`+`exec`, not a shell `cd`, so nvm's `chpwd` autoload never fires and a worktrunk post-start hook runs in a throwaway subprocess. The only point that runs *in the process that becomes claude* is the launch command itself — hence a shim.

## What's in here
- **Shim** (`dot_local/bin/shims/executable_claude`): walk-up-then-bounded-walk-down `.nvmrc` finder; PATH-prepend activation for installed versions (~0.4 ms, **never sources `nvm.sh`**); cold/alias fallback to `nvm install`/`use`; near-zero-cost passthrough when no `.nvmrc`; execs the real binary by absolute path (no recursion).
- **PATH wiring** (`dot_zshrc.tmpl`): shims dir prepended ahead of `~/.local/bin`; no-op if bypassed.
- **AoE** (`private_dot_agent-of-empires/modify_private_config.toml`): `NVM_DIR` added to `[sandbox].environment` passthrough so the shim resolves versions from the filesystem inside the sandbox. (`[sandbox].enabled_by_default = false`, so by default claude runs outside the sandbox and inherits PATH — the shim is hit with no extra wiring.)
- **Docs** (`docs/manual.html`): new "Node version on launch (nvm-aware shim)" subsection in §11.

## Verification
Behavior proven against a sandboxed test harness (fake `$HOME`/`$NVM_DIR`/real-claude stub) — **15/15 scenarios**: exact/bare/major/minor pins, walk-up, subdir walk-down, multiple-`.nvmrc` shallowest+warn, `node_modules` skip, whitespace/CR tolerance, empty/no `.nvmrc` passthrough, cold install, alias fallback, and confirmation that installed versions never source `nvm.sh`.

Live-apply verification (tasks §2.2, §3.3, §4.1–4.5) is **deferred to post-merge** — those require a `chezmoi apply` that shadows the running `claude`. Each task is annotated in `tasks.md` with its harness coverage and the remaining live step.

## Rollback
Remove the shim file + the `dot_zshrc.tmpl` PATH line, `chezmoi apply`. Launchers fall back to the real `claude` with zero residue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an nvm-aware `claude` launcher shim that selects the Node version from the nearest `.nvmrc`.
  * Wired shell startup and PATH ordering so the shim is used reliably, including when using alternate launch entry points.

* **Bug Fixes**
  * Improved behavior when the pinned Node version (or alias) isn’t installed, with safer fallback handling.
  * Ensured AoE-launched Claude sessions pass through the needed environment so the pinned Node is applied to Claude and child processes.

* **Documentation**
  * Updated the manual and added nvm-aware launch guidance, design notes, specs, and implementation plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->