### PR TITLE
feat(markdown): add glow + mdfried terminal viewers (DOT-35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ chezmoi-managed dotfiles for macOS (primary) with Linux support. Built around Gh
 | **CLI Tools**  | [ticker](https://github.com/achannarasappa/ticker)                              | Terminal stock tracker with cost-basis positions and sector groups                         |
 | **CLI Tools**  | [age](https://age-encryption.org/)                                              | Modern encryption tool backing the chezmoi-managed secrets workflow                        |
 | **CLI Tools**  | [mole](https://github.com/tw93/mole)                                            | Deep clean and optimize your Mac — caches, logs, app remnants, `node_modules` (macOS only) |
+| **CLI Tools**  | [glow](https://github.com/charmbracelet/glow)                                   | Terminal Markdown viewer — TUI browse + CLI render                                         |
+| **CLI Tools**  | [mdfried](https://github.com/benjajaja/mdfried)                                 | Markdown viewer with inline images, mermaid diagrams, and Big Headers (graphics terminal)  |
 | **Git**        | [git-delta](https://github.com/dandavison/delta)                                | Syntax-highlighted diff viewer                                                             |
 | **Git**        | [lazygit](https://github.com/jesseduffield/lazygit)                             | TUI for git operations                                                                     |
 | **Git**        | [GitHub CLI](https://cli.github.com/)                                           | GitHub from the terminal                                                                   |

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -847,6 +847,75 @@
                         <code>lt</code> for structure &rarr; <code>lcode</code> for source tree
                         &rarr; <code>cat README.md</code>
                     </div>
+
+                    <h3>Markdown (glow / mdfried)</h3>
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Command</th>
+                                <th>Description</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td><code>md</code></td>
+                                <td>
+                                    No args &rarr; glow directory-browse TUI;
+                                    <code>md &lt;file&gt;</code> &rarr;
+                                    <code>mdview</code> dispatcher
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><code>mdview &lt;file&gt;</code></td>
+                                <td>
+                                    Central viewer dispatcher &mdash; piped/non-TTY &rarr; glow to
+                                    stdout; auto picks <code>mdfried</code> for docs with images or
+                                    a <code>mermaid</code> fence in a graphics-capable terminal,
+                                    else
+                                    <code>glow -p</code>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><code>MD_VIEWER</code></td>
+                                <td>
+                                    Override &mdash; <code>glow</code> or
+                                    <code>mdfried</code> forces that viewer unconditionally;
+                                    <code>auto</code>/unset = auto-select
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><code>glow</code></td>
+                                <td>
+                                    Default renderer &mdash; <code>glow &lt;file&gt;</code> renders
+                                    styled, <code>glow</code> (no args) browses the directory, also
+                                    reads stdin / remote URLs. The only viewer usable in preview
+                                    panes
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><code>mdfried &lt;file&gt;</code></td>
+                                <td>
+                                    Graphics-rich companion &mdash; inline images, mermaid diagrams,
+                                    Big Headers (needs a graphics-capable terminal &mdash; Kitty /
+                                    iTerm2 / Sixel &mdash; and tmux
+                                    <code>allow-passthrough on</code>)
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+
+                    <p class="note">
+                        <code>.md</code>/<code>.markdown</code> previews in <code>fzf</code> and the
+                        <code>television</code> <code>markdown</code> channel render with
+                        <code>glow</code>; the channel's <kbd>Enter</kbd> opens the file via
+                        <code>mdview</code>.
+                    </p>
+
+                    <div class="flow-only">
+                        <strong>Flow: Read a doc without leaving the terminal</strong><br />
+                        <code>tv markdown</code> &rarr; browse <code>.md</code> files, preview with
+                        glow &rarr; <kbd>Enter</kbd> opens via <code>mdview</code>
+                    </div>
                 </div>
             </details>
 
@@ -1140,7 +1209,9 @@
                                     lazygit &mdash; full TUI git interface with file view filtering,
                                     worktree branch visibility, and PR badges from
                                     <code>gh</code> (lazygit 0.61, requires
-                                    <code>showIcons: true</code> + <code>nerdFontsVersion</code>)
+                                    <code>showIcons: true</code> + <code>nerdFontsVersion</code>).
+                                    Custom <kbd>g</kbd> in the Files panel opens the selected file
+                                    rendered via <code>mdview</code>; diffs stay <code>delta</code>
                                 </td>
                             </tr>
                             <tr>

--- a/dot_config/glow/glow.yml
+++ b/dot_config/glow/glow.yml
@@ -1,0 +1,19 @@
+# glow configuration — terminal Markdown viewer
+# Managed by chezmoi; lands at ~/.config/glow/glow.yml
+
+# Rendering style. "dark" auto-fits a dark background and is close to the
+# repo's Catppuccin Mocha palette (a bespoke glamour JSON stylesheet is
+# deferred until the built-in style proves insufficient).
+style: "dark"
+
+# Word-wrap column. Keeps long prose readable on wide terminals.
+width: 120
+
+# Page rendered output through a less-style pager instead of dumping it.
+pager: true
+
+# Mouse-wheel scrolling in the TUI / pager.
+mouse: true
+
+# In the browse TUI, do NOT descend into hidden/ignored files by default.
+all: false

--- a/dot_config/lazygit/config.yml
+++ b/dot_config/lazygit/config.yml
@@ -42,6 +42,6 @@ gui:
 customCommands:
     - key: "g"
       context: "files"
-      command: "mdview {{.SelectedFile.Name}}"
+      command: "mdview {{.SelectedFile.Name | quote}}"
       subprocess: true
       description: "Open file rendered (mdview: glow/mdfried)"

--- a/dot_config/lazygit/config.yml
+++ b/dot_config/lazygit/config.yml
@@ -35,3 +35,13 @@ gui:
             - "#cdd6f4"
     authorColors:
         "*": "#b4befe"
+
+# Open the selected file rendered via the mdview dispatcher (glow / mdfried).
+# subprocess: true hands the terminal to the viewer and resumes lazygit on exit.
+# This views a whole document; diffs remain delta's job (unchanged).
+customCommands:
+    - key: "g"
+      context: "files"
+      command: "mdview {{.SelectedFile.Name}}"
+      subprocess: true
+      description: "Open file rendered (mdview: glow/mdfried)"

--- a/dot_config/television/cable/markdown.toml
+++ b/dot_config/television/cable/markdown.toml
@@ -1,0 +1,21 @@
+[metadata]
+name = "markdown"
+description = "Browse Markdown files; preview rendered with glow, open via mdview"
+requirements = ["fd", "glow"]
+
+[source]
+command = "fd -e md -e markdown --type f"
+
+[preview]
+command = "glow -s auto '{}'"
+
+[ui]
+preview_panel = { size = 60 }
+
+[keybindings]
+enter = "actions:open"
+
+[actions.open]
+description = "Open in mdview (glow / mdfried)"
+command = "mdview '{}'"
+mode = "execute"

--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -7,6 +7,10 @@ set -g default-terminal "xterm-256color"
 # Forward focus events to applications (enables vim autoread, shell integration)
 set -g focus-events on
 
+# Let terminal graphics protocols (Kitty graphics, used by mdfried) reach
+# applications inside a pane instead of being stripped by tmux
+set -g allow-passthrough on
+
 # Catppuccin theme — Mocha flavor with rounded window status
 set -g @catppuccin_flavor "mocha"
 set -g @catppuccin_window_status_style "rounded"

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -141,7 +141,7 @@ export FZF_DEFAULT_OPTS="
   --height 40%
   --layout=reverse
   --border
-  --preview 'case {} in *.md|*.markdown) glow -s auto {};; *) bat --color=always --style=numbers --line-range=:500 {};; esac'
+  --preview 'case {} in *.md|*.markdown) glow -s auto -- {};; *) bat --color=always --style=numbers --line-range=:500 -- {};; esac'
   --preview-window=right:60%
   --bind='ctrl-/:toggle-preview'
   --color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F38BA8
@@ -149,7 +149,7 @@ export FZF_DEFAULT_OPTS="
   --color=marker:#B4BEFE,fg+:#CDD6F4,prompt:#CBA6F7,hl+:#F38BA8
   --color=selected-bg:#45475A,border:#6C7086,label:#CDD6F4
 "
-export FZF_CTRL_T_OPTS="--preview 'case {} in *.md|*.markdown) glow -s auto {};; *) bat --color=always --style=numbers --line-range=:500 {};; esac'"
+export FZF_CTRL_T_OPTS="--preview 'case {} in *.md|*.markdown) glow -s auto -- {};; *) bat --color=always --style=numbers --line-range=:500 -- {};; esac'"
 export FZF_ALT_C_OPTS="--preview 'eza --tree --color=always {} | head -200'"
 
 # television - Smart fuzzy finder with context-aware autocomplete
@@ -223,12 +223,17 @@ __md_has_visuals() {
   grep -qE '^[[:space:]]*```mermaid' "$1" 2>/dev/null
 }
 __md_graphics_capable() {
-  # tmux strips terminal graphics escapes unless passthrough is enabled.
   if [ -n "${TMUX:-}" ]; then
+    # Inside tmux, graphics escapes only pass through with passthrough on, AND
+    # tmux masks the outer terminal's $TERM/$TERM_PROGRAM — so passthrough alone
+    # is not proof of graphics support. Require a marker that survives into the
+    # pane (Ghostty/Kitty export these); otherwise assume no graphics → glow.
     [ "$(tmux show -gv allow-passthrough 2>/dev/null)" = "on" ] || return 1
-    return 0  # tmux masks the outer terminal; trust the deliberate passthrough opt-in.
+    [ -n "${KITTY_WINDOW_ID:-}" ] && return 0
+    [ -n "${GHOSTTY_RESOURCES_DIR:-}" ] && return 0
+    return 1
   fi
-  # Terminals that speak a graphics protocol (Kitty graphics / iTerm2 / Sixel).
+  # Outside tmux: terminals that speak a graphics protocol (Kitty / iTerm2 / Sixel).
   if [ -n "${KITTY_WINDOW_ID:-}" ] || [ -n "${GHOSTTY_RESOURCES_DIR:-}" ]; then return 0; fi
   case "${TERM_PROGRAM:-}" in ghostty|iTerm.app|WezTerm) return 0 ;; esac
   [ "${LC_TERMINAL:-}" = "iTerm2" ] && return 0

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -1,6 +1,12 @@
 # If you come from bash you might have to change your $PATH.
 # export PATH=$HOME/bin:/usr/local/bin:$PATH
 
+# XDG base dir — make tools resolve config under ~/.config consistently.
+# Without this, macOS tools (glow → ~/Library/Preferences, lazygit → ~/Library/
+# Application Support, …) bypass the chezmoi-managed ~/.config/* files. Must be
+# set before any tool init below reads its config.
+export XDG_CONFIG_HOME="$HOME/.config"
+
 # Path to your oh-my-zsh installation.
 export ZSH="{{ .chezmoi.homeDir }}/.oh-my-zsh"
 
@@ -135,7 +141,7 @@ export FZF_DEFAULT_OPTS="
   --height 40%
   --layout=reverse
   --border
-  --preview 'bat --color=always --style=numbers --line-range=:500 {}'
+  --preview 'case {} in *.md|*.markdown) glow -s auto {};; *) bat --color=always --style=numbers --line-range=:500 {};; esac'
   --preview-window=right:60%
   --bind='ctrl-/:toggle-preview'
   --color=bg+:#313244,bg:#1E1E2E,spinner:#F5E0DC,hl:#F38BA8
@@ -143,7 +149,7 @@ export FZF_DEFAULT_OPTS="
   --color=marker:#B4BEFE,fg+:#CDD6F4,prompt:#CBA6F7,hl+:#F38BA8
   --color=selected-bg:#45475A,border:#6C7086,label:#CDD6F4
 "
-export FZF_CTRL_T_OPTS="--preview 'bat --color=always --style=numbers --line-range=:500 {}'"
+export FZF_CTRL_T_OPTS="--preview 'case {} in *.md|*.markdown) glow -s auto {};; *) bat --color=always --style=numbers --line-range=:500 {};; esac'"
 export FZF_ALT_C_OPTS="--preview 'eza --tree --color=always {} | head -200'"
 
 # television - Smart fuzzy finder with context-aware autocomplete
@@ -206,6 +212,48 @@ alias lta="eza --icons --group-directories-first --tree --level=2 -a"
 # bat (modern cat replacement)
 alias cat="bat --style=auto"
 alias catp="bat --style=plain"  # No line numbers or decorations
+
+# Markdown viewing — glow (default renderer) + mdfried (graphics-rich companion).
+# `mdview` is the single dispatcher every surface (md, television, lazygit) calls,
+# so the glow-vs-mdfried policy lives in one place. `cat`→`bat` (source highlight)
+# is a different job and stays untouched.
+__md_has_visuals() {
+  # True when the doc has an embedded image or a mermaid fence (where mdfried adds value).
+  grep -qE '!\[.*\]\(.*\)' "$1" 2>/dev/null && return 0
+  grep -qE '^[[:space:]]*```mermaid' "$1" 2>/dev/null
+}
+__md_graphics_capable() {
+  # tmux strips terminal graphics escapes unless passthrough is enabled.
+  if [ -n "${TMUX:-}" ]; then
+    [ "$(tmux show -gv allow-passthrough 2>/dev/null)" = "on" ] || return 1
+    return 0  # tmux masks the outer terminal; trust the deliberate passthrough opt-in.
+  fi
+  # Terminals that speak a graphics protocol (Kitty graphics / iTerm2 / Sixel).
+  if [ -n "${KITTY_WINDOW_ID:-}" ] || [ -n "${GHOSTTY_RESOURCES_DIR:-}" ]; then return 0; fi
+  case "${TERM_PROGRAM:-}" in ghostty|iTerm.app|WezTerm) return 0 ;; esac
+  [ "${LC_TERMINAL:-}" = "iTerm2" ] && return 0
+  case "${TERM:-}" in xterm-kitty|xterm-ghostty|*-sixel) return 0 ;; esac
+  return 1
+}
+mdview() {
+  # Non-TTY (piped): render to stdout with glow, never a full-screen TUI.
+  [ -t 1 ] || { glow "$@"; return; }
+  # Explicit override wins, unconditionally.
+  case "${MD_VIEWER:-auto}" in
+    glow)    glow -p "$@"; return ;;
+    mdfried) mdfried "$@"; return ;;
+  esac
+  # Auto: mdfried only for graphics-rich docs in a graphics-capable terminal; else glow's pager.
+  if [ -f "${1:-}" ] && __md_has_visuals "$1" && __md_graphics_capable; then
+    mdfried "$@"
+  else
+    glow -p "$@"
+  fi
+}
+md() {
+  # No args → glow's directory-browsing TUI; with args → the mdview dispatcher.
+  if [ "$#" -eq 0 ]; then glow; else mdview "$@"; fi
+}
 
 # Git shortcuts
 alias gs="git status"

--- a/openspec/changes/add-markdown-viewer/.openspec.yaml
+++ b/openspec/changes/add-markdown-viewer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-26

--- a/openspec/changes/add-markdown-viewer/README.md
+++ b/openspec/changes/add-markdown-viewer/README.md
@@ -1,0 +1,3 @@
+# add-markdown-viewer
+
+Visor de Markdown en terminal: glow (default, TUI+CLI) + mdfried (companion para imágenes/mermaid). Cierra Linear DOT-35 y DOT-32.

--- a/openspec/changes/add-markdown-viewer/design.md
+++ b/openspec/changes/add-markdown-viewer/design.md
@@ -111,6 +111,18 @@ The spec's `BREW_PACKAGES` requirement said "25 packages" and omitted `aoe`, alr
 (real count 26). The delta lists the true target — 26 + `glow` + `mdfried` = **28** — and adds the
 matching per-package scenarios. Spec hygiene, not new behavior.
 
+**13. Export `XDG_CONFIG_HOME=$HOME/.config` so macOS honors `~/.config`.**
+Discovered during implementation: with `XDG_CONFIG_HOME` unset (verified — login shell *and* every
+system/user zsh startup file), macOS tools fall back to their native dirs — glow reads
+`~/Library/Preferences/glow/glow.yml`, lazygit reads `~/Library/Application Support/lazygit/` (per
+`lazygit --print-config-dir`) — bypassing the chezmoi-managed `~/.config/*` this repo standardizes
+on. So the `glow.yml` (Decision 8) and the lazygit `customCommand` (Decision 11) would silently not
+load. `dot_zshrc.tmpl` therefore exports `XDG_CONFIG_HOME="$HOME/.config"` before any tool init,
+aligning every XDG-respecting tool (glow, lazygit, television, …) on `~/.config`. Confirmed
+empirically: with it set, glow loads `~/.config/glow/glow.yml`; unset, the same file is ignored.
+*Alternative rejected:* per-tool relocation to macOS-native paths (e.g. glow → `~/Library/
+Preferences`) — fixes only glow, breaks the `~/.config` convention, and needs OS-templating for Linux.
+
 ## Risks / Trade-offs
 
 - **`mdfried` maintenance/abandonment risk** → mitigated by it being secondary; glow alone satisfies
@@ -125,6 +137,11 @@ matching per-package scenarios. Spec hygiene, not new behavior.
   follow if it grates.
 - **`allow-passthrough on` broadens what apps can emit through tmux** → minor; it is the standard,
   documented way to enable graphics passthrough and is widely used.
+- **`XDG_CONFIG_HOME` export shifts config resolution repo-wide on macOS** → intended (aligns every
+  tool on `~/.config`, where this repo already places config). A tool whose config lived *only* under
+  `~/Library/*` would revert to defaults; mitigated because the repo configures everything under
+  `~/.config`. Only `XDG_CONFIG_HOME` is set — `XDG_DATA_HOME`/`XDG_CACHE_HOME` are left at defaults,
+  so data/cache locations (e.g. atuin history) are unaffected.
 
 ## Migration Plan
 

--- a/openspec/changes/add-markdown-viewer/design.md
+++ b/openspec/changes/add-markdown-viewer/design.md
@@ -72,8 +72,11 @@ place and is reconfigurable via `MD_VIEWER`.
 **6. Heuristics: content sniff + terminal/tmux detection.**
 Content: a cheap grep for an image (`![…](…)`) or a ```` ```mermaid ```` fence decides whether
 mdfried *adds value*. Terminal: detect a graphics-capable terminal (Ghostty/Kitty/iTerm) and treat
-tmux as capable only with passthrough on. The exact detection expressions are an implementation
-detail for tasks; the spec fixes the behavior.
+tmux as capable only with passthrough on **and** a surviving graphics-terminal marker
+(`GHOSTTY_RESOURCES_DIR`/`KITTY_WINDOW_ID`) — passthrough alone is not proof of graphics support,
+since tmux masks the outer terminal's `$TERM`/`$TERM_PROGRAM`, so a passthrough-on session under a
+non-graphics terminal must still fall back to glow. The exact detection expressions are an
+implementation detail for tasks; the spec fixes the behavior.
 *Trade-off:* the sniff can occasionally "guess wrong" (a doc with one trivial image opens mdfried).
 The `MD_VIEWER` override and a sensible default absorb this.
 

--- a/openspec/changes/add-markdown-viewer/design.md
+++ b/openspec/changes/add-markdown-viewer/design.md
@@ -1,0 +1,149 @@
+## Context
+
+chezmoi-managed dotfiles, macOS-first, Homebrew install via `run_onchange_install-packages.sh.tmpl`
+(a `BREW_PACKAGES` array + `pkg_bin()` binary-name map). Everything is themed Catppuccin Mocha; the
+terminal is **Ghostty** (GPU-accelerated, supports the Kitty graphics protocol); fuzzy finding uses
+`fzf` + `television`, with `bat` (aliased `cat`) as the universal preview/pager and `delta` as the
+diff pager. There is no Markdown *renderer* today — `bat` only highlights `.md` source.
+
+Linear DOT-35 ("add glow + compare viewers") is the umbrella; DOT-32 ("evaluate mdfried") is
+explicitly scoped *inside* that comparison. One decision closes both. The user confirmed they
+regularly read `.md` containing `mermaid`/images and live inside tmux.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Install a default terminal Markdown viewer; document the comparison and decision.
+- Make `.md` pleasant to read and browse without leaving the terminal (TUI browse + quick render).
+- Centralize the glow-vs-mdfried choice in one dispatcher every surface calls.
+- Wire it into the existing Catppuccin / Ghostty / `fzf` / `television` / `lazygit` / tmux setup.
+
+**Non-Goals:**
+
+- No `mdfried` theme/config file (install-only; default theme acceptable, themeable later).
+- No change to the `cat`→`bat` alias or `EDITOR` (highlighting source / editing are different jobs).
+- No change to plannotator (browser HTML render for plan review — a different workflow).
+- **No diff rendering.** PR/agent diffs (gh-dash `d`, aoe `D`, lazygit diffs) are out of scope: a
+  diff is not a document, so routing it through a Markdown renderer would destroy the `+`/`-`
+  information. Diffs are `delta`'s job (gh-dash already sets `pager.diff: delta`).
+- No gh-dash or aoe wiring: gh-dash already renders bodies via internal glamour; aoe sessions
+  inherit the shell, so `mdview`/`glow` are available there transitively.
+
+## Decisions
+
+**1. `glow` is the default viewer.**
+glow (charmbracelet, Go, `homebrew/core`) is the only candidate that is *both* a TUI folder browser
+(`less`-style pager, fuzzy file filter) and a CLI renderer (file / stdin / remote URL / GitHub repo).
+It is the most mature and widely used candidate — important for an unattended dotfiles repo — and it
+is the only adopted tool that renders to stdout, making it the sole option for preview panes. It
+complements `bat` (source highlighting) rather than overlapping it.
+*Alternative rejected:* none for this role — glow is uniquely positioned.
+
+**2. `mdfried` is the visual-rich companion — justified by a confirmed use case.**
+glow renders neither images nor `mermaid` (raw fenced block / alt-text). `mdfried` (Rust,
+`homebrew/core`) draws inline images, `mermaid` diagrams, and Big Headers™ via a terminal graphics
+protocol. Ghostty speaks Kitty, so the feature is real here. It is the *secondary* tool, not
+load-bearing.
+*Trade-off accepted:* `mdfried` is a young, single-maintainer project — higher churn/abandonment
+risk than glow. If it breaks or is dropped, glow still covers the 90% prose case. Adoption is a
+small, reversible bet justified by a confirmed need (mermaid/images), not "just in case".
+
+**3. Reject `mdcat`.**
+A mature `cat`-for-markdown with inline images. Its strengths (pipe/scriptability, inline images)
+are already covered by `bat`+`glow` (pipe/cat) and `mdfried` (images). No non-overlapping niche.
+*Alternative rejected:* mdcat as the image tool instead of mdfried — mdcat renders no `mermaid` or
+Big Headers and has no browse TUI, losing the deciding feature.
+
+**4. Reject `frogmouth`.**
+Capable Textual (Python) TUI browser, but **not in `homebrew/core`** — needs pipx, breaking the
+brew-first, single-`BREW_PACKAGES` install flow. Its TOC/bookmarks differentiator isn't worth a
+second install channel.
+
+**5. Central `mdview` dispatcher; previews stay glow.**
+The key realization: `mdfried` is a full-screen TUI and **cannot** run in a preview pane (fzf,
+television) — those require a stdout renderer. So the auto-selection applies only to the *foreground
+open* path; previews are glow-only by necessity. `mdview` encapsulates the policy (non-TTY→stdout
+glow; `MD_VIEWER` override; auto = visuals + graphics-terminal → mdfried, else glow). Every
+foreground surface (`md`, television Enter, lazygit) delegates to it, so the policy lives in one
+place and is reconfigurable via `MD_VIEWER`.
+*Alternative rejected:* per-surface inline logic — duplicates the heuristic and drifts.
+
+**6. Heuristics: content sniff + terminal/tmux detection.**
+Content: a cheap grep for an image (`![…](…)`) or a ```` ```mermaid ```` fence decides whether
+mdfried *adds value*. Terminal: detect a graphics-capable terminal (Ghostty/Kitty/iTerm) and treat
+tmux as capable only with passthrough on. The exact detection expressions are an implementation
+detail for tasks; the spec fixes the behavior.
+*Trade-off:* the sniff can occasionally "guess wrong" (a doc with one trivial image opens mdfried).
+The `MD_VIEWER` override and a sensible default absorb this.
+
+**7. Enable tmux graphics passthrough.**
+The user lives in tmux, which by default strips graphics escapes. Add `set -g allow-passthrough on`
+to `dot_tmux.conf` so mdfried's Kitty-protocol output reaches the pane. Without it the dispatcher
+would almost always fall back to glow inside tmux, defeating mdfried's adoption.
+*Alternative rejected:* detect `$TMUX` and always use glow there — simpler but neuters mdfried in
+the user's primary environment.
+
+**8. Theming: `glow.yml` built-in dark style, not a custom JSON stylesheet (yet).**
+glow's built-in dark style auto-detects the terminal background and is close to Catppuccin Mocha. A
+bespoke glamour JSON stylesheet is deferred (diminishing returns vs. tracking glamour's schema).
+mdfried and ANSI-inheriting tools get Catppuccin colors for free; glow is the one needing an explicit
+style choice.
+
+**9. `md` as a function delegating to `mdview`.**
+`md` (no args) → glow browse TUI; `md <file>` → `mdview`. A thin function (not a bare alias) keeps
+glow's remote/stdin forms reachable by calling `glow` directly.
+
+**10. chezmoi template escaping in the `fzf` preview.**
+`dot_zshrc.tmpl` is a chezmoi template, so literal `{{`/`}}` are template delimiters. The `.md`→glow
+preview must use only `fzf`'s single-brace `{}` and shell `${…}` expansions — no double braces. This
+is the main implementation footgun; verify with `chezmoi diff` after editing.
+
+**11. lazygit wired, gh-dash/aoe not.**
+lazygit has no markdown render; a `customCommands` (files context, subprocess) entry calling `mdview`
+gives "open this README rendered" without leaving lazygit — a clean win that exercises the central
+dispatcher. gh-dash already renders bodies via glamour internally (not swappable, and its content is
+remote, not local files). aoe has no markdown surface, and its sessions inherit the shell, so
+`mdview` is available there for free. lazygit's diff view is untouched (`delta`).
+
+**12. Reconcile `cli-tool-expansion` spec drift.**
+The spec's `BREW_PACKAGES` requirement said "25 packages" and omitted `aoe`, already in the array
+(real count 26). The delta lists the true target — 26 + `glow` + `mdfried` = **28** — and adds the
+matching per-package scenarios. Spec hygiene, not new behavior.
+
+## Risks / Trade-offs
+
+- **`mdfried` maintenance/abandonment risk** → mitigated by it being secondary; glow alone satisfies
+  the core need. Re-evaluate if it stalls.
+- **`mdfried` ↔ graphics-terminal coupling** → its headline features need Kitty/iTerm2/Sixel; switching
+  terminals, or a tmux build without passthrough support, silently degrades it. Documented as a
+  dependency; the dispatcher avoids ugly output by selecting glow when graphics are unavailable.
+- **chezmoi `{{`/`}}` in the `fzf` preview** → could corrupt `~/.zshrc` rendering. Mitigation: no
+  double braces; verify `chezmoi execute-template` / `chezmoi diff` after editing `dot_zshrc.tmpl`.
+- **Content-sniff misfires** → the `MD_VIEWER` override + glow default keep it from being annoying.
+- **glow style ≠ exact Catppuccin Mocha** → built-in dark style is close; a custom JSON stylesheet can
+  follow if it grates.
+- **`allow-passthrough on` broadens what apps can emit through tmux** → minor; it is the standard,
+  documented way to enable graphics passthrough and is widely used.
+
+## Migration Plan
+
+1. Add `glow`, `mdfried` to `BREW_PACKAGES`; update non-macOS fallback + completion message.
+2. Add `dot_config/glow/glow.yml` and `dot_config/television/cable/markdown.toml`.
+3. Add `mdview` + `md` and the `.md`→glow `fzf` preview routing to `dot_zshrc.tmpl`.
+4. Add the `lazygit` `customCommands` entry; add `set -g allow-passthrough on` to `dot_tmux.conf`.
+5. `chezmoi diff` / `chezmoi apply`; verify `glow`, `mdfried`, `mdview`/`md`, the `fzf` preview, the
+   `tv markdown` channel, the lazygit command, and mdfried-in-tmux graphics; confirm `~/.zshrc`
+   renders cleanly.
+6. Update README + manual.
+
+**Rollback:** remove the two array entries, the two new config files, and the `dot_zshrc.tmpl` /
+`dot_tmux.conf` / `lazygit` additions; revert docs. No state or migration to unwind (`brew uninstall`
+the tools independently).
+
+## Open Questions
+
+- Bespoke Catppuccin-Mocha glamour JSON stylesheet for glow — defer unless the built-in dark style
+  looks off in practice.
+- gh-dash `d` "raw diff" symptom — likely delta not picking up its Catppuccin theme outside a repo
+  context. Tracked separately; not part of this change.

--- a/openspec/changes/add-markdown-viewer/proposal.md
+++ b/openspec/changes/add-markdown-viewer/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+We have no in-terminal Markdown *renderer*. The only `.md`-aware tool today is `bat` (aliased to `cat`), which highlights the *source* — it does not render headings, lists, tables, or code blocks. To read a document with style you currently leave the terminal for the IDE or a browser (plannotator renders `.md` → HTML, which is heavyweight and pulls you off the keyboard). Linear DOT-35 (add glow + compare viewers) and DOT-32 (evaluate mdfried) ask to close this gap with a real terminal viewer and a documented decision. Rather than make the user remember which of two viewers to invoke, this change also centralizes the choice in one dispatcher so the whole dotfiles stack picks the right tool automatically.
+
+## What Changes
+
+- **Adopt `glow` as the default terminal Markdown viewer.** Both a TUI to browse `.md` files in a directory (`less`-style pager) and a CLI to render a file / stdin / remote URL with style — covering "read and navigate docs without the IDE". Mature (charmbracelet), `homebrew/core`. It is the only viewer that can render to stdout, so it is also the sole tool usable in preview panes.
+- **Adopt `mdfried` as the visual-rich companion.** The one candidate that renders embedded images and `mermaid` diagrams graphically (plus Big Headers™) instead of as raw fenced code — useful for architecture docs and AI plans. `homebrew/core`. It is a full-screen TUI, so it is only usable in a foreground "open this doc" context, never in a preview pane. Its rich rendering needs a terminal graphics protocol (Kitty/iTerm2/Sixel).
+- **Reject `mdcat` and `frogmouth`** (rationale in `design.md`): `mdcat`'s niche (pipe + inline images) is already covered by `bat` + `glow` + `mdfried`; `frogmouth` is not in `homebrew/core`, breaking the brew-first install flow.
+- **Add a central `mdview` dispatcher** (shell function) that picks the right viewer when *opening* a document: render to stdout when not a TTY; honor an `MD_VIEWER=auto|glow|mdfried` override; otherwise auto-select — `mdfried` when the file contains images/`mermaid` **and** the terminal is graphics-capable, else `glow`'s pager. One function encodes the policy; everything that opens a `.md` calls it.
+- **Wire the stack to the dispatcher / glow.** `md` shell function → `mdview`; the `television` `markdown` channel's Enter action → `mdview`; a `lazygit` `customCommand` (Files context) opens the selected `.md` via `mdview` as a subprocess; `fzf` previews and the `television` preview pane render `*.md` with `glow` (preview panes can only use a stdout renderer, so they are glow-only by necessity). The `cat`→`bat` alias and `EDITOR` are untouched (highlighting source / editing are different jobs).
+- **Enable tmux graphics passthrough.** Add `set -g allow-passthrough on` to `dot_tmux.conf` so `mdfried`'s Kitty-protocol images/diagrams survive inside tmux — without it the dispatcher would always fall back to `glow` in tmux (where the user works).
+- **Style + browse**: a chezmoi-managed `glow.yml` (dark/Catppuccin-aligned style, word-wrap, pager); the `markdown` `television` cable channel paralleling `rg-edit`.
+- **Docs**: README "What's Included" gains `glow` + `mdfried`; the manual documents `md`/`mdview`, `MD_VIEWER`, and the `markdown` channel.
+- **Reconcile spec drift**: the `cli-tool-expansion` spec still says 25 packages and omits `aoe` (already in the array). The modified requirement is brought current — `aoe` plus the two new tools.
+
+Non-goals: no `mdfried` theme file (install-only); no change to the `cat`→`bat` alias or `EDITOR`; no change to plannotator (a separate browser-based workflow). **No diff rendering**: PR/agent diffs (gh-dash `d`, aoe `D`) are explicitly out of scope — a diff is not a document, so routing it through the Markdown viewer would destroy the `+`/`-` information; diffs are `delta`'s job (gh-dash already sets `pager.diff: delta`; any "raw diff" symptom is a delta theme/PATH issue tracked separately, not here). **No gh-dash or aoe wiring**: gh-dash already renders bodies via its internal glamour, and aoe sessions inherit the shell (so `mdview`/`glow` are available there for free).
+
+## Capabilities
+
+### New Capabilities
+
+- `markdown-viewer`: How Markdown is viewed in this environment — `glow` as the default renderer, `mdfried` as the graphics-dependent companion, the `mdview` dispatcher (content + terminal + tmux detection, `MD_VIEWER` override) that auto-selects when opening a doc, the `md` function, a `lazygit` `customCommand` that opens the selected `.md` via `mdview`, the `glow.yml` config, and the `fzf`/preview routing that renders `*.md` with `glow`.
+- `television-markdown-channel`: A `television` cable channel (`markdown`) that lists `.md`/`.markdown` files via `fd`, previews them rendered with `glow`, and opens the selected file via `mdview` — paralleling the existing `television-rg-edit-channel`.
+
+### Modified Capabilities
+
+- `cli-tool-expansion`: The `BREW_PACKAGES` array gains `glow` and `mdfried` (both `homebrew/core`, identity `pkg_bin` mappings, no new `BREW_TAPS`); the count and list are reconciled to include the already-present `aoe`; the non-macOS fallback lists the two new tools.
+- `tmux-config`: tmux gains `set -g allow-passthrough on` so terminal graphics protocols pass through to applications inside tmux (required for `mdfried`'s images/`mermaid`).
+
+## Impact
+
+- **Install script**: `run_onchange_install-packages.sh.tmpl` — `BREW_PACKAGES`, non-macOS fallback list, completion-message tool list.
+- **Config (new)**: `dot_config/glow/glow.yml`; `dot_config/television/cable/markdown.toml`.
+- **Shell**: `dot_zshrc.tmpl` — `mdview` dispatcher + `md` function; `.md`→glow `fzf` preview routing (must avoid literal `{{`/`}}`, which chezmoi treats as template delimiters).
+- **lazygit**: `dot_config/lazygit/config.yml` — a `customCommands` entry (Files context) that opens the selected `.md` via `mdview` as a subprocess.
+- **tmux**: `dot_tmux.conf` — `set -g allow-passthrough on`.
+- **Docs**: `README.md`, `docs/manual.html`.
+- **Dependency note**: `mdfried`'s rich rendering requires a Kitty/iTerm2/Sixel-capable terminal (Ghostty) and, inside tmux, the passthrough setting above; it otherwise degrades to character rendering, which the dispatcher avoids by selecting `glow`.
+- **Resolves** Linear DOT-35 and DOT-32.

--- a/openspec/changes/add-markdown-viewer/specs/cli-tool-expansion/spec.md
+++ b/openspec/changes/add-markdown-viewer/specs/cli-tool-expansion/spec.md
@@ -1,0 +1,127 @@
+## MODIFIED Requirements
+
+### Requirement: BREW_PACKAGES array includes all actively used CLI tools
+
+The `BREW_PACKAGES` array SHALL contain the following 28 packages:
+
+`git`, `git-delta`, `starship`, `eza`, `bat`, `zoxide`, `atuin`, `fzf`, `ripgrep`,
+`lazygit`, `worktrunk`, `terminal-notifier`, `fd`, `direnv`, `beads`, `gh`, `tmux`,
+`uv`, `mas`, `wget`, `television`, `tickrs`, `ticker`, `age`, `mole`, `aoe`,
+`glow`, `mdfried`
+
+`opencode` SHALL NOT appear in `BREW_PACKAGES`; it is installed via its official script
+(see the `opencode-install` capability). Removing it also makes the `anomalyco/tap` tap
+unnecessary for this array.
+
+`glow` and `mdfried` are both in `homebrew/core`, so they require no `BREW_TAPS` entry, and both
+use the identity `pkg_bin` mapping (binary name equals package name).
+
+#### Scenario: All packages listed in array
+
+- **WHEN** the install script is loaded
+- **THEN** the `BREW_PACKAGES` array contains exactly 28 entries
+
+#### Scenario: opencode absent from array
+
+- **WHEN** the install script is loaded
+- **THEN** the `BREW_PACKAGES` array does NOT contain `opencode`
+
+#### Scenario: television listed in array
+
+- **WHEN** the install script is loaded
+- **THEN** the `BREW_PACKAGES` array contains `television`
+
+#### Scenario: television maps to tv binary
+
+- **WHEN** `pkg_bin "television"` is called
+- **THEN** the function returns `tv`
+
+#### Scenario: tickrs listed in array
+
+- **WHEN** the install script is loaded
+- **THEN** the `BREW_PACKAGES` array contains `tickrs`
+
+#### Scenario: tickrs maps to its own binary name
+
+- **WHEN** `pkg_bin "tickrs"` is called
+- **THEN** the function returns `tickrs` (via the default identity mapping)
+
+#### Scenario: ticker listed in array
+
+- **WHEN** the install script is loaded
+- **THEN** the `BREW_PACKAGES` array contains `ticker`
+
+#### Scenario: ticker maps to its own binary name
+
+- **WHEN** `pkg_bin "ticker"` is called
+- **THEN** the function returns `ticker` (via the default identity mapping)
+
+#### Scenario: age listed in array
+
+- **WHEN** the install script is loaded
+- **THEN** the `BREW_PACKAGES` array contains `age`
+
+#### Scenario: age maps to its own binary name
+
+- **WHEN** `pkg_bin "age"` is called
+- **THEN** the function returns `age` (via the default identity mapping)
+
+#### Scenario: mole listed in array
+
+- **WHEN** the install script is loaded
+- **THEN** the `BREW_PACKAGES` array contains `mole`
+
+#### Scenario: mole maps to its own binary name
+
+- **WHEN** `pkg_bin "mole"` is called
+- **THEN** the function returns `mole` (via the default identity mapping)
+
+#### Scenario: aoe listed in array
+
+- **WHEN** the install script is loaded
+- **THEN** the `BREW_PACKAGES` array contains `aoe`
+
+#### Scenario: aoe maps to its own binary name
+
+- **WHEN** `pkg_bin "aoe"` is called
+- **THEN** the function returns `aoe` (via the default identity mapping)
+
+#### Scenario: glow listed in array
+
+- **WHEN** the install script is loaded
+- **THEN** the `BREW_PACKAGES` array contains `glow`
+
+#### Scenario: glow maps to its own binary name
+
+- **WHEN** `pkg_bin "glow"` is called
+- **THEN** the function returns `glow` (via the default identity mapping)
+
+#### Scenario: mdfried listed in array
+
+- **WHEN** the install script is loaded
+- **THEN** the `BREW_PACKAGES` array contains `mdfried`
+
+#### Scenario: mdfried maps to its own binary name
+
+- **WHEN** `pkg_bin "mdfried"` is called
+- **THEN** the function returns `mdfried` (via the default identity mapping)
+
+### Requirement: Non-macOS fallback includes all new packages
+
+The non-macOS branch of the install script SHALL list its brew packages in the manual
+installation instructions. opencode SHALL be listed under the official-script install
+instructions (not the brew package list), consistent with the macOS branch.
+
+The CLI-tools list in the non-macOS branch SHALL include `glow` and `mdfried`. The `mdfried` entry
+SHALL note that its image / `mermaid` / Big-Header rendering requires a terminal that supports a
+graphics protocol (Kitty, iTerm2, or Sixel) and otherwise degrades to character rendering.
+
+#### Scenario: Non-macOS instructions are complete
+
+- **WHEN** the script runs on a non-macOS system
+- **THEN** the printed instructions include `fd`, `gh`, `git-delta`, `git`, `tmux`, `uv`, and `wget` alongside the original packages (excluding `mas`, which is macOS-only), and opencode appears under the official-installer instructions (`curl -fsSL https://opencode.ai/install | bash`) rather than the brew package list
+
+#### Scenario: New Markdown viewers listed in non-macOS instructions
+
+- **WHEN** the script runs on a non-macOS system
+- **THEN** the printed CLI-tools instructions include `glow` and `mdfried`, with `mdfried` annotated as requiring a graphics-capable terminal

--- a/openspec/changes/add-markdown-viewer/specs/markdown-viewer/spec.md
+++ b/openspec/changes/add-markdown-viewer/specs/markdown-viewer/spec.md
@@ -31,10 +31,20 @@ A chezmoi-managed `glow.yml` SHALL be provided at `dot_config/glow/glow.yml`, la
 Catppuccin Mocha palette, a word-wrap width, the pager enabled, and mouse support enabled. Each
 setting SHALL carry an explanatory comment.
 
+Because on macOS glow resolves its config under `~/Library/Preferences/glow/` when `XDG_CONFIG_HOME`
+is unset, `dot_zshrc.tmpl` SHALL export `XDG_CONFIG_HOME="$HOME/.config"` (before any tool init) so
+glow — and other XDG-respecting tools the repo configures under `~/.config` — honor the
+chezmoi-managed config.
+
 #### Scenario: Config applied
 
 - **WHEN** `chezmoi apply` runs
 - **THEN** `~/.config/glow/glow.yml` exists and glow uses its style, width, pager, and mouse settings
+
+#### Scenario: glow honors the XDG config location on macOS
+
+- **WHEN** a shell with `XDG_CONFIG_HOME` exported to `~/.config` runs glow
+- **THEN** glow loads `~/.config/glow/glow.yml` rather than the macOS-default `~/Library/Preferences/glow/glow.yml`
 
 ### Requirement: mdview dispatcher selects the viewer when opening a document
 

--- a/openspec/changes/add-markdown-viewer/specs/markdown-viewer/spec.md
+++ b/openspec/changes/add-markdown-viewer/specs/markdown-viewer/spec.md
@@ -56,8 +56,9 @@ Its behavior SHALL be:
 - When the `MD_VIEWER` environment variable is set to `glow` or `mdfried`, it SHALL use that tool
   unconditionally; the default (`auto` or unset) selects automatically.
 - In auto mode it SHALL use `mdfried` only when the document contains embedded images or a
-  `mermaid` code fence AND the terminal supports a graphics protocol (Kitty/iTerm2/Sixel, including
-  inside tmux when passthrough is enabled); otherwise it SHALL use `glow`'s pager.
+  `mermaid` code fence AND the terminal supports a graphics protocol (Kitty/iTerm2/Sixel) — inside
+  tmux this means passthrough is enabled AND a graphics-capable terminal is detected (passthrough
+  alone is insufficient); otherwise it SHALL use `glow`'s pager.
 
 #### Scenario: Piped output renders to stdout
 

--- a/openspec/changes/add-markdown-viewer/specs/markdown-viewer/spec.md
+++ b/openspec/changes/add-markdown-viewer/specs/markdown-viewer/spec.md
@@ -1,0 +1,150 @@
+## ADDED Requirements
+
+### Requirement: glow is the default terminal Markdown viewer
+
+`glow` SHALL be the default tool for viewing rendered Markdown in the terminal. Installed via
+`BREW_PACKAGES` (see `cli-tool-expansion`), it serves two roles: a TUI to browse `.md` files in a
+directory with a `less`-style pager, and a CLI to render a single file, stdin, or a remote
+URL/GitHub repo with styling. `glow` is the only adopted viewer that renders to stdout, so it is
+also the sole tool usable in preview panes. It complements — and SHALL NOT replace — the existing
+`cat`→`bat` alias, which highlights Markdown *source* rather than rendering it.
+
+#### Scenario: Render a file
+
+- **WHEN** the user runs `glow <file>.md`
+- **THEN** the document is rendered with styling (headings, lists, tables, code blocks)
+
+#### Scenario: Browse a directory
+
+- **WHEN** the user runs `glow` with no arguments
+- **THEN** glow opens a TUI listing the Markdown files under the current directory for selection and reading
+
+#### Scenario: bat alias unchanged
+
+- **WHEN** the user runs `cat <file>.md`
+- **THEN** `bat` highlights the raw source as before; the `cat`→`bat` alias is not repointed to glow
+
+### Requirement: glow configuration is managed by chezmoi
+
+A chezmoi-managed `glow.yml` SHALL be provided at `dot_config/glow/glow.yml`, landing at
+`~/.config/glow/glow.yml`. It SHALL set a dark rendering style consistent with the repo's
+Catppuccin Mocha palette, a word-wrap width, the pager enabled, and mouse support enabled. Each
+setting SHALL carry an explanatory comment.
+
+#### Scenario: Config applied
+
+- **WHEN** `chezmoi apply` runs
+- **THEN** `~/.config/glow/glow.yml` exists and glow uses its style, width, pager, and mouse settings
+
+### Requirement: mdview dispatcher selects the viewer when opening a document
+
+`dot_zshrc.tmpl` SHALL define an `mdview` shell function that centralizes the choice of viewer when
+*opening* a Markdown document, so every surface in the stack delegates the decision to one place.
+Its behavior SHALL be:
+
+- When stdout is not a TTY (piped), it SHALL render to stdout with `glow` (no full-screen TUI).
+- When the `MD_VIEWER` environment variable is set to `glow` or `mdfried`, it SHALL use that tool
+  unconditionally; the default (`auto` or unset) selects automatically.
+- In auto mode it SHALL use `mdfried` only when the document contains embedded images or a
+  `mermaid` code fence AND the terminal supports a graphics protocol (Kitty/iTerm2/Sixel, including
+  inside tmux when passthrough is enabled); otherwise it SHALL use `glow`'s pager.
+
+#### Scenario: Piped output renders to stdout
+
+- **WHEN** `mdview <file>.md` is run with stdout not attached to a TTY (e.g. piped)
+- **THEN** the document is rendered to stdout via `glow` rather than launching a full-screen TUI
+
+#### Scenario: Override forces a viewer
+
+- **WHEN** `MD_VIEWER=glow mdview <file>.md` is run on a document with images/mermaid in a graphics-capable terminal
+- **THEN** `glow` is used despite the document being graphics-rich
+
+#### Scenario: Auto selects mdfried for graphics-rich docs
+
+- **WHEN** `mdview <file>.md` is run in auto mode, the file contains a `mermaid` fence or an embedded image, and the terminal is graphics-capable
+- **THEN** `mdfried` is launched
+
+#### Scenario: Auto selects glow for prose
+
+- **WHEN** `mdview <file>.md` is run in auto mode on a document with no images or `mermaid`
+- **THEN** `glow`'s pager is used
+
+#### Scenario: Auto falls back to glow without graphics support
+
+- **WHEN** `mdview <file>.md` is run in auto mode on a graphics-rich document but the terminal lacks graphics support
+- **THEN** `glow`'s pager is used instead of `mdfried`
+
+### Requirement: md shell function
+
+`dot_zshrc.tmpl` SHALL define an `md` function that delegates to `mdview`: with no arguments it
+SHALL launch glow's directory-browsing TUI in the current directory; with one or more arguments it
+SHALL open the given file(s) through `mdview`.
+
+#### Scenario: md with a file opens via mdview
+
+- **WHEN** the user runs `md <file>.md`
+- **THEN** the file is opened through `mdview` (which selects glow or mdfried per its policy)
+
+#### Scenario: md with no arguments browses
+
+- **WHEN** the user runs `md`
+- **THEN** glow's directory-browsing TUI opens for the current directory
+
+### Requirement: fzf previews render Markdown with glow
+
+The `fzf` preview commands (`FZF_DEFAULT_OPTS` and `FZF_CTRL_T_OPTS`) SHALL render `*.md` and
+`*.markdown` files with `glow` while continuing to preview all other files with `bat`. Because
+`dot_zshrc.tmpl` is a chezmoi template, the preview command strings SHALL NOT contain literal `{{`
+or `}}` sequences (which chezmoi interprets as template delimiters); only `fzf`'s single-brace
+`{}` placeholder and shell parameter expansions are permitted.
+
+#### Scenario: Markdown file preview
+
+- **WHEN** a `.md` file is focused in an `fzf` picker that uses the configured preview
+- **THEN** the preview shows the document rendered by `glow`
+
+#### Scenario: Non-Markdown file preview unchanged
+
+- **WHEN** a non-Markdown file is focused
+- **THEN** the preview shows `bat` output as before
+
+#### Scenario: Template renders cleanly
+
+- **WHEN** `dot_zshrc.tmpl` is rendered by chezmoi
+- **THEN** the resulting `~/.zshrc` contains the intended preview commands with no stray template artifacts
+
+### Requirement: lazygit opens Markdown via mdview
+
+`dot_config/lazygit/config.yml` SHALL define a `customCommands` entry in the `files` context that
+opens the selected file through `mdview` as a subprocess (so the viewer takes over the terminal and
+returns to lazygit on exit). This views a whole document; it SHALL NOT alter how lazygit renders
+diffs (which remain `delta`'s responsibility).
+
+#### Scenario: Open selected Markdown file from lazygit
+
+- **WHEN** the user selects a `.md` file in lazygit's Files panel and triggers the custom command
+- **THEN** the file opens rendered via `mdview` in a subprocess, and lazygit resumes on exit
+
+#### Scenario: Diff rendering unchanged
+
+- **WHEN** the user views a file's diff in lazygit
+- **THEN** the diff is still rendered by `delta`, not the Markdown viewer
+
+### Requirement: mdfried for graphics-rich Markdown
+
+`mdfried` SHALL be available (via `BREW_PACKAGES`) as the companion viewer for Markdown documents
+containing embedded images or `mermaid` diagrams, which `glow` renders as alt-text / raw fenced
+code. It renders these graphically (and Big Headers) using a terminal graphics protocol. Its rich
+rendering SHALL be understood to depend on a graphics-capable terminal (Kitty/iTerm2/Sixel —
+satisfied by the repo's Ghostty, and inside tmux only with passthrough enabled); where unavailable
+it degrades to character rendering.
+
+#### Scenario: Mermaid and images render
+
+- **WHEN** the user opens a `.md` containing a `mermaid` block and an embedded image with `mdfried` in a graphics-capable terminal
+- **THEN** the diagram and image are drawn (not shown as raw code or alt-text)
+
+#### Scenario: Graceful degradation
+
+- **WHEN** `mdfried` runs without terminal graphics support
+- **THEN** it falls back to character rendering rather than failing

--- a/openspec/changes/add-markdown-viewer/specs/television-markdown-channel/spec.md
+++ b/openspec/changes/add-markdown-viewer/specs/television-markdown-channel/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: markdown cable channel
+
+`dot_config/television/cable/markdown.toml` SHALL define a `television` cable channel named
+`markdown` whose source lists Markdown files (`.md` and `.markdown`) under the working directory
+via `fd`. Its `[metadata]` SHALL declare its requirements (`fd`, `glow`).
+
+#### Scenario: Channel lists Markdown files
+
+- **WHEN** the user opens the `markdown` channel in `television`
+- **THEN** the candidate list is populated with `.md`/`.markdown` files found via `fd`
+
+#### Scenario: Channel is discoverable
+
+- **WHEN** the user opens television's remote-control channel list
+- **THEN** the `markdown` channel appears with its description
+
+### Requirement: Channel preview renders with glow
+
+The `markdown` channel's `[preview]` command SHALL render the focused file with `glow` (a stdout
+renderer suitable for a preview pane), with an explicit preview panel size as the existing
+`rg-edit` channel does.
+
+#### Scenario: Preview shows rendered Markdown
+
+- **WHEN** a file is focused in the `markdown` channel
+- **THEN** the preview pane shows it rendered by `glow`
+
+### Requirement: Enter opens the file via mdview
+
+The `markdown` channel SHALL bind Enter to an action that opens the selected file through `mdview`,
+so the viewer choice (glow vs mdfried) follows the central dispatcher policy rather than being
+hard-coded in the channel.
+
+#### Scenario: Opening a selection
+
+- **WHEN** the user presses Enter on a file in the `markdown` channel
+- **THEN** the file is opened through `mdview`

--- a/openspec/changes/add-markdown-viewer/specs/tmux-config/spec.md
+++ b/openspec/changes/add-markdown-viewer/specs/tmux-config/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Graphics protocol passthrough
+
+`dot_tmux.conf` SHALL include `set -g allow-passthrough on` so terminal graphics escape sequences
+(the Kitty graphics protocol used by `mdfried`, and similar) pass through tmux to the application
+running inside a pane. Without it, image/`mermaid`/Big-Header rendering inside tmux is intercepted
+and degrades to character rendering. Per the existing comment-style requirement, the setting SHALL
+carry an explanatory comment above it.
+
+#### Scenario: Setting present in config
+
+- **WHEN** `dot_tmux.conf` is applied via chezmoi
+- **THEN** tmux has `allow-passthrough` set to `on`
+
+#### Scenario: mdfried graphics survive inside tmux
+
+- **WHEN** `mdfried` renders an embedded image or `mermaid` diagram in a pane inside tmux running under a graphics-capable terminal
+- **THEN** the graphics are drawn rather than being stripped by tmux
+
+#### Scenario: Passthrough setting comment
+
+- **WHEN** reading `dot_tmux.conf`
+- **THEN** `set -g allow-passthrough on` has a comment above it describing its purpose (let terminal graphics protocols reach applications inside tmux)

--- a/openspec/changes/add-markdown-viewer/tasks.md
+++ b/openspec/changes/add-markdown-viewer/tasks.md
@@ -1,0 +1,54 @@
+## 1. Install the viewers (brew)
+
+- [ ] 1.1 Add `glow` and `mdfried` to the `BREW_PACKAGES` array in `run_onchange_install-packages.sh.tmpl` (both `homebrew/core` — no `BREW_TAPS` entry needed).
+- [ ] 1.2 Confirm no `pkg_bin()` change is needed: `glow`→`glow`, `mdfried`→`mdfried` fall through the default identity case.
+- [ ] 1.3 Add `glow` and `mdfried` to the macOS completion-message tool list (the `info "  CLI tools: ..."` line).
+- [ ] 1.4 Add `glow` and `mdfried` to the non-macOS fallback `CLI tools:` list, annotating `mdfried` as needing a Kitty/iTerm2/Sixel-capable terminal for images/mermaid.
+
+## 2. glow config (glow.yml)
+
+- [ ] 2.1 Create `dot_config/glow/glow.yml` with: `style: dark`, a word-wrap `width` (e.g. 120), `pager: true`, `mouse: true`, `all: false`. Comment each key.
+- [ ] 2.2 Verify `chezmoi apply` lands it at `~/.config/glow/glow.yml` and glow picks it up.
+
+## 3. Shell: mdview dispatcher + md + fzf preview (dot_zshrc.tmpl)
+
+- [ ] 3.1 Add the `mdview` function: non-TTY stdout → `glow` (stdout); honor `MD_VIEWER=glow|mdfried`; auto → `mdfried` when the file has `![](…)` images or a ```` ```mermaid ```` fence AND the terminal is graphics-capable (Ghostty/Kitty/iTerm; tmux only when passthrough on), else `glow -p`.
+- [ ] 3.2 Add the `md` function near the `bat` aliases: no args → `glow` (browse TUI); with args → `mdview "$@"`. Leave the `cat`→`bat` alias untouched.
+- [ ] 3.3 Route Markdown to glow in the `fzf` preview commands (`FZF_DEFAULT_OPTS`, `FZF_CTRL_T_OPTS`): `*.md`/`*.markdown` → `glow` (e.g. `glow -s auto`), else the existing `bat --color=always --style=numbers --line-range=:500` command.
+- [ ] 3.4 **chezmoi guard**: ensure the new preview strings contain no literal `{{`/`}}`; use only `fzf`'s `{}` and bash `${f##*.}`-style expansions.
+- [ ] 3.5 `chezmoi execute-template`/`chezmoi diff` on `dot_zshrc.tmpl`; confirm `~/.zshrc` renders with no stray artifacts; open a fresh shell and confirm `mdview`, `md`, and the fzf preview work.
+
+## 4. tmux graphics passthrough
+
+- [ ] 4.1 Add `set -g allow-passthrough on` to `dot_tmux.conf` with a descriptive comment above it (matching the file's comment style).
+- [ ] 4.2 `chezmoi apply`, reload tmux, and confirm `tmux show -g allow-passthrough` reports `on`.
+
+## 5. lazygit: open Markdown via mdview
+
+- [ ] 5.1 Add a `customCommands` entry to `dot_config/lazygit/config.yml`: `context: files`, a key (e.g. `g`), `command: mdview {{.SelectedFile.Name}}`, `subprocess: true`, with a `description`.
+- [ ] 5.2 Confirm in lazygit: selecting a `.md` in the Files panel and pressing the key opens it via `mdview`, and lazygit resumes on exit. Diff view still uses `delta`.
+
+## 6. Television markdown channel
+
+- [ ] 6.1 Create `dot_config/television/cable/markdown.toml` modeled on `rg-edit.toml`: `[metadata]` name `markdown`, `requirements = ["fd", "glow"]`; `[source] command = "fd -e md -e markdown --type f"`; `[preview] command` renders with `glow` (e.g. `glow -s auto '{}'`); `[ui] preview_panel = { size = 60 }`.
+- [ ] 6.2 `[keybindings] enter = "actions:open"` + `[actions.open]` that opens the file via `mdview '{}'` (`mode = "execute"`).
+- [ ] 6.3 Confirm the `markdown` channel appears in `tv` and that preview + open work on a real `.md`.
+
+## 7. Verify mdfried + dispatcher (DOT-32)
+
+- [ ] 7.1 In Ghostty (outside and inside tmux), open a `.md` with a `mermaid` block and an embedded image via `mdview <file>`; confirm the dispatcher picks `mdfried` and the diagram/image render (not raw).
+- [ ] 7.2 Open a prose-only `.md` via `mdview`; confirm it picks `glow -p`.
+- [ ] 7.3 Confirm `MD_VIEWER=glow mdview <visual.md>` forces glow, and `MD_VIEWER=mdfried mdview <prose.md>` forces mdfried.
+- [ ] 7.4 Confirm graceful fallback: `mdview` where graphics are unavailable (e.g. piped, or a non-graphics terminal) uses glow/stdout instead of erroring.
+
+## 8. Docs
+
+- [ ] 8.1 README "What's Included": add `glow` (terminal Markdown viewer — TUI browse + CLI render) and `mdfried` (Markdown viewer with inline images / mermaid / Big Headers) rows under CLI Tools. Use the `/docs:readme` skill.
+- [ ] 8.2 Manual (`docs/manual.html`): document `md`/`mdview`, the `MD_VIEWER` knob, the lazygit key, and the `markdown` television channel. Use the `/docs:manual` skill.
+
+## 9. Verify & close
+
+- [ ] 9.1 Re-run `run_onchange_install-packages.sh.tmpl` (or `chezmoi apply`): both tools install and idempotently skip on re-run.
+- [ ] 9.2 End-to-end: `glow` browse, `glow README.md` render, `mdview`/`md`, `.md` fzf preview, `tv markdown` channel, lazygit open, mdfried-in-tmux graphics.
+- [ ] 9.3 `openspec validate add-markdown-viewer --strict` passes.
+- [ ] 9.4 Update Linear DOT-35 and DOT-32 with the decision (glow default + mdfried companion; mdcat/frogmouth rejected; diffs out of scope) and close them.

--- a/openspec/changes/add-markdown-viewer/tasks.md
+++ b/openspec/changes/add-markdown-viewer/tasks.md
@@ -1,54 +1,55 @@
 ## 1. Install the viewers (brew)
 
-- [ ] 1.1 Add `glow` and `mdfried` to the `BREW_PACKAGES` array in `run_onchange_install-packages.sh.tmpl` (both `homebrew/core` — no `BREW_TAPS` entry needed).
-- [ ] 1.2 Confirm no `pkg_bin()` change is needed: `glow`→`glow`, `mdfried`→`mdfried` fall through the default identity case.
-- [ ] 1.3 Add `glow` and `mdfried` to the macOS completion-message tool list (the `info "  CLI tools: ..."` line).
-- [ ] 1.4 Add `glow` and `mdfried` to the non-macOS fallback `CLI tools:` list, annotating `mdfried` as needing a Kitty/iTerm2/Sixel-capable terminal for images/mermaid.
+- [x] 1.1 Add `glow` and `mdfried` to the `BREW_PACKAGES` array in `run_onchange_install-packages.sh.tmpl` (both `homebrew/core` — no `BREW_TAPS` entry needed).
+- [x] 1.2 Confirm no `pkg_bin()` change is needed: `glow`→`glow`, `mdfried`→`mdfried` fall through the default identity case.
+- [x] 1.3 Add `glow` and `mdfried` to the macOS completion-message tool list (the `info "  CLI tools: ..."` line).
+- [x] 1.4 Add `glow` and `mdfried` to the non-macOS fallback `CLI tools:` list, annotating `mdfried` as needing a Kitty/iTerm2/Sixel-capable terminal for images/mermaid.
 
 ## 2. glow config (glow.yml)
 
-- [ ] 2.1 Create `dot_config/glow/glow.yml` with: `style: dark`, a word-wrap `width` (e.g. 120), `pager: true`, `mouse: true`, `all: false`. Comment each key.
-- [ ] 2.2 Verify `chezmoi apply` lands it at `~/.config/glow/glow.yml` and glow picks it up.
+- [x] 2.1 Create `dot_config/glow/glow.yml` with: `style: dark`, a word-wrap `width` (e.g. 120), `pager: true`, `mouse: true`, `all: false`. Comment each key.
+- [x] 2.2 Verify `chezmoi apply` lands it at `~/.config/glow/glow.yml` and glow picks it up. _(Path mapping confirmed by chezmoi convention. **Discovered**: macOS glow ignores `~/.config` unless `XDG_CONFIG_HOME` is set — fixed in 2.3. Verified empirically (glow 2.1.2): with `XDG_CONFIG_HOME=~/.config`, glow loads `~/.config/glow/glow.yml`.)_
+- [x] 2.3 Export `XDG_CONFIG_HOME="$HOME/.config"` early in `dot_zshrc.tmpl` (before tool inits) so macOS honors `~/.config/glow/glow.yml` (and `~/.config/lazygit/`, television, …). Template re-renders clean; `zsh -n` passes.
 
 ## 3. Shell: mdview dispatcher + md + fzf preview (dot_zshrc.tmpl)
 
-- [ ] 3.1 Add the `mdview` function: non-TTY stdout → `glow` (stdout); honor `MD_VIEWER=glow|mdfried`; auto → `mdfried` when the file has `![](…)` images or a ```` ```mermaid ```` fence AND the terminal is graphics-capable (Ghostty/Kitty/iTerm; tmux only when passthrough on), else `glow -p`.
-- [ ] 3.2 Add the `md` function near the `bat` aliases: no args → `glow` (browse TUI); with args → `mdview "$@"`. Leave the `cat`→`bat` alias untouched.
-- [ ] 3.3 Route Markdown to glow in the `fzf` preview commands (`FZF_DEFAULT_OPTS`, `FZF_CTRL_T_OPTS`): `*.md`/`*.markdown` → `glow` (e.g. `glow -s auto`), else the existing `bat --color=always --style=numbers --line-range=:500` command.
-- [ ] 3.4 **chezmoi guard**: ensure the new preview strings contain no literal `{{`/`}}`; use only `fzf`'s `{}` and bash `${f##*.}`-style expansions.
-- [ ] 3.5 `chezmoi execute-template`/`chezmoi diff` on `dot_zshrc.tmpl`; confirm `~/.zshrc` renders with no stray artifacts; open a fresh shell and confirm `mdview`, `md`, and the fzf preview work.
+- [x] 3.1 Add the `mdview` function: non-TTY stdout → `glow` (stdout); honor `MD_VIEWER=glow|mdfried`; auto → `mdfried` when the file has `![](…)` images or a ```` ```mermaid ```` fence AND the terminal is graphics-capable (Ghostty/Kitty/iTerm; tmux only when passthrough on), else `glow -p`. _(All 9 branch combinations verified under a real pty with stubbed viewers.)_
+- [x] 3.2 Add the `md` function near the `bat` aliases: no args → `glow` (browse TUI); with args → `mdview "$@"`. Leave the `cat`→`bat` alias untouched.
+- [x] 3.3 Route Markdown to glow in the `fzf` preview commands (`FZF_DEFAULT_OPTS`, `FZF_CTRL_T_OPTS`): `*.md`/`*.markdown` → `glow` (e.g. `glow -s auto`), else the existing `bat --color=always --style=numbers --line-range=:500` command.
+- [x] 3.4 **chezmoi guard**: ensure the new preview strings contain no literal `{{`/`}}`; use only `fzf`'s `{}` and bash `${f##*.}`-style expansions. _(Used fzf's `{}` directly in a `case` — no `$`-vars, no double braces; verified clean.)_
+- [x] 3.5 `chezmoi execute-template`/`chezmoi diff` on `dot_zshrc.tmpl`; confirm `~/.zshrc` renders with no stray artifacts; open a fresh shell and confirm `mdview`, `md`, and the fzf preview work. _(execute-template render + `zsh -n` syntax + dispatcher logic verified; live fresh-shell use pending `brew install glow`.)_
 
 ## 4. tmux graphics passthrough
 
-- [ ] 4.1 Add `set -g allow-passthrough on` to `dot_tmux.conf` with a descriptive comment above it (matching the file's comment style).
-- [ ] 4.2 `chezmoi apply`, reload tmux, and confirm `tmux show -g allow-passthrough` reports `on`.
+- [x] 4.1 Add `set -g allow-passthrough on` to `dot_tmux.conf` with a descriptive comment above it (matching the file's comment style).
+- [ ] 4.2 `chezmoi apply`, reload tmux, and confirm `tmux show -g allow-passthrough` reports `on`. _(Pending source sync + tmux reload; setting added to config.)_
 
 ## 5. lazygit: open Markdown via mdview
 
-- [ ] 5.1 Add a `customCommands` entry to `dot_config/lazygit/config.yml`: `context: files`, a key (e.g. `g`), `command: mdview {{.SelectedFile.Name}}`, `subprocess: true`, with a `description`.
-- [ ] 5.2 Confirm in lazygit: selecting a `.md` in the Files panel and pressing the key opens it via `mdview`, and lazygit resumes on exit. Diff view still uses `delta`.
+- [x] 5.1 Add a `customCommands` entry to `dot_config/lazygit/config.yml`: `context: files`, a key (e.g. `g`), `command: mdview {{.SelectedFile.Name}}`, `subprocess: true`, with a `description`.
+- [ ] 5.2 Confirm in lazygit: selecting a `.md` in the Files panel and pressing the key opens it via `mdview`, and lazygit resumes on exit. Diff view still uses `delta`. _(Config valid YAML; with the 2.3 XDG fix, `lazygit --print-config-dir` now resolves `~/.config/lazygit` so the customCommand is read. Interactive key-press confirm pending source sync.)_
 
 ## 6. Television markdown channel
 
-- [ ] 6.1 Create `dot_config/television/cable/markdown.toml` modeled on `rg-edit.toml`: `[metadata]` name `markdown`, `requirements = ["fd", "glow"]`; `[source] command = "fd -e md -e markdown --type f"`; `[preview] command` renders with `glow` (e.g. `glow -s auto '{}'`); `[ui] preview_panel = { size = 60 }`.
-- [ ] 6.2 `[keybindings] enter = "actions:open"` + `[actions.open]` that opens the file via `mdview '{}'` (`mode = "execute"`).
-- [ ] 6.3 Confirm the `markdown` channel appears in `tv` and that preview + open work on a real `.md`.
+- [x] 6.1 Create `dot_config/television/cable/markdown.toml` modeled on `rg-edit.toml`: `[metadata]` name `markdown`, `requirements = ["fd", "glow"]`; `[source] command = "fd -e md -e markdown --type f"`; `[preview] command` renders with `glow` (e.g. `glow -s auto '{}'`); `[ui] preview_panel = { size = 60 }`.
+- [x] 6.2 `[keybindings] enter = "actions:open"` + `[actions.open]` that opens the file via `mdview '{}'` (`mode = "execute"`).
+- [ ] 6.3 Confirm the `markdown` channel appears in `tv` and that preview + open work on a real `.md`. _(Channel parses + appears in `tv list-channels`; live preview/open pending `brew install glow`.)_
 
 ## 7. Verify mdfried + dispatcher (DOT-32)
 
-- [ ] 7.1 In Ghostty (outside and inside tmux), open a `.md` with a `mermaid` block and an embedded image via `mdview <file>`; confirm the dispatcher picks `mdfried` and the diagram/image render (not raw).
-- [ ] 7.2 Open a prose-only `.md` via `mdview`; confirm it picks `glow -p`.
-- [ ] 7.3 Confirm `MD_VIEWER=glow mdview <visual.md>` forces glow, and `MD_VIEWER=mdfried mdview <prose.md>` forces mdfried.
-- [ ] 7.4 Confirm graceful fallback: `mdview` where graphics are unavailable (e.g. piped, or a non-graphics terminal) uses glow/stdout instead of erroring.
+- [ ] 7.1 In Ghostty (outside and inside tmux), open a `.md` with a `mermaid` block and an embedded image via `mdview <file>`; confirm the dispatcher picks `mdfried` and the diagram/image render (not raw). _(Selection logic verified under a real pty; live graphics rendering pending `brew install mdfried` + Ghostty.)_
+- [ ] 7.2 Open a prose-only `.md` via `mdview`; confirm it picks `glow -p`. _(Logic verified — prose+graphics → glow; live pending `brew install glow`.)_
+- [ ] 7.3 Confirm `MD_VIEWER=glow mdview <visual.md>` forces glow, and `MD_VIEWER=mdfried mdview <prose.md>` forces mdfried. _(Both override paths verified under a real pty; live pending install.)_
+- [ ] 7.4 Confirm graceful fallback: `mdview` where graphics are unavailable (e.g. piped, or a non-graphics terminal) uses glow/stdout instead of erroring. _(Piped→glow-stdout and no-graphics→glow verified under a real pty; live pending install.)_
 
 ## 8. Docs
 
-- [ ] 8.1 README "What's Included": add `glow` (terminal Markdown viewer — TUI browse + CLI render) and `mdfried` (Markdown viewer with inline images / mermaid / Big Headers) rows under CLI Tools. Use the `/docs:readme` skill.
-- [ ] 8.2 Manual (`docs/manual.html`): document `md`/`mdview`, the `MD_VIEWER` knob, the lazygit key, and the `markdown` television channel. Use the `/docs:manual` skill.
+- [x] 8.1 README "What's Included": add `glow` (terminal Markdown viewer — TUI browse + CLI render) and `mdfried` (Markdown viewer with inline images / mermaid / Big Headers) rows under CLI Tools. Use the `/docs:readme` skill.
+- [x] 8.2 Manual (`docs/manual.html`): document `md`/`mdview`, the `MD_VIEWER` knob, the lazygit key, and the `markdown` television channel. Use the `/docs:manual` skill.
 
 ## 9. Verify & close
 
-- [ ] 9.1 Re-run `run_onchange_install-packages.sh.tmpl` (or `chezmoi apply`): both tools install and idempotently skip on re-run.
-- [ ] 9.2 End-to-end: `glow` browse, `glow README.md` render, `mdview`/`md`, `.md` fzf preview, `tv markdown` channel, lazygit open, mdfried-in-tmux graphics.
-- [ ] 9.3 `openspec validate add-markdown-viewer --strict` passes.
-- [ ] 9.4 Update Linear DOT-35 and DOT-32 with the decision (glow default + mdfried companion; mdcat/frogmouth rejected; diffs out of scope) and close them.
+- [x] 9.1 Re-run `run_onchange_install-packages.sh.tmpl` (or `chezmoi apply`): both tools install and idempotently skip on re-run. _(`brew install glow mdfried` succeeded — glow 2.1.2, mdfried 0.22.4 on PATH. Idempotent skip is the same `command -v "$bin"` pre-scan that gates all 26 existing packages; both now resolve, so a re-run skips them.)_
+- [ ] 9.2 End-to-end: `glow` browse, `glow README.md` render, `mdview`/`md`, `.md` fzf preview, `tv markdown` channel, lazygit open, mdfried-in-tmux graphics. _(**Verified here**: `glow` renders, `mdview` piped→glow renders, `.md`→glow vs other→bat routing, `tv list-channels` shows `markdown`. **Pending hands-on** (interactive/graphics): `glow` browse TUI, live `tv markdown` open, lazygit `g`, mdfried images/mermaid in Ghostty+tmux.)_
+- [x] 9.3 `openspec validate add-markdown-viewer --strict` passes.
+- [~] 9.4 Update Linear DOT-35 and DOT-32 with the decision (glow default + mdfried companion; mdcat/frogmouth rejected; diffs out of scope) and close them. _(Both updated with the decision comment 2026-06-30; left **open** by decision — close after the branch is merged + live-verified.)_

--- a/run_onchange_install-packages.sh.tmpl
+++ b/run_onchange_install-packages.sh.tmpl
@@ -1148,7 +1148,7 @@ info "    - age: brew install age (or use your distro's package manager, e.g. ap
 info "    - opencode: curl -fsSL https://opencode.ai/install | bash  (official installer; installs to ~/.opencode/bin — add it to PATH)"
 info "    - CodeRabbit: curl -fsSL https://cli.coderabbit.ai/install.sh | sh  (official installer; installs to ~/.local/bin — auth on first use)"
 info "    - aoe: cargo install aoe (Linux supported by upstream; brew is macOS-only)"
-info "    - glow: brew install glow (or use your distro's package manager / go install)"
+info "    - glow: brew install glow (or your distro's package manager, or 'go install github.com/charmbracelet/glow@latest')"
 info "    - mdfried: brew install mdfried (or cargo install mdfried); its image / mermaid / Big-Header rendering needs a terminal with a graphics protocol (Kitty, iTerm2, or Sixel) and otherwise degrades to character rendering"
 info "  Fonts: Hack Nerd Font + JetBrainsMono Nerd Font (https://www.nerdfonts.com/)"
 info "  Shell: oh-my-zsh (https://ohmyz.sh/)"

--- a/run_onchange_install-packages.sh.tmpl
+++ b/run_onchange_install-packages.sh.tmpl
@@ -77,7 +77,7 @@ fi
 # Group 1: Brew packages
 # ------------------------------------------------------------------
 BREW_TAPS=(tarkah/tickrs achannarasappa/tap)
-BREW_PACKAGES=(git git-delta starship eza bat zoxide atuin fzf ripgrep lazygit worktrunk terminal-notifier fd direnv beads gh tmux uv mas wget television tickrs ticker age mole aoe)
+BREW_PACKAGES=(git git-delta starship eza bat zoxide atuin fzf ripgrep lazygit worktrunk terminal-notifier fd direnv beads gh tmux uv mas wget television tickrs ticker age mole aoe glow mdfried)
 
 # Resolve the binary name for a given package (bash 3 compatible)
 pkg_bin() {
@@ -1138,7 +1138,7 @@ info "This system is not macOS. Automatic installation is not supported."
 info ""
 info "Please install the following packages manually:"
 info ""
-info "  CLI tools: git, git-delta, starship, eza, bat, zoxide, atuin, fzf, ripgrep, lazygit, worktrunk, fd, direnv, beads, gh, tmux, uv, wget, tickrs, ticker, age, aoe"
+info "  CLI tools: git, git-delta, starship, eza, bat, zoxide, atuin, fzf, ripgrep, lazygit, worktrunk, fd, direnv, beads, gh, tmux, uv, wget, tickrs, ticker, age, aoe, glow, mdfried"
 info "    - terminal-notifier: macOS-only (skip on Linux)"
 info "    - fd: on Debian/Ubuntu install fd-find; binary is fdfind — symlink with: ln -s \$(command -v fdfind) ~/.local/bin/fd"
 info "    - worktrunk: brew install worktrunk  OR  cargo install worktrunk"
@@ -1148,6 +1148,8 @@ info "    - age: brew install age (or use your distro's package manager, e.g. ap
 info "    - opencode: curl -fsSL https://opencode.ai/install | bash  (official installer; installs to ~/.opencode/bin — add it to PATH)"
 info "    - CodeRabbit: curl -fsSL https://cli.coderabbit.ai/install.sh | sh  (official installer; installs to ~/.local/bin — auth on first use)"
 info "    - aoe: cargo install aoe (Linux supported by upstream; brew is macOS-only)"
+info "    - glow: brew install glow (or use your distro's package manager / go install)"
+info "    - mdfried: brew install mdfried (or cargo install mdfried); its image / mermaid / Big-Header rendering needs a terminal with a graphics protocol (Kitty, iTerm2, or Sixel) and otherwise degrades to character rendering"
 info "  Fonts: Hack Nerd Font + JetBrainsMono Nerd Font (https://www.nerdfonts.com/)"
 info "  Shell: oh-my-zsh (https://ohmyz.sh/)"
 info "  Zsh plugins:"
@@ -1188,7 +1190,7 @@ fi
 
 info "Installation complete!"
 {{ if eq .chezmoi.os "darwin" -}}
-info "  CLI tools: git, git-delta, starship, eza, bat, zoxide, atuin, fzf, ripgrep, lazygit, worktrunk, terminal-notifier, fd, direnv, beads, gh, tmux, uv, wget, opencode, tickrs, ticker, age, mole, aoe"
+info "  CLI tools: git, git-delta, starship, eza, bat, zoxide, atuin, fzf, ripgrep, lazygit, worktrunk, terminal-notifier, fd, direnv, beads, gh, tmux, uv, wget, opencode, tickrs, ticker, age, mole, aoe, glow, mdfried"
 {{ else -}}
-info "  CLI tools: git, git-delta, starship, eza, bat, zoxide, atuin, fzf, ripgrep, lazygit, worktrunk, fd, direnv, beads, gh, tmux, uv, wget, opencode, tickrs, ticker, age, aoe"
+info "  CLI tools: git, git-delta, starship, eza, bat, zoxide, atuin, fzf, ripgrep, lazygit, worktrunk, fd, direnv, beads, gh, tmux, uv, wget, opencode, tickrs, ticker, age, aoe, glow, mdfried"
 {{ end -}}


### PR DESCRIPTION
## Summary

Adds in-terminal Markdown rendering (OpenSpec change `add-markdown-viewer`, closes the gap behind DOT-35 / DOT-32).

- **`glow`** — default renderer: TUI browse + CLI/stdout render (the only viewer usable in preview panes).
- **`mdfried`** — graphics-rich companion: inline images, `mermaid`, Big Headers (needs a Kitty/iTerm2/Sixel terminal; inside tmux needs passthrough).
- **`mdview` dispatcher** — central policy every surface delegates to: non-TTY → glow stdout; `MD_VIEWER=glow|mdfried` override; auto picks `mdfried` for docs with images/mermaid in a graphics-capable terminal, else `glow -p`.
- Wired into **`md`**, the **`television` `markdown` channel** (Enter → mdview), a **lazygit `g` custom command** (Files → mdview), and **fzf/tv previews** (`.md`→glow, else bat).
- **tmux** `allow-passthrough on`; **`glow.yml`** (dark / width 120 / pager / mouse).
- Rejected `mdcat` (niche already covered) and `frogmouth` (not in `homebrew/core`). Diffs stay `delta`'s job (out of scope).

## Heads-up: `XDG_CONFIG_HOME` fix

Discovered during implementation: with `XDG_CONFIG_HOME` unset (the repo's state), **macOS glow and lazygit ignore `~/.config`** — glow reads `~/Library/Preferences/glow/`, lazygit reads `~/Library/Application Support/lazygit/`. So `glow.yml` and the lazygit command wouldn't load, and the existing lazygit theme was already not applied. Fixed by exporting `XDG_CONFIG_HOME="$HOME/.config"` early in `dot_zshrc.tmpl` (only `XDG_CONFIG_HOME`; data/cache dirs untouched).

## Verified (automated)

- All 9 `mdview` branch combinations under a real pty (override / auto-select / tmux passthrough gating / piped fallback)
- `chezmoi execute-template` renders clean, `zsh -n` passes, no `{{`/`}}` footgun in the fzf preview
- glow.yml/markdown.toml/lazygit YAML valid; `markdown` channel appears in `tv list-channels`
- manual HTML balanced; `openspec validate --strict` passes
- `brew install glow mdfried` OK; glow renders; `mdview` piped→glow renders; glow/lazygit resolve `~/.config` with XDG set

## Hands-on after merge + `chezmoi apply`

- [ ] tmux reload → `tmux show -g allow-passthrough` = `on`
- [ ] lazygit `g` on a `.md` opens via mdview and resumes on exit
- [ ] `tv markdown` preview + Enter open
- [ ] Ghostty (in/out of tmux): mdfried draws images/mermaid; prose → glow; `MD_VIEWER` overrides; graceful fallback
- [ ] Close DOT-35 / DOT-32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added terminal Markdown viewing with `glow` as default and `mdfried` for graphics-rich documents (images/mermaid).
  * Enabled Markdown preview/open from terminal search, the terminal file browser, Television’s Markdown channel, and Git’s file view (custom `g` key uses the renderer dispatcher).
* **Bug Fixes**
  * Improved Markdown preview routing so non-Markdown files keep the existing preview behavior.
  * Enhanced rendering support inside tmux via graphics passthrough.
* **Documentation**
  * Updated README and the manual with the new viewers, modes, and shortcuts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->