### PR TITLE
feat(config): update brew deps and adopt new features

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -2,5 +2,5 @@
 
 # Agent of Empires installs CC0 sound assets here via `aoe sounds install`.
 # They are machine-local, non-committable binaries — never let chezmoi track them.
-.agent-of-empires/sounds
-.agent-of-empires/sounds/**
+.config/agent-of-empires/sounds
+.config/agent-of-empires/sounds/**

--- a/.oxfmtignore
+++ b/.oxfmtignore
@@ -5,4 +5,4 @@ openspec/
 .husky/_/
 # chezmoi modify_ script: a POSIX shell script that carries its target's .toml
 # extension (chezmoi naming). oxfmt would parse it as TOML and corrupt it.
-private_dot_agent-of-empires/modify_private_config.toml
+dot_config/private_agent-of-empires/modify_private_config.toml

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -964,7 +964,10 @@
                             <tr>
                                 <td><code>gl</code></td>
                                 <td>
-                                    <code>git log --oneline --graph --decorate --all</code>
+                                    <code
+                                        >git log --oneline --graph --graph-lane-limit=8 --decorate
+                                        --all</code
+                                    >
                                     (overrides OMZ)
                                 </td>
                             </tr>
@@ -1014,7 +1017,7 @@
                             </tr>
                             <tr>
                                 <td><code>git lg</code></td>
-                                <td>Pretty graph log with colors and author</td>
+                                <td>Pretty graph log with colors and author (max 8 graph lanes)</td>
                             </tr>
                         </tbody>
                     </table>
@@ -1187,6 +1190,14 @@
                                     (Catppuccin theme)
                                 </td>
                             </tr>
+                            <tr>
+                                <td><code>gh skill</code></td>
+                                <td>
+                                    Official <code>gh</code> agent skill for Claude Code &mdash;
+                                    installed by the install script (<code>cli/cli</code>, user
+                                    scope)
+                                </td>
+                            </tr>
                         </tbody>
                     </table>
 
@@ -1329,7 +1340,10 @@
                             </tr>
                             <tr>
                                 <td><code>wt list</code></td>
-                                <td>List all worktrees</td>
+                                <td>
+                                    List all worktrees &mdash; pinned columns: branch, HEAD&plusmn;,
+                                    main&hellip;&plusmn;, CI, summary
+                                </td>
                             </tr>
                             <tr>
                                 <td><code>wt commit</code></td>
@@ -1349,6 +1363,35 @@
                             <tr>
                                 <td><code>wt merge --no-ff</code></td>
                                 <td>Merge with semi-linear history (no fast-forward)</td>
+                            </tr>
+                            <tr>
+                                <td><code>wt wtpr</code></td>
+                                <td>
+                                    <code>wt switch --prs</code> &mdash; picker over open PRs with
+                                    live CI/review state
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><code>wt wtci</code></td>
+                                <td>
+                                    <code>wt list --full --branches</code> &mdash; quick CI +
+                                    branches snapshot
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><code>wt wtlog &lt;id&gt;</code></td>
+                                <td>
+                                    Tail a hook log by
+                                    <code>&lt;source:hook_type:name&gt;</code> (e.g.
+                                    <code>user:post-start:install-deps</code>)
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><code>wt mc</code></td>
+                                <td>
+                                    <code>wt merge</code> with the squash message handwritten in
+                                    <code>$EDITOR</code> instead of Claude haiku
+                                </td>
                             </tr>
                         </tbody>
                     </table>
@@ -2559,19 +2602,34 @@
                             <tr>
                                 <td>Config</td>
                                 <td>
-                                    <code>~/.agent-of-empires/config.toml</code> &mdash;
-                                    chezmoi-managed (<code>0600</code>)
+                                    <code>~/.config/agent-of-empires/config.toml</code> &mdash;
+                                    chezmoi-managed (<code>0600</code>), XDG path (aoe &ge;1.10.1)
                                 </td>
                             </tr>
                             <tr>
                                 <td>Theme</td>
                                 <td>
-                                    <code>catppuccin-mocha</code> (custom), <code>truecolor</code>
+                                    <code>catppuccin-mocha</code> (custom), <code>truecolor</code>,
+                                    unread sessions in teal
                                 </td>
                             </tr>
                             <tr>
                                 <td>Default tool</td>
                                 <td><code>claude</code></td>
+                            </tr>
+                            <tr>
+                                <td>Delete guard</td>
+                                <td>
+                                    <code>confirm_delete = true</code> &mdash; confirmation before
+                                    deleting a session from the TUI
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Rate-limit auto-resume</td>
+                                <td>
+                                    <code>[acp] rate_limit_auto_resume = true</code> &mdash; ACP
+                                    sessions respawn automatically once the rate-limit reset passes
+                                </td>
                             </tr>
                             <tr>
                                 <td>Status hooks</td>

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -125,7 +125,7 @@
       {
         "hooks": [
           {
-            "command": "sh -c '[ -n \"$AOE_INSTANCE_ID\" ] || exit 0; mkdir -p /tmp/aoe-hooks/$AOE_INSTANCE_ID 2>/dev/null; printf running > /tmp/aoe-hooks/$AOE_INSTANCE_ID/status 2>/dev/null; exit 0'",
+            "command": "sh -c 'unset IFS; set -f; umask 077; [ -n \"$AOE_INSTANCE_ID\" ] || exit 0; case \"$AOE_INSTANCE_ID\" in *[!0-9a-zA-Z_-]*) exit 0 ;; esac; B=/tmp/aoe-hooks-{{ .chezmoi.uid }}; mkdir -p \"$B\" 2>/dev/null || exit 0; LS=$(LC_ALL=C ls -ldn \"$B\" 2>/dev/null) || exit 0; set -- $LS; M=\"$1\"; case \"$M\" in drwx------|drwx------.|drwx------+|drwx------@) ;; *) exit 0 ;; esac; ME=$(id -u 2>/dev/null) || exit 0; [ \"$3\" = \"$ME\" ] || exit 0; D=\"$B/$AOE_INSTANCE_ID\"; mkdir -p \"$D\" 2>/dev/null; LS=$(LC_ALL=C ls -ldn \"$D\" 2>/dev/null) || exit 0; set -- $LS; M=\"$1\"; case \"$M\" in drwx------|drwx------.|drwx------+|drwx------@) ;; *) exit 0 ;; esac; [ \"$3\" = \"$ME\" ] || exit 0; printf running > \"$D/status\" 2>/dev/null; exit 0 # aoe-hooks'",
             "type": "command"
           }
         ]
@@ -135,11 +135,20 @@
       {
         "hooks": [
           {
-            "command": "sh -c '[ -n \"$AOE_INSTANCE_ID\" ] || exit 0; mkdir -p /tmp/aoe-hooks/$AOE_INSTANCE_ID 2>/dev/null; printf waiting > /tmp/aoe-hooks/$AOE_INSTANCE_ID/status 2>/dev/null; exit 0'",
+            "command": "sh -c 'unset IFS; set -f; umask 077; [ -n \"$AOE_INSTANCE_ID\" ] || exit 0; case \"$AOE_INSTANCE_ID\" in *[!0-9a-zA-Z_-]*) exit 0 ;; esac; B=/tmp/aoe-hooks-{{ .chezmoi.uid }}; mkdir -p \"$B\" 2>/dev/null || exit 0; LS=$(LC_ALL=C ls -ldn \"$B\" 2>/dev/null) || exit 0; set -- $LS; M=\"$1\"; case \"$M\" in drwx------|drwx------.|drwx------+|drwx------@) ;; *) exit 0 ;; esac; ME=$(id -u 2>/dev/null) || exit 0; [ \"$3\" = \"$ME\" ] || exit 0; D=\"$B/$AOE_INSTANCE_ID\"; mkdir -p \"$D\" 2>/dev/null; LS=$(LC_ALL=C ls -ldn \"$D\" 2>/dev/null) || exit 0; set -- $LS; M=\"$1\"; case \"$M\" in drwx------|drwx------.|drwx------+|drwx------@) ;; *) exit 0 ;; esac; [ \"$3\" = \"$ME\" ] || exit 0; printf waiting > \"$D/status\" 2>/dev/null; exit 0 # aoe-hooks'",
             "type": "command"
           }
         ],
         "matcher": "permission_prompt|elicitation_dialog"
+      },
+      {
+        "hooks": [
+          {
+            "command": "sh -c 'unset IFS; set -f; umask 077; [ -n \"$AOE_INSTANCE_ID\" ] || exit 0; case \"$AOE_INSTANCE_ID\" in *[!0-9a-zA-Z_-]*) exit 0 ;; esac; B=/tmp/aoe-hooks-{{ .chezmoi.uid }}; mkdir -p \"$B\" 2>/dev/null || exit 0; LS=$(LC_ALL=C ls -ldn \"$B\" 2>/dev/null) || exit 0; set -- $LS; M=\"$1\"; case \"$M\" in drwx------|drwx------.|drwx------+|drwx------@) ;; *) exit 0 ;; esac; ME=$(id -u 2>/dev/null) || exit 0; [ \"$3\" = \"$ME\" ] || exit 0; D=\"$B/$AOE_INSTANCE_ID\"; mkdir -p \"$D\" 2>/dev/null; LS=$(LC_ALL=C ls -ldn \"$D\" 2>/dev/null) || exit 0; set -- $LS; M=\"$1\"; case \"$M\" in drwx------|drwx------.|drwx------+|drwx------@) ;; *) exit 0 ;; esac; [ \"$3\" = \"$ME\" ] || exit 0; printf idle > \"$D/status\" 2>/dev/null; exit 0 # aoe-hooks'",
+            "type": "command"
+          }
+        ],
+        "matcher": "idle_prompt"
       }
     ],
     "PreCompact": [
@@ -157,7 +166,7 @@
       {
         "hooks": [
           {
-            "command": "sh -c '[ -n \"$AOE_INSTANCE_ID\" ] || exit 0; mkdir -p /tmp/aoe-hooks/$AOE_INSTANCE_ID 2>/dev/null; printf running > /tmp/aoe-hooks/$AOE_INSTANCE_ID/status 2>/dev/null; exit 0'",
+            "command": "sh -c 'unset IFS; set -f; umask 077; [ -n \"$AOE_INSTANCE_ID\" ] || exit 0; case \"$AOE_INSTANCE_ID\" in *[!0-9a-zA-Z_-]*) exit 0 ;; esac; B=/tmp/aoe-hooks-{{ .chezmoi.uid }}; mkdir -p \"$B\" 2>/dev/null || exit 0; LS=$(LC_ALL=C ls -ldn \"$B\" 2>/dev/null) || exit 0; set -- $LS; M=\"$1\"; case \"$M\" in drwx------|drwx------.|drwx------+|drwx------@) ;; *) exit 0 ;; esac; ME=$(id -u 2>/dev/null) || exit 0; [ \"$3\" = \"$ME\" ] || exit 0; D=\"$B/$AOE_INSTANCE_ID\"; mkdir -p \"$D\" 2>/dev/null; LS=$(LC_ALL=C ls -ldn \"$D\" 2>/dev/null) || exit 0; set -- $LS; M=\"$1\"; case \"$M\" in drwx------|drwx------.|drwx------+|drwx------@) ;; *) exit 0 ;; esac; [ \"$3\" = \"$ME\" ] || exit 0; printf running > \"$D/status\" 2>/dev/null; exit 0 # aoe-hooks'",
             "type": "command"
           }
         ]
@@ -172,13 +181,31 @@
           }
         ],
         "matcher": ""
+      },
+      {
+        "hooks": [
+          {
+            "command": "sh -c '[ -n \"$AOE_INSTANCE_ID\" ] || exit 0; command -v aoe >/dev/null 2>&1 || exit 0; aoe __extract-session-id 2>/dev/null; exit 0 # aoe-hooks'",
+            "type": "command"
+          }
+        ]
       }
     ],
     "Stop": [
       {
         "hooks": [
           {
-            "command": "sh -c '[ -n \"$AOE_INSTANCE_ID\" ] || exit 0; mkdir -p /tmp/aoe-hooks/$AOE_INSTANCE_ID 2>/dev/null; printf idle > /tmp/aoe-hooks/$AOE_INSTANCE_ID/status 2>/dev/null; exit 0'",
+            "command": "sh -c 'unset IFS; set -f; umask 077; [ -n \"$AOE_INSTANCE_ID\" ] || exit 0; case \"$AOE_INSTANCE_ID\" in *[!0-9a-zA-Z_-]*) exit 0 ;; esac; B=/tmp/aoe-hooks-{{ .chezmoi.uid }}; mkdir -p \"$B\" 2>/dev/null || exit 0; LS=$(LC_ALL=C ls -ldn \"$B\" 2>/dev/null) || exit 0; set -- $LS; M=\"$1\"; case \"$M\" in drwx------|drwx------.|drwx------+|drwx------@) ;; *) exit 0 ;; esac; ME=$(id -u 2>/dev/null) || exit 0; [ \"$3\" = \"$ME\" ] || exit 0; D=\"$B/$AOE_INSTANCE_ID\"; mkdir -p \"$D\" 2>/dev/null; LS=$(LC_ALL=C ls -ldn \"$D\" 2>/dev/null) || exit 0; set -- $LS; M=\"$1\"; case \"$M\" in drwx------|drwx------.|drwx------+|drwx------@) ;; *) exit 0 ;; esac; [ \"$3\" = \"$ME\" ] || exit 0; printf idle > \"$D/status\" 2>/dev/null; exit 0 # aoe-hooks'",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "command": "sh -c 'unset IFS; set -f; umask 077; [ -n \"$AOE_INSTANCE_ID\" ] || exit 0; case \"$AOE_INSTANCE_ID\" in *[!0-9a-zA-Z_-]*) exit 0 ;; esac; B=/tmp/aoe-hooks-{{ .chezmoi.uid }}; mkdir -p \"$B\" 2>/dev/null || exit 0; LS=$(LC_ALL=C ls -ldn \"$B\" 2>/dev/null) || exit 0; set -- $LS; M=\"$1\"; case \"$M\" in drwx------|drwx------.|drwx------+|drwx------@) ;; *) exit 0 ;; esac; ME=$(id -u 2>/dev/null) || exit 0; [ \"$3\" = \"$ME\" ] || exit 0; D=\"$B/$AOE_INSTANCE_ID\"; mkdir -p \"$D\" 2>/dev/null; LS=$(LC_ALL=C ls -ldn \"$D\" 2>/dev/null) || exit 0; set -- $LS; M=\"$1\"; case \"$M\" in drwx------|drwx------.|drwx------+|drwx------@) ;; *) exit 0 ;; esac; [ \"$3\" = \"$ME\" ] || exit 0; printf idle > \"$D/status\" 2>/dev/null; exit 0 # aoe-hooks'",
             "type": "command"
           }
         ]
@@ -188,7 +215,11 @@
       {
         "hooks": [
           {
-            "command": "sh -c '[ -n \"$AOE_INSTANCE_ID\" ] || exit 0; mkdir -p /tmp/aoe-hooks/$AOE_INSTANCE_ID 2>/dev/null; printf running > /tmp/aoe-hooks/$AOE_INSTANCE_ID/status 2>/dev/null; exit 0'",
+            "command": "sh -c '[ -n \"$AOE_INSTANCE_ID\" ] || exit 0; command -v aoe >/dev/null 2>&1 || exit 0; aoe __extract-session-id 2>/dev/null; exit 0 # aoe-hooks'",
+            "type": "command"
+          },
+          {
+            "command": "sh -c 'unset IFS; set -f; umask 077; [ -n \"$AOE_INSTANCE_ID\" ] || exit 0; case \"$AOE_INSTANCE_ID\" in *[!0-9a-zA-Z_-]*) exit 0 ;; esac; B=/tmp/aoe-hooks-{{ .chezmoi.uid }}; mkdir -p \"$B\" 2>/dev/null || exit 0; LS=$(LC_ALL=C ls -ldn \"$B\" 2>/dev/null) || exit 0; set -- $LS; M=\"$1\"; case \"$M\" in drwx------|drwx------.|drwx------+|drwx------@) ;; *) exit 0 ;; esac; ME=$(id -u 2>/dev/null) || exit 0; [ \"$3\" = \"$ME\" ] || exit 0; D=\"$B/$AOE_INSTANCE_ID\"; mkdir -p \"$D\" 2>/dev/null; LS=$(LC_ALL=C ls -ldn \"$D\" 2>/dev/null) || exit 0; set -- $LS; M=\"$1\"; case \"$M\" in drwx------|drwx------.|drwx------+|drwx------@) ;; *) exit 0 ;; esac; [ \"$3\" = \"$ME\" ] || exit 0; printf running > \"$D/status\" 2>/dev/null; exit 0 # aoe-hooks'",
             "type": "command"
           }
         ]

--- a/dot_config/private_agent-of-empires/modify_private_config.toml
+++ b/dot_config/private_agent-of-empires/modify_private_config.toml
@@ -1,5 +1,5 @@
 #!/bin/sh
-# chezmoi modify_ script for ~/.agent-of-empires/config.toml (mode 0600 via the
+# chezmoi modify_ script for ~/.config/agent-of-empires/config.toml (mode 0600 via the
 # `private_` attribute). chezmoi pipes the live on-disk config to stdin; we overlay
 # ONLY the deliberately-managed keys (MANAGED below) and emit the merged file to
 # stdout, leaving AoE's runtime writeback (`[app_state]`/`[web]`/`[cockpit]`/
@@ -41,6 +41,12 @@ MANAGED = [
     (("theme", "color_mode"), "truecolor", False),
     (("session", "default_tool"), "claude", False),
     (("session", "agent_status_hooks"), True, False),
+    # Confirmation guard before deleting a session from the TUI (aoe 1.12.0).
+    (("session", "confirm_delete"), True, False),
+    # Auto-resume ACP sessions once the adapter-reported rate-limit reset
+    # passes (aoe 1.10.1, opt-in; +15s default grace). Terminal/tmux-view
+    # sessions are unaffected; status_hooks below still notify.
+    (("acp", "rate_limit_auto_resume"), True, False),
     (("worktree", "init_submodules"), False, False),
     (("tmux", "status_bar"), "disabled", False),
     (("tmux", "clipboard"), "enabled", False),

--- a/dot_config/private_agent-of-empires/themes/catppuccin-mocha.toml
+++ b/dot_config/private_agent-of-empires/themes/catppuccin-mocha.toml
@@ -18,6 +18,7 @@ running = "#a6e3a1" # green
 waiting = "#f9e2af" # yellow
 fresh_idle = "#fab387" # peach
 idle = "#6c7086" # overlay0
+unread = "#94e2d5" # teal — distinct from accent blue; luminance waiting > unread > idle
 error = "#f38ba8" # red
 terminal_active = "#89b4fa" # blue
 group = "#89dceb" # sky

--- a/dot_config/television/cable/markdown.toml
+++ b/dot_config/television/cable/markdown.toml
@@ -20,5 +20,7 @@ enter = "actions:open"
 
 [actions.open]
 description = "Open in mdview (glow / mdfried)"
-command = "mdview '{}'"
+# Bare {} — tv auto-quotes it in action commands; explicit '{}' double-quotes
+# and breaks filenames with spaces. Preview commands are NOT auto-quoted.
+command = "mdview {}"
 mode = "execute"

--- a/dot_config/worktrunk/config.toml
+++ b/dot_config/worktrunk/config.toml
@@ -2,11 +2,11 @@
 # Managed by chezmoi — edit the source, not ~/.config/worktrunk/config.toml
 
 [list]
-# `summary` requires `full` (or the `--full` flag) to render — see worktrunk
-# list docs. Defaulting to full ensures plain `wt list` shows the LLM summary,
-# CI status, and main…± diffstat without needing `wt list --full` every time.
-full = true
-summary = true
+# Pin the exact layout (0.62+). Column names ≠ display headers: working-diff
+# renders "HEAD±", branch-diff renders "main…±". Since 0.63 an explicit
+# `columns` list overrides the full/summary presets, so full/summary keys are
+# redundant here; the summary column still uses [commit.generation] below.
+columns = ["branch", "working-diff", "branch-diff", "ci", "summary"]
 
 [switch.picker]
 pager = "delta --paging=never"
@@ -143,7 +143,7 @@ BRANCH: {{ branch }}
 TARGET: {{ target_branch }}
 
 SQUASHED COMMITS:
-{{ commits }}
+{{ commit_details }}
 
 DIFF STAT:
 {{ git_diff_stat }}
@@ -158,6 +158,9 @@ wtlog = '''id={{ args[0] }}; [ -n "$id" ] || { echo "usage: wt wtlog <source:hoo
 
 # Quick CI + branches snapshot.
 wtci = "wt list --full --branches"
+
+# Picker over open PRs with live CI/review state (0.63+).
+wtpr = "wt switch --prs"
 
 # wt merge with a one-shot WORKTRUNK_COMMIT__GENERATION__COMMAND override that
 # opens $EDITOR (fallback: vi) so the user handwrites the squash message instead

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -54,7 +54,7 @@
 	features = catppuccin-mocha
 
 [alias]
-	lg = log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
+	lg = log --graph --graph-lane-limit=8 --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
 	last = log -1 HEAD --stat
 	unstage = reset HEAD --
 	undo = reset --soft HEAD~1

--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -20,5 +20,9 @@ set -g status-right-length 100
 set -g status-left ""
 set -gF status-right "#{E:@catppuccin_status_application}#{E:@catppuccin_status_session}"
 
-# Load Catppuccin plugin (graceful — no error if not yet installed)
-run -b "[ -f ~/.config/tmux/plugins/catppuccin/tmux/catppuccin.tmux ] && ~/.config/tmux/plugins/catppuccin/tmux/catppuccin.tmux"
+# Load Catppuccin plugin (graceful — no error if not yet installed), then
+# append `fill` to message styles: tmux 3.7 draws prompts/messages as a partial
+# status-line overlay and only paints the full width when the style declares
+# fill, which catppuccin v2.3.0 (latest) predates. ##{...} defers expansion so
+# run-shell doesn't resolve @thm_overlay_0 before the plugin defines it.
+run -b "[ -f ~/.config/tmux/plugins/catppuccin/tmux/catppuccin.tmux ] && ~/.config/tmux/plugins/catppuccin/tmux/catppuccin.tmux && tmux set -agF message-style ',fill=##{@thm_overlay_0}' && tmux set -agF message-command-style ',fill=##{@thm_overlay_0}'"

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -234,7 +234,7 @@ alias gs="git status"
 alias ga="git add"
 alias gc="git commit"
 alias gp="git push"
-alias gl="git log --oneline --graph --decorate --all"
+alias gl="git log --oneline --graph --graph-lane-limit=8 --decorate --all"
 alias gd="git diff"
 alias lg="lazygit"  # Open lazygit for visual git interface
 

--- a/openspec/changes/update-brew-deps/.openspec.yaml
+++ b/openspec/changes/update-brew-deps/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/update-brew-deps/design.md
+++ b/openspec/changes/update-brew-deps/design.md
@@ -1,0 +1,35 @@
+## Context
+
+18 brew packages are outdated. The changelog audit (release notes for every version in each range, each finding verified against upstream source and this repo) surfaced the follow-ups in the proposal. Most edits are one-liners; the only sequencing-sensitive piece is the aoe XDG relocation, which mixes a git mv in the source tree, a live-state move on disk, and ignore-file path updates. This repo uses the dual-dir chezmoi layout (dev clone ≠ `~/.local/share/chezmoi`), so applying requires the source to be synced.
+
+## Goals / Non-Goals
+
+- **Goals**: upgrade all 18 packages; adopt every approved improvement; keep `chezmoi diff` clean/idempotent afterwards; keep the install script bash-3.2-compatible and idempotent.
+- **Non-Goals**: pinning brew versions; migrating the pinned catppuccin/tmux plugin (v2.3.0 is latest); adopting rejected items (`gh discussion` allowlist, worktrunk `--safe-mode` flags, zsh `_as_if`); README/manual edits (post-implementation docs skills).
+
+## Decisions
+
+- **D1 — aoe XDG relocation order**: move live state (`mv ~/.agent-of-empires ~/.config/agent-of-empires`) BEFORE the renamed chezmoi source is applied. AoE prefers an existing XDG dir over the legacy dir; applying first would create the XDG dir and strand live state (sessions DB) in the legacy path. aoe must be quit first (sqlite WAL: `cockpit_events.db-wal`/`-shm`, `tui.active`). Alternative (symlink legacy→XDG) rejected: leaves the wart the change is meant to remove.
+- **D2 — brew upgrade before apply**: aoe ≥1.10.1 is required for XDG support and ≥1.11.2/1.12.0 for the new theme/config keys; upgrade first, then relocate/apply. tmux 3.7b lands with the running 3.6b server still alive — restart the server (`tmux kill-server`) in the same window aoe is closed (aoe sessions live in tmux).
+- **D3 — tmux fill via run-shell chain, not a plain `set`**: the fill attribute must land AFTER catppuccin.tmux runs (the plugin sets `message-style` itself). Extending the existing guarded `run -b` line keeps graceful degradation when the plugin is absent. `##{…}` escaping prevents run-shell from expanding the format before the plugin defines `@thm_overlay_0`; `-agF` appends and expands formats at set time.
+- **D4 — worktrunk `[list]` columns replace full/summary**: since 0.63 explicit `columns` override the presets, making `full`/`summary` redundant for rendering. Column NAMES (not display headers) are required: `working-diff` (renders "HEAD±"), `branch-diff` (renders "main…±"). The summary column still depends on `[commit.generation]`, which stays. `wtci` alias (`wt list --full --branches`) remains valid and untouched.
+- **D5 — gh skill idempotency via `--json`**: detection uses `gh skill list --agent claude-code --json skillName --jq '.[].skillName' | grep -qx "gh"` rather than parsing human output; the group lives inside the existing gh-extensions confirm gate, consistent with gh-dash/gh-enhance stanzas.
+- **D6 — edit chezmoi source, never `wt config update`**: the migrator rewrites the live `~/.config/worktrunk/config.toml`, which would drift from the source. After the source edit, `wt config update` finding nothing to migrate is the verification.
+- **D7 — no spec deltas for zshrc `gl` and squash-template**: neither is covered by an existing requirement; they are implementation details of this change (spec deltas would over-specify).
+
+## Risks / Trade-offs
+
+- [aoe state relocation while a session exists] → hard prerequisite: quit aoe + `tmux kill-server` first; verify no `tui.active` before moving.
+- [oxfmt corrupting the moved modify_ script] → `.oxfmtignore` path updated in the same commit as the git mv (memory: oxfmt mangles chezmoi scripts).
+- [`chezmoi apply` re-runs the full onchange script interactively] → expected; groups are confirmable and idempotent, only the gh-skill step is new work.
+- [worktrunk columns render unexpectedly] → verified names against 0.65 docs; fallback is restoring `full`/`summary` (one-line revert).
+- [auto-resume respawns Claude unattended] → opt-in was user-approved; only applies to ACP sessions and existing status_hooks still notify.
+
+## Migration Plan
+
+1. Repo edits (all files) → 2. `brew upgrade` (18) → 3. quit aoe, `tmux kill-server`, `mv` legacy state → 4. sync source + `chezmoi diff` + `chezmoi apply` → 5. restart tmux/aoe, verify → 6. docs skills → 7. commit + PR.
+Rollback: config edits revert via git; aoe path reverts by moving the dir back (AoE falls back to legacy when no XDG dir exists); brew rollback not planned (no breaking changes found).
+
+## Open Questions
+
+None — all judgment calls resolved by the user (all 8 features approved).

--- a/openspec/changes/update-brew-deps/proposal.md
+++ b/openspec/changes/update-brew-deps/proposal.md
@@ -53,4 +53,5 @@
 - **Files**: `dot_config/worktrunk/config.toml`, `dot_config/television/cable/markdown.toml`, `dot_tmux.conf`, `dot_zshrc.tmpl`, `dot_gitconfig.tmpl`, `run_onchange_install-packages.sh.tmpl`, `private_dot_agent-of-empires/` → `dot_config/private_agent-of-empires/` (git mv), `.oxfmtignore`, `.chezmoiignore`
 - **Specs**: `gh-skill-install` (new); deltas for `agent-manager`, `worktrunk-config`, `television-markdown-channel`, `tmux-catppuccin`, `git-config`
 - **Systems**: Homebrew (18 formulae), live `~/.agent-of-empires` state relocation (aoe must be closed; sqlite WAL), tmux server restart to load 3.7b + new conf (coordinate with aoe shutdown), `chezmoi apply` re-runs the onchange install script (installs the gh skill interactively)
-- **Out of scope**: gl/squash-template zshrc details not covered by specs need no delta; README/manual sync handled post-implementation via `/docs:manual` + `/docs:readme`
+- **Out of scope**: gl/squash-template zshrc details not covered by specs need no delta
+- **Docs (in scope)**: README/manual sync via `/docs:manual` + `/docs:readme` post-implementation (tasks 6.1–6.2)

--- a/openspec/changes/update-brew-deps/proposal.md
+++ b/openspec/changes/update-brew-deps/proposal.md
@@ -25,6 +25,7 @@
 - gh: new idempotent install step for the official `gh` agent skill (`gh skill install cli/cli gh --agent claude-code --scope user`, 2.94/2.95)
 - worktrunk `[aliases]`: add `wtpr = "wt switch --prs"` (0.63 PR picker with live CI/review state)
 - worktrunk `[list]`: replace `full = true` / `summary = true` with `columns = ["branch", "working-diff", "branch-diff", "ci", "summary"]` (0.62+; since 0.63 explicit columns override the presets)
+- Claude settings template: sync the aoe-injected hook set to what aoe 1.12 writes (hardened `/tmp/aoe-hooks-<uid>` commands with perm checks, `idle_prompt`/`StopFailure` coverage, `__extract-session-id` hooks; uid via `{{ .chezmoi.uid }}`) — found post-upgrade as `chezmoi diff` churn where apply would downgrade the live hooks
 
 ### Audited and rejected (documented, no action)
 
@@ -43,6 +44,7 @@
 - `agent-manager`: config path moves to `~/.config/agent-of-empires/` (source `dot_config/private_agent-of-empires/`); knob set gains `[acp].rate_limit_auto_resume` and `[session].confirm_delete`; theme gains `unread`; first-install path verification updated to the XDG location.
 - `worktrunk-config`: `[list]` requirement changes from `full`/`summary` flags to an explicit `columns` pin; `[aliases]` grows `wtpr`.
 - `television-markdown-channel`: Enter action requirement now mandates bare `{}` (auto-quoted) in the open command.
+- `claude-hooks`: AoE session-status hook requirement updated to the aoe 1.12 hardened hook set (uid-suffixed base dir, new matchers/events, session-id extraction).
 - `tmux-catppuccin`: plugin-load requirement extended to restore full-width message/prompt styling under tmux ≥3.7.
 - `git-config`: `lg` alias requirement gains `--graph-lane-limit=8`.
 

--- a/openspec/changes/update-brew-deps/proposal.md
+++ b/openspec/changes/update-brew-deps/proposal.md
@@ -1,0 +1,54 @@
+## Why
+
+`brew outdated` reports 18 pending upgrades, two with security fixes worth applying promptly (openssl@3 3.6.3 fixes 16 CVEs incl. a High-severity OCSP double-free; libevent 2.1.13 fixes 6+ security issues). A full changelog × config audit (every release note in each installed→target range, each finding adversarially verified against upstream code and this repo) found no hard breakage but one deprecation that touches our config (worktrunk `{{ commits }}`), one cosmetic regression (tmux 3.7 × pinned catppuccin v2.3.0 message-style), one latent bug in our television markdown channel surfaced by the 0.15.9 changelog, and eight adoptable features the user approved in full.
+
+## What Changes
+
+### Brew upgrades (no repo changes — `brew upgrade` per package)
+
+- **Security**: openssl@3 3.6.2→3.6.3, libevent 2.1.12_1→2.1.13
+- **Patches/minors, config no-ops**: bash 5.3.9→5.3.15, chezmoi 2.70.4→2.70.5, dolt 2.1.0→2.1.10 (beads dep; no schema migration; only removes unused `dolt archive`), jpeg-turbo 3.1.4.1→3.2.0, lazygit 0.62.1→0.62.2, llhttp 9.4.1→9.4.2, mole 1.40.0→1.44.1, starship 1.25.1→1.26.0, uv 0.11.17→0.11.26, zsh 5.9→5.9.1 (login shell is Apple zsh; brew zsh unaffected as shell)
+- **Minors with config follow-ups**: aoe 1.9.5→1.12.0, gh 2.93.0→2.95.0, git 2.54.0→2.55.0, television 0.15.7→0.15.9, tmux 3.6b→3.7b, worktrunk 0.55.0→0.65.0
+
+### Fixes (corrections to existing config)
+
+- worktrunk squash-template: `{{ commits }}` → `{{ commit_details }}` (deprecated in 0.59.0; edit chezmoi source, never `wt config update`, which would drift the live file)
+- television `cable/markdown.toml` open action: `mdview '{}'` → `mdview {}` (tv auto-quotes bare `{}` in action commands; our explicit quotes double-quote and break filenames with spaces)
+- tmux 3.7 draws messages/prompts as a partial status-line overlay; append `fill=##{@thm_overlay_0}` to `message-style`/`message-command-style` after loading catppuccin v2.3.0 (pinned; no upstream release fixes it) to restore the full-width themed bar
+
+### Feature adoption (user-approved)
+
+- aoe theme: add `unread = "#94e2d5"` (1.11.2 unread session state; without the key it falls back to accent blue, indistinguishable)
+- aoe managed config: `[acp].rate_limit_auto_resume = true` (1.10.1 opt-in auto-resume after rate-limit reset) and `[session].confirm_delete = true` (1.12.0 delete guard)
+- **BREAKING (operational)**: aoe config relocates from `~/.agent-of-empires/` to the XDG path `~/.config/agent-of-empires/` (1.10.1, upstream-designed for chezmoi). Live state must move BEFORE the renamed source is applied (an existing XDG dir outranks the legacy dir); `.oxfmtignore` and `.chezmoiignore` paths follow
+- git aliases: `--graph-lane-limit=8` (new in 2.55) added to zshrc `gl` and gitconfig `lg`
+- gh: new idempotent install step for the official `gh` agent skill (`gh skill install cli/cli gh --agent claude-code --scope user`, 2.94/2.95)
+- worktrunk `[aliases]`: add `wtpr = "wt switch --prs"` (0.63 PR picker with live CI/review state)
+- worktrunk `[list]`: replace `full = true` / `summary = true` with `columns = ["branch", "working-diff", "branch-diff", "ci", "summary"]` (0.62+; since 0.63 explicit columns override the presets)
+
+### Audited and rejected (documented, no action)
+
+- `Bash(gh discussion *)` allowlist — GitHub Discussions unused here; command set is preview
+- worktrunk `--safe-mode --setting-sources='user'` commit-generation flags — only needed with apiKeyHelper auth; this machine uses subscription/keychain (deferred note)
+- zsh 5.9.1 `_as_if` completion for `wsh` — `wt switch --create <TAB>` offers no candidates, and the login shell (Apple zsh 5.9) lacks `_as_if` in fpath
+
+## Capabilities
+
+### New Capabilities
+
+- `gh-skill-install`: install the official `gh` agent skill for Claude Code inside the existing gh CLI extensions confirmable group, idempotently.
+
+### Modified Capabilities
+
+- `agent-manager`: config path moves to `~/.config/agent-of-empires/` (source `dot_config/private_agent-of-empires/`); knob set gains `[acp].rate_limit_auto_resume` and `[session].confirm_delete`; theme gains `unread`; first-install path verification updated to the XDG location.
+- `worktrunk-config`: `[list]` requirement changes from `full`/`summary` flags to an explicit `columns` pin; `[aliases]` grows `wtpr`.
+- `television-markdown-channel`: Enter action requirement now mandates bare `{}` (auto-quoted) in the open command.
+- `tmux-catppuccin`: plugin-load requirement extended to restore full-width message/prompt styling under tmux ≥3.7.
+- `git-config`: `lg` alias requirement gains `--graph-lane-limit=8`.
+
+## Impact
+
+- **Files**: `dot_config/worktrunk/config.toml`, `dot_config/television/cable/markdown.toml`, `dot_tmux.conf`, `dot_zshrc.tmpl`, `dot_gitconfig.tmpl`, `run_onchange_install-packages.sh.tmpl`, `private_dot_agent-of-empires/` → `dot_config/private_agent-of-empires/` (git mv), `.oxfmtignore`, `.chezmoiignore`
+- **Specs**: `gh-skill-install` (new); deltas for `agent-manager`, `worktrunk-config`, `television-markdown-channel`, `tmux-catppuccin`, `git-config`
+- **Systems**: Homebrew (18 formulae), live `~/.agent-of-empires` state relocation (aoe must be closed; sqlite WAL), tmux server restart to load 3.7b + new conf (coordinate with aoe shutdown), `chezmoi apply` re-runs the onchange install script (installs the gh skill interactively)
+- **Out of scope**: gl/squash-template zshrc details not covered by specs need no delta; README/manual sync handled post-implementation via `/docs:manual` + `/docs:readme`

--- a/openspec/changes/update-brew-deps/specs/agent-manager/spec.md
+++ b/openspec/changes/update-brew-deps/specs/agent-manager/spec.md
@@ -1,0 +1,148 @@
+# agent-manager Delta
+
+## REMOVED Requirements
+
+### Requirement: AoE configuration is chezmoi-managed at `~/.agent-of-empires/config.toml`
+
+**Reason**: AoE 1.10.1 added XDG config support on macOS (upstream PR #1968, designed for dotfile managers); the config relocates to `~/.config/agent-of-empires/`, removing the documented "breaking the `~/.config/` convention" wart.
+**Migration**: Quit aoe, `mv ~/.agent-of-empires ~/.config/agent-of-empires` BEFORE applying the renamed source (an existing XDG dir outranks the legacy dir), `git mv private_dot_agent-of-empires dot_config/private_agent-of-empires`, update `.oxfmtignore` and `.chezmoiignore` paths.
+
+## ADDED Requirements
+
+### Requirement: AoE configuration is chezmoi-managed at `~/.config/agent-of-empires/config.toml`
+
+The dotfiles source tree SHALL contain a `dot_config/private_agent-of-empires/config.toml` management (modify_ script) targeting `~/.config/agent-of-empires/config.toml` (AoE ≥1.10.1 reads `$XDG_CONFIG_HOME/agent-of-empires/` on macOS when that directory exists, preferring it over the legacy `~/.agent-of-empires/`). The file SHALL be applied unconditionally on `chezmoi apply` (no per-host gating). No `~/.agent-of-empires/` directory SHALL remain after migration (its presence alongside the XDG dir would strand legacy state).
+
+#### Scenario: Config file present after chezmoi apply
+
+- **WHEN** the user runs `chezmoi apply` on any supported host
+- **THEN** `~/.config/agent-of-empires/config.toml` SHALL exist and be readable by the current user
+
+#### Scenario: Config file is private (chezmoi `private_` attribute)
+
+- **WHEN** `chezmoi apply` materializes the file
+- **THEN** the resulting `~/.config/agent-of-empires/config.toml` SHALL have permissions `0600` or stricter
+
+#### Scenario: Legacy dir absent after migration
+
+- **WHEN** the migration has run on a host that previously used `~/.agent-of-empires/`
+- **THEN** `~/.agent-of-empires/` no longer exists and aoe reads (and writes runtime state to) `~/.config/agent-of-empires/`
+
+## MODIFIED Requirements
+
+### Requirement: AoE config sets deliberate knobs for power use
+
+The `~/.config/agent-of-empires/config.toml` managed by chezmoi SHALL contain the following table entries (or their schema-equivalent keys after `aoe init` verification):
+
+- `[session]` with `default_tool = "claude"`, `agent_status_hooks = true`, and `confirm_delete = true` (AoE 1.12.0: confirmation guard before deleting a session from the TUI).
+- `[acp]` with `rate_limit_auto_resume = true` (AoE 1.10.1: opt-in daemon auto-resume of ACP sessions once the adapter-reported rate-limit reset time passes).
+- `[status_hooks]` with `on_waiting` and `on_idle` commands that invoke `terminal-notifier` (already provided by `cli-tool-expansion`).
+- `[worktree]` with `init_submodules = false`.
+- `[tmux]` with `status_bar = "disabled"` (user owns `~/.tmux.conf`).
+- `[updates]` with `update_check_mode = "off"` (updates flow through brew + chezmoi).
+- An `environment` passthrough list including `CLAUDE_CONFIG_DIR`, `EDITOR`, `TERM`, and `COLORTERM`.
+
+The config MAY include a `[theme]` block matching the rest of the dotfiles' Catppuccin Mocha palette if AoE offers an equivalent named theme; otherwise the theme block SHALL be omitted (defaults are acceptable).
+
+#### Scenario: default_tool set to claude
+
+- **WHEN** the config file is rendered by chezmoi
+- **THEN** the rendered file contains `default_tool = "claude"` under a `[session]` table
+
+#### Scenario: agent_status_hooks enabled
+
+- **WHEN** the config file is rendered by chezmoi
+- **THEN** the rendered file contains `agent_status_hooks = true` under a `[session]` table
+
+#### Scenario: Session delete guarded
+
+- **WHEN** the config file is rendered by chezmoi
+- **THEN** the rendered file contains `confirm_delete = true` under a `[session]` table
+
+#### Scenario: Rate-limited ACP sessions auto-resume
+
+- **WHEN** the config file is rendered by chezmoi
+- **THEN** the rendered file contains `rate_limit_auto_resume = true` under an `[acp]` table
+
+#### Scenario: status_hooks use terminal-notifier
+
+- **WHEN** the config file is rendered by chezmoi
+- **THEN** the rendered file contains both `on_waiting` and `on_idle` keys under a `[status_hooks]` table, and each value invokes the `terminal-notifier` binary
+
+#### Scenario: init_submodules disabled
+
+- **WHEN** the config file is rendered by chezmoi
+- **THEN** the rendered file contains `init_submodules = false` under a `[worktree]` table
+
+#### Scenario: tmux status bar disabled
+
+- **WHEN** the config file is rendered by chezmoi
+- **THEN** the rendered file contains `status_bar = "disabled"` under a `[tmux]` table
+
+#### Scenario: Update check disabled
+
+- **WHEN** the config file is rendered by chezmoi
+- **THEN** the rendered file contains `update_check_mode = "off"` under an `[updates]` table
+
+#### Scenario: Environment passthrough includes Claude variables
+
+- **WHEN** the config file is rendered by chezmoi
+- **THEN** the rendered file contains an `environment` list (or table) that names `CLAUDE_CONFIG_DIR`, `EDITOR`, `TERM`, and `COLORTERM`
+
+### Requirement: AoE config path is verified at first install
+
+The implementation tasks SHALL include a manual verification step confirming AoE reads from `~/.config/agent-of-empires/config.toml` on macOS (AoE ≥1.10.1 prefers `$XDG_CONFIG_HOME/agent-of-empires/` when the directory exists; the legacy `~/.agent-of-empires/` is only used when no XDG dir exists). If verification reveals different precedence, the chezmoi target SHALL be relocated accordingly and this spec SHALL be updated via a follow-up delta.
+
+#### Scenario: Verified path is `~/.config/agent-of-empires/`
+
+- **WHEN** the user launches `aoe` on a host where `~/.config/agent-of-empires/` exists and `~/.agent-of-empires/` does not
+- **THEN** AoE reads and writes `~/.config/agent-of-empires/config.toml`
+- **AND** no change to the chezmoi target is required
+
+#### Scenario: Verified path differs from documented expectation
+
+- **WHEN** verification reveals AoE actually reads from a different path
+- **THEN** the chezmoi source path is moved accordingly AND a follow-up change updates this spec to reference the verified path
+
+### Requirement: AoE forces tmux clipboard passthrough
+
+The AoE config (`~/.config/agent-of-empires/config.toml`, chezmoi-managed) SHALL set `[tmux].clipboard = "enabled"` so AoE applies `set-clipboard on` and `allow-passthrough on` to its tmux sessions, letting OSC 52 clipboard writes from wrapped agents reach the terminal. The default `"auto"` is a no-op when a user-owned `~/.tmux.conf` exists.
+
+#### Scenario: Clipboard passthrough enabled
+
+- **WHEN** the AoE config is rendered by chezmoi
+- **THEN** it contains `clipboard = "enabled"` under a `[tmux]` table
+
+### Requirement: AoE config preserves runtime writeback under chezmoi
+
+The chezmoi management of `~/.config/agent-of-empires/config.toml` SHALL preserve AoE's runtime writeback tables (`[app_state]`, `[web]`, `[cockpit]`, `[logging]`, and default-expanded keys) rather than clobbering them on `chezmoi apply`, while still enforcing the deliberately-managed keys (`[theme]`, `[session]`, `[acp]`, `[worktree]`, `[tmux]`, `[updates]`, `[status_hooks]`, `[sandbox]`, `[sound]`, `[tools.lazygit]`). The chezmoi target file SHALL remain mode `0600`.
+
+#### Scenario: Apply does not drop AoE runtime state
+
+- **WHEN** AoE has written runtime tables (e.g. `[app_state]`, `[web]`) into the live config and the user runs `chezmoi apply`
+- **THEN** those runtime tables remain present in `~/.config/agent-of-empires/config.toml`
+- **AND** the deliberately-managed keys reflect the chezmoi-managed values
+
+#### Scenario: Re-apply is quiet (no churn)
+
+- **WHEN** the deliberately-managed keys already hold the chezmoi-managed values and `chezmoi apply` / `chezmoi diff` runs again (including after AoE has only rewritten its own runtime tables)
+- **THEN** the management reproduces the on-disk file with no formatting churn and `chezmoi diff` reports no changes to any non-managed table
+
+#### Scenario: Managed config stays private
+
+- **WHEN** chezmoi materializes the config
+- **THEN** `~/.config/agent-of-empires/config.toml` has permissions `0600` or stricter
+
+### Requirement: AoE uses a Catppuccin Mocha theme
+
+The AoE config SHALL set `[theme].name = "catppuccin-mocha"` referencing a chezmoi-managed custom theme at `dot_config/private_agent-of-empires/themes/catppuccin-mocha.toml` (AoE ships no built-in Catppuccin dark theme), aligning AoE with the rest of the Catppuccin Mocha stack. `color_mode` SHALL remain `truecolor`. The theme SHALL define `unread = "#94e2d5"` (Mocha teal) so the unread session state introduced in AoE 1.11.2 is distinguishable from accent-colored elements (omitting the key falls back to the theme accent, blue `#89b4fa`, which this theme already uses for accent/title/hint) while respecting AoE's waiting > unread > idle luminance ordering.
+
+#### Scenario: Custom Mocha theme referenced
+
+- **WHEN** the AoE config is rendered by chezmoi
+- **THEN** `[theme].name = "catppuccin-mocha"` and a chezmoi-managed `themes/catppuccin-mocha.toml` exists
+
+#### Scenario: Unread sessions visually distinct
+
+- **WHEN** the theme file is rendered by chezmoi
+- **THEN** it contains `unread = "#94e2d5"`

--- a/openspec/changes/update-brew-deps/specs/agent-manager/spec.md
+++ b/openspec/changes/update-brew-deps/specs/agent-manager/spec.md
@@ -11,7 +11,7 @@
 
 ### Requirement: AoE configuration is chezmoi-managed at `~/.config/agent-of-empires/config.toml`
 
-The dotfiles source tree SHALL contain a `dot_config/private_agent-of-empires/config.toml` management (modify_ script) targeting `~/.config/agent-of-empires/config.toml` (AoE ≥1.10.1 reads `$XDG_CONFIG_HOME/agent-of-empires/` on macOS when that directory exists, preferring it over the legacy `~/.agent-of-empires/`). The file SHALL be applied unconditionally on `chezmoi apply` (no per-host gating). No `~/.agent-of-empires/` directory SHALL remain after migration (its presence alongside the XDG dir would strand legacy state).
+The dotfiles source tree SHALL contain `dot_config/private_agent-of-empires/modify_private_config.toml`, which targets `~/.config/agent-of-empires/config.toml` (AoE ≥1.10.1 reads `$XDG_CONFIG_HOME/agent-of-empires/` on macOS when that directory exists, preferring it over the legacy `~/.agent-of-empires/`). The file SHALL be applied unconditionally on `chezmoi apply` (no per-host gating). No `~/.agent-of-empires/` directory SHALL remain after migration (its presence alongside the XDG dir would strand legacy state).
 
 #### Scenario: Config file present after chezmoi apply
 

--- a/openspec/changes/update-brew-deps/specs/claude-hooks/spec.md
+++ b/openspec/changes/update-brew-deps/specs/claude-hooks/spec.md
@@ -1,0 +1,37 @@
+# claude-hooks Delta
+
+## MODIFIED Requirements
+
+### Requirement: AoE session-status hooks are present in the settings template
+
+The chezmoi-managed `dot_claude/settings.json.tmpl` `hooks` block SHALL carry the AoE 1.12 session-status hook set verbatim (as written by `aoe` itself, marked `# aoe-hooks`), so `chezmoi apply` never downgrades hooks that AoE re-injects on session start. Specifically: `UserPromptSubmit`, `PreToolUse`, and `ElicitationResult` SHALL write `running`; `Notification` SHALL write `waiting` (matcher `permission_prompt|elicitation_dialog`) and `idle` (matcher `idle_prompt`); `Stop` and `StopFailure` SHALL write `idle`; `UserPromptSubmit` and `SessionStart` SHALL additionally run `aoe __extract-session-id` (gated on `aoe` being installed). Each status command SHALL use AoE's hardened form: status words written to `/tmp/aoe-hooks-{{ .chezmoi.uid }}/$AOE_INSTANCE_ID/status` with `umask 077`, `$AOE_INSTANCE_ID` character-set validation, and owner/mode (`0700`, own uid) verification of both directories before writing. These hooks SHALL coexist with the existing `bd prime` hooks (`SessionStart`, `PreCompact`).
+
+#### Scenario: Running-status hooks present
+
+- **WHEN** the settings template is rendered by chezmoi
+- **THEN** the `hooks` block contains `UserPromptSubmit`, `PreToolUse`, and `ElicitationResult` entries whose command writes `running` to `/tmp/aoe-hooks-<uid>/$AOE_INSTANCE_ID/status`
+
+#### Scenario: Waiting- and idle-notification hooks present with matchers
+
+- **WHEN** the settings template is rendered by chezmoi
+- **THEN** the `Notification` hook with matcher `permission_prompt|elicitation_dialog` writes `waiting` AND the `Notification` hook with matcher `idle_prompt` writes `idle`
+
+#### Scenario: Idle-status hooks present
+
+- **WHEN** the settings template is rendered by chezmoi
+- **THEN** the `Stop` and `StopFailure` hooks write `idle`
+
+#### Scenario: Session-id extraction hooks present
+
+- **WHEN** the settings template is rendered by chezmoi
+- **THEN** `UserPromptSubmit` and `SessionStart` contain a hook running `aoe __extract-session-id`, gated on `$AOE_INSTANCE_ID` and `command -v aoe`
+
+#### Scenario: Render matches what AoE writes (no apply churn)
+
+- **WHEN** AoE has injected its hooks into the live `~/.claude/settings.json` and `chezmoi diff` runs
+- **THEN** the hooks block reports no differences (uid rendered via `{{ .chezmoi.uid }}` matches the live `/tmp/aoe-hooks-<uid>` base)
+
+#### Scenario: AoE hooks do not displace bd prime hooks
+
+- **WHEN** the settings template is rendered by chezmoi
+- **THEN** the `SessionStart` and `PreCompact` hooks still run `bd prime` alongside the AoE status hooks

--- a/openspec/changes/update-brew-deps/specs/gh-skill-install/spec.md
+++ b/openspec/changes/update-brew-deps/specs/gh-skill-install/spec.md
@@ -1,0 +1,22 @@
+# gh-skill-install Delta
+
+## ADDED Requirements
+
+### Requirement: gh agent skill install
+
+The chezmoi install script SHALL install the official `gh` agent skill for Claude Code inside the existing gh CLI extensions confirmable group, using `gh skill install cli/cli gh --agent claude-code --scope user` (available since gh 2.94). Detection SHALL be structured — `gh skill list --agent claude-code --json skillName --jq '.[].skillName'` matched exactly against `gh` — not grepping human-readable output.
+
+#### Scenario: Fresh install of the gh skill
+
+- **WHEN** chezmoi apply runs, the user confirms the gh extensions group, and the skill is not yet installed
+- **THEN** the script runs `gh skill install cli/cli gh --agent claude-code --scope user`
+
+#### Scenario: gh skill already installed
+
+- **WHEN** chezmoi apply runs and `gh skill list --agent claude-code --json skillName` already contains `gh`
+- **THEN** the script skips installation and reports it as already installed
+
+#### Scenario: Install failure is non-fatal
+
+- **WHEN** `gh skill install` fails (offline, auth expired)
+- **THEN** the script records the error via the standard `error` helper and continues with the remaining groups

--- a/openspec/changes/update-brew-deps/specs/git-config/spec.md
+++ b/openspec/changes/update-brew-deps/specs/git-config/spec.md
@@ -1,0 +1,37 @@
+# git-config Delta
+
+## MODIFIED Requirements
+
+### Requirement: Curated git aliases
+
+The gitconfig SHALL define exactly these aliases:
+
+- `lg` = graph log with color formatting, abbreviated commits, and `--graph-lane-limit=8` (git ≥2.55) so wide commit graphs are truncated to at most 8 lanes
+- `last` = `log -1 HEAD --stat`
+- `unstage` = `reset HEAD --`
+- `undo` = `reset --soft HEAD~1`
+- `amend` = `commit --amend --no-edit`
+- `branches` = `branch -a`
+- `remotes` = `remote -v`
+
+The gitconfig SHALL NOT include shorthand aliases (`st`, `co`, `ci`, `cm`, `ca`, `br`, `df`, `dc`) as these are provided by the OMZ git plugin.
+
+#### Scenario: Git lg shows graph
+
+- **WHEN** `git lg` is run in a repository with commits
+- **THEN** a colored graph log with abbreviated hashes, branch names, relative dates, and author names is displayed
+
+#### Scenario: Git lg caps graph lanes
+
+- **WHEN** `git lg` is run in a repository whose history would render more than 8 parallel graph lanes
+- **THEN** the graph is truncated to 8 lanes instead of widening unbounded
+
+#### Scenario: Git unstage removes from index
+
+- **WHEN** `git unstage <file>` is run
+- **THEN** the file is removed from the staging area but remains in the working tree
+
+#### Scenario: Git amend adds to last commit
+
+- **WHEN** staged changes exist and `git amend` is run
+- **THEN** the staged changes are added to the previous commit without changing its message

--- a/openspec/changes/update-brew-deps/specs/television-markdown-channel/spec.md
+++ b/openspec/changes/update-brew-deps/specs/television-markdown-channel/spec.md
@@ -1,0 +1,17 @@
+# television-markdown-channel Delta
+
+## MODIFIED Requirements
+
+### Requirement: Enter opens the file via mdview
+
+The `markdown` channel SHALL bind Enter to an action that opens the selected file through `mdview`, so the viewer choice (glow vs mdfried) follows the central dispatcher policy rather than being hard-coded in the channel. The action command SHALL pass the selection as a bare `{}` token (`command = "mdview {}"`): television auto-quotes bare `{}` in action commands, so explicit surrounding quotes would double-quote the entry and break filenames containing spaces. Preview commands are not auto-quoted and keep their explicit quoting.
+
+#### Scenario: Opening a selection
+
+- **WHEN** the user presses Enter on a file in the `markdown` channel
+- **THEN** the file is opened through `mdview`
+
+#### Scenario: Filenames with spaces open correctly
+
+- **WHEN** the user presses Enter on a Markdown file whose path contains spaces
+- **THEN** `mdview` receives the full path as a single argument (no double-quoting) and renders the file

--- a/openspec/changes/update-brew-deps/specs/tmux-catppuccin/spec.md
+++ b/openspec/changes/update-brew-deps/specs/tmux-catppuccin/spec.md
@@ -1,0 +1,22 @@
+# tmux-catppuccin Delta
+
+## MODIFIED Requirements
+
+### Requirement: tmux uses Catppuccin plugin with Mocha flavor
+
+The tmux configuration SHALL load the catppuccin/tmux plugin from `~/.config/tmux/plugins/catppuccin/tmux/catppuccin.tmux` with flavor set to `mocha` and window status style set to `rounded`. After the plugin runs, the same guarded `run` chain SHALL append `fill=##{@thm_overlay_0}` to `message-style` and `message-command-style` (via `tmux set -agF`): tmux ≥3.7 draws messages/prompts as a partial status-line overlay and only paints the full width when the style declares `fill`, which the pinned catppuccin v2.3.0 predates (no newer upstream release exists). The `##{…}` escaping SHALL be used so run-shell does not expand the format before the plugin defines `@thm_overlay_0`.
+
+#### Scenario: tmux session started
+
+- **WHEN** user starts or attaches to a tmux session
+- **THEN** the window list, status bar, and pane borders render with Catppuccin Mocha colors
+
+#### Scenario: plugin not yet installed
+
+- **WHEN** tmux starts and the plugin directory does not exist
+- **THEN** tmux starts without errors (graceful degradation with default colors)
+
+#### Scenario: command prompt paints the full bar (tmux ≥3.7)
+
+- **WHEN** the user opens the command prompt (`prefix :`) or tmux displays a message under tmux 3.7+
+- **THEN** the prompt/message line fills the entire status-line width with the Catppuccin overlay background instead of a partial overlay

--- a/openspec/changes/update-brew-deps/specs/worktrunk-config/spec.md
+++ b/openspec/changes/update-brew-deps/specs/worktrunk-config/spec.md
@@ -1,0 +1,65 @@
+# worktrunk-config Delta
+
+## MODIFIED Requirements
+
+### Requirement: LLM branch summaries enabled in list view
+
+The user config SHALL pin the `wt list` layout with `[list].columns = ["branch", "working-diff", "branch-diff", "ci", "summary"]` so plain `wt list` and the `wt switch` picker display the branch, HEAD± working diffstat, main…± branch diffstat, CI status, and the LLM-generated summary (generated via the configured `[commit.generation].command`) on every invocation. Since worktrunk 0.63 an explicit `columns` list overrides the `full`/`summary` presets, so the config SHALL NOT also set `[list].full` or `[list].summary` (redundant). Column identifiers are names, not display headers (`working-diff` renders "HEAD±", `branch-diff` renders "main…±").
+
+#### Scenario: list shows branch summaries
+
+- **GIVEN** the user has configured `[commit.generation].command`
+- **WHEN** the user runs `wt list`
+- **THEN** each branch row SHALL include an LLM-generated summary line
+
+#### Scenario: list shows CI and diffstat columns
+
+- **WHEN** the user runs `wt list`
+- **THEN** each row SHALL include the working diffstat (HEAD±), the branch diffstat (main…±), and CI status columns
+
+#### Scenario: Config applied on fresh machine
+
+- **WHEN** the user runs `chezmoi apply`
+- **THEN** `~/.config/worktrunk/config.toml` SHALL contain `columns = ["branch", "working-diff", "branch-diff", "ci", "summary"]` under a `[list]` table and no `full` or `summary` keys
+
+### Requirement: User-defined wt aliases for daily operations
+
+The user config SHALL define a `[aliases]` table with four entries: `wtlog` (tail the log file of a named hook by resolving its path through `wt config state logs --format=json | jq` filtering on `<source>:<hook_type>:<name>`), `wtci` (wrapper for `wt list --full --branches`), `wtpr` (wrapper for `wt switch --prs`, the worktrunk 0.63 picker mode listing open PRs with live CI/review state), and `mc` (wrapper for `wt merge` that overrides `WORKTRUNK_COMMIT__GENERATION__COMMAND` so the squash message is composed in `$EDITOR` instead of via the configured Claude haiku command).
+
+#### Scenario: wtlog tails a named hook log
+
+- **GIVEN** the user passes a hook identifier such as `user:post-start:install-deps`
+- **WHEN** the user runs `wt wtlog <hook-id>`
+- **THEN** the alias SHALL execute `tail -f` on the path obtained by querying `wt config state logs --format=json` and filtering the `hook_output[]` array for the entry whose composite `<source>:<hook_type>:<name>` equals the supplied id
+
+#### Scenario: wtlog reports a clear error when the hook id is missing
+
+- **WHEN** the user runs `wt wtlog` with no argument
+- **THEN** the alias SHALL print `usage: wt wtlog <source:hook_type:name>` to stderr AND exit with a non-zero status without invoking `tail`
+
+#### Scenario: wtlog reports a clear error when the hook id is unknown
+
+- **GIVEN** the user passes a hook identifier that does not match any entry in `wt config state logs --format=json`
+- **WHEN** the user runs `wt wtlog <hook-id>`
+- **THEN** the alias SHALL print `hook log not found: <hook-id>` to stderr AND exit with a non-zero status without invoking `tail`
+
+#### Scenario: wtci shows full branch + CI snapshot
+
+- **WHEN** the user runs `wt wtci`
+- **THEN** the alias SHALL execute `wt list --full --branches`
+
+#### Scenario: wtpr opens the PR picker
+
+- **WHEN** the user runs `wt wtpr`
+- **THEN** the alias SHALL execute `wt switch --prs`, opening the picker with open pull requests and their live CI/review state
+
+#### Scenario: mc opens editor for squash message
+
+- **WHEN** the user runs `wt mc`
+- **THEN** the alias SHALL execute `wt merge` with the environment variable `WORKTRUNK_COMMIT__GENERATION__COMMAND` set to a command that opens `$EDITOR` (falling back to `vi`) for the user to author the commit message
+- **AND** the override SHALL apply only to that single invocation, leaving the global `[commit.generation].command` untouched
+
+#### Scenario: Aliases present after chezmoi apply
+
+- **WHEN** the user runs `chezmoi apply`
+- **THEN** `~/.config/worktrunk/config.toml` SHALL contain a `[aliases]` table with keys `wtlog`, `wtci`, `wtpr`, and `mc`

--- a/openspec/changes/update-brew-deps/tasks.md
+++ b/openspec/changes/update-brew-deps/tasks.md
@@ -13,6 +13,7 @@
 - [x] 2.5 `dot_zshrc.tmpl`: add `--graph-lane-limit=8` after `--graph` in the `gl` alias
 - [x] 2.6 `dot_gitconfig.tmpl`: add `--graph-lane-limit=8` after `--graph` in the `lg` alias
 - [x] 2.7 `run_onchange_install-packages.sh.tmpl`: add the idempotent gh agent skill stanza (structured `--json` detection, `gh skill install cli/cli gh --agent claude-code --scope user`) after the gh-enhance stanza inside the gh extensions group
+- [x] 2.8 `dot_claude/settings.json.tmpl`: sync the aoe hook set to what aoe 1.12 writes (hardened `/tmp/aoe-hooks-{{ .chezmoi.uid }}` commands, idle_prompt/StopFailure, `__extract-session-id`) — post-upgrade `chezmoi diff` churn fix
 
 ## 3. aoe XDG relocation (source side)
 
@@ -24,16 +25,16 @@
 ## 4. Upgrade + live migration (operational)
 
 - [x] 4.1 `brew upgrade` the 18 outdated packages; confirm `brew outdated` is clean
-- [ ] 4.2 Quit aoe (no `tui.active`), `tmux kill-server`
-- [ ] 4.3 `mv ~/.agent-of-empires ~/.config/agent-of-empires` (BEFORE any apply of the renamed source)
-- [ ] 4.4 Sync chezmoi source (dual-dir) and run `chezmoi diff`, then `chezmoi apply` (onchange script re-runs; confirm gh extensions group to install the gh skill)
+- [x] 4.2 Quit aoe (no `tui.active`), `tmux kill-server`
+- [x] 4.3 `mv ~/.agent-of-empires ~/.config/agent-of-empires` (BEFORE any apply of the renamed source)
+- [x] 4.4 Sync chezmoi source (dual-dir) and run `chezmoi diff`, then `chezmoi apply` (onchange script re-runs; confirm gh extensions group to install the gh skill)
 
 ## 5. Verification
 
-- [ ] 5.1 aoe launches reading `~/.config/agent-of-empires/config.toml`; no legacy dir; theme loads with unread teal; `[acp]`/`confirm_delete` keys present in live config; re-run `chezmoi diff` is clean
+- [x] 5.1 aoe launches reading `~/.config/agent-of-empires/config.toml`; no legacy dir; theme loads with unread teal; `[acp]`/`confirm_delete` keys present in live config; re-run `chezmoi diff` is clean
 - [x] 5.2 `wt config update` finds nothing to migrate; `wt list` shows the 5 pinned columns; `wt wtpr` opens the PR picker
 - [x] 5.3 `tv` markdown channel opens a file with spaces in its name via mdview
-- [ ] 5.4 New tmux server on 3.7b: `prefix :` prompt fills the whole status bar with overlay background; mdfried passthrough still works
+- [x] 5.4 New tmux server on 3.7b: `prefix :` prompt fills the whole status bar with overlay background; mdfried passthrough still works
 - [x] 5.5 `git lg` and zshrc `gl` run with `--graph-lane-limit=8`; `gh skill list --agent claude-code` includes `gh`; re-running the install script skips it
 - [x] 5.6 `openspec validate update-brew-deps` passes
 

--- a/openspec/changes/update-brew-deps/tasks.md
+++ b/openspec/changes/update-brew-deps/tasks.md
@@ -1,0 +1,43 @@
+## 1. Repo edits — fixes
+
+- [x] 1.1 `dot_config/worktrunk/config.toml`: replace `{{ commits }}` with `{{ commit_details }}` in squash-template (deprecated in 0.59.0)
+- [x] 1.2 `dot_config/television/cable/markdown.toml`: change `[actions.open]` command from `mdview '{}'` to `mdview {}` (preview command unchanged)
+- [x] 1.3 `dot_tmux.conf` line 24: extend the catppuccin `run -b` chain with `tmux set -agF message-style ',fill=##{@thm_overlay_0}'` and the same for `message-command-style`
+
+## 2. Repo edits — features
+
+- [x] 2.1 `private_dot_agent-of-empires/themes/catppuccin-mocha.toml`: add `unread = "#94e2d5" # teal` after the `idle` line
+- [x] 2.2 `private_dot_agent-of-empires/modify_private_config.toml`: add MANAGED entries `(("acp", "rate_limit_auto_resume"), True, False),` and `(("session", "confirm_delete"), True, False),`
+- [x] 2.3 `dot_config/worktrunk/config.toml`: replace `[list]` `full = true` / `summary = true` with `columns = ["branch", "working-diff", "branch-diff", "ci", "summary"]` and update the stale comment (diffstat default since 0.62; columns override presets since 0.63)
+- [x] 2.4 `dot_config/worktrunk/config.toml`: add `wtpr = "wt switch --prs"` to `[aliases]`
+- [x] 2.5 `dot_zshrc.tmpl`: add `--graph-lane-limit=8` after `--graph` in the `gl` alias
+- [x] 2.6 `dot_gitconfig.tmpl`: add `--graph-lane-limit=8` after `--graph` in the `lg` alias
+- [x] 2.7 `run_onchange_install-packages.sh.tmpl`: add the idempotent gh agent skill stanza (structured `--json` detection, `gh skill install cli/cli gh --agent claude-code --scope user`) after the gh-enhance stanza inside the gh extensions group
+
+## 3. aoe XDG relocation (source side)
+
+- [x] 3.1 `git mv private_dot_agent-of-empires dot_config/private_agent-of-empires`
+- [x] 3.2 `.oxfmtignore`: update the modify-script path to `dot_config/private_agent-of-empires/modify_private_config.toml`
+- [x] 3.3 `.chezmoiignore`: update `.agent-of-empires/sounds` patterns to `.config/agent-of-empires/sounds`
+- [x] 3.4 Validate the install script template still renders (`chezmoi execute-template` + `bash -n`)
+
+## 4. Upgrade + live migration (operational)
+
+- [x] 4.1 `brew upgrade` the 18 outdated packages; confirm `brew outdated` is clean
+- [ ] 4.2 Quit aoe (no `tui.active`), `tmux kill-server`
+- [ ] 4.3 `mv ~/.agent-of-empires ~/.config/agent-of-empires` (BEFORE any apply of the renamed source)
+- [ ] 4.4 Sync chezmoi source (dual-dir) and run `chezmoi diff`, then `chezmoi apply` (onchange script re-runs; confirm gh extensions group to install the gh skill)
+
+## 5. Verification
+
+- [ ] 5.1 aoe launches reading `~/.config/agent-of-empires/config.toml`; no legacy dir; theme loads with unread teal; `[acp]`/`confirm_delete` keys present in live config; re-run `chezmoi diff` is clean
+- [x] 5.2 `wt config update` finds nothing to migrate; `wt list` shows the 5 pinned columns; `wt wtpr` opens the PR picker
+- [x] 5.3 `tv` markdown channel opens a file with spaces in its name via mdview
+- [ ] 5.4 New tmux server on 3.7b: `prefix :` prompt fills the whole status bar with overlay background; mdfried passthrough still works
+- [x] 5.5 `git lg` and zshrc `gl` run with `--graph-lane-limit=8`; `gh skill list --agent claude-code` includes `gh`; re-running the install script skips it
+- [x] 5.6 `openspec validate update-brew-deps` passes
+
+## 6. Docs sync
+
+- [x] 6.1 Run `/docs:manual` to sync docs/manual.html (git aliases, wtpr, wt list columns, gh skill, tmux fill)
+- [x] 6.2 Run `/docs:readme` in case the gh agent skill counts as tool-level for README.md

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,1 @@
+schema: spec-driven

--- a/run_onchange_install-packages.sh.tmpl
+++ b/run_onchange_install-packages.sh.tmpl
@@ -326,7 +326,7 @@ fi
 # Group: gh CLI extensions
 # ------------------------------------------------------------------
 if command -v gh &>/dev/null; then
-    if confirm "Install gh CLI extensions (gh-dash, gh-enhance)?"; then
+    if confirm "Install gh CLI extensions (gh-dash, gh-enhance) + gh agent skill?"; then
         if gh extension list 2>/dev/null | grep -q "dlvhdr/gh-dash"; then
             info "  gh-dash — already installed, skipping"
         else
@@ -342,6 +342,17 @@ if command -v gh &>/dev/null; then
             info "  Installing gh-enhance..."
             if ! gh extension install dlvhdr/gh-enhance; then
                 error "Failed to install gh-enhance"
+            fi
+        fi
+
+        # Official gh agent skill for Claude Code (gh 2.94+). Structured
+        # detection via --json instead of grepping human-readable output.
+        if gh skill list --agent claude-code --json skillName --jq '.[].skillName' 2>/dev/null | grep -qx "gh"; then
+            info "  gh agent skill — already installed, skipping"
+        else
+            info "  Installing gh agent skill (Claude Code, user scope)..."
+            if ! gh skill install cli/cli gh --agent claude-code --scope user; then
+                error "Failed to install gh agent skill"
             fi
         fi
     else


### PR DESCRIPTION
## Why

`brew outdated` reported 18 pending upgrades, two with security fixes (openssl@3 3.6.3: 16 CVEs incl. a High-severity OCSP double-free; libevent 2.1.13: 6+ security fixes). Every release note in each installed→target range was audited against this repo's configs, with each finding adversarially verified against upstream source.

## What

**Brew upgrades (done):** aoe 1.9.5→1.12.0, bash, chezmoi, dolt, gh 2.93→2.96, git 2.54→2.55, jpeg-turbo, lazygit, libevent, llhttp, mole, openssl@3, starship, television 0.15.7→0.15.9, tmux 3.6b→3.7b, uv, worktrunk 0.55→0.65, zsh 5.9→5.9.1.

**Fixes:**
- worktrunk squash-template: `{{ commits }}` → `{{ commit_details }}` (deprecated 0.59)
- television markdown channel: bare `{}` in open action (explicit quotes double-quoted paths with spaces)
- tmux 3.7 draws prompts as partial overlay: append `fill=@thm_overlay_0` to message styles after catppuccin v2.3.0 loads

**Features adopted:**
- aoe: XDG config relocation (`~/.config/agent-of-empires/`), `unread` teal theme color, `session.confirm_delete`, `acp.rate_limit_auto_resume`
- git: `--graph-lane-limit=8` in `gl`/`lg` aliases
- gh: official `gh` agent skill installed from the install script (idempotent `--json` detection)
- worktrunk: `[list] columns` pin, `wtpr` PR-picker alias

**Audited and rejected** (see `openspec/changes/update-brew-deps/proposal.md`): `gh discussion` allowlist, worktrunk `--safe-mode` commit flags, zsh `_as_if` completion.

## Verification

- `wt config update`: no deprecated settings; `wt list` renders the 5 pinned columns
- `git lg` / `gl` work with lane limit; gh skill installed + skip path verified
- install script re-rendered (`chezmoi execute-template`) + `bash -n` clean
- modify script dry-run emits the new `[acp]`/`confirm_delete` keys; theme TOML parses

## Pending (operational, outside this PR's tmux)

Live `~/.agent-of-empires` → `~/.config/agent-of-empires` move + full `chezmoi apply` + tmux server restart — blocked on closing the active aoe TUI and sibling tmux sessions; runbook in the session summary. OpenSpec change will be archived after those checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved `gl`/`lg` Git log graph readability with a capped lane limit.
  * Enhanced Worktrunk `wt list` with configurable columns, plus new helpers: `wtpr`, `wtci`, `wtlog`, and `mc`.
  * Added official `gh` agent skill installation for Claude Code.
  * Added Catppuccin “unread” theme color and new session controls (delete confirmation, auto-resume).
* **Bug Fixes**
  * Improved Markdown viewing behavior for paths containing spaces.
  * Hardened AoE session-status hook handling and temp file behavior.
* **Documentation**
  * Updated manual cheat sheets and configuration highlights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->