### PR TITLE
feat(zsh): add update-extra command for non-brew tool updates (DOT-28)

### DIFF
--- a/.claude/skills/classify-tool-updates/SKILL.md
+++ b/.claude/skills/classify-tool-updates/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: classify-tool-updates
+description: Use when adding a new tool to the dotfiles or removing one — a brew formula/cask, a curl-installed binary, a cloned plugin, an npx-installed CLI in run_onchange_install-packages.sh.tmpl, a zshrc-initialized tool, or a new config under dot_config/. Classifies the tool by update mechanism (brew-managed / self-updating / repo-pinned / manual) and keeps the `update-extra` step list in dot_zshrc.tmpl in sync.
+---
+
+# Classify Tool Updates
+
+Classify a new (or removed) dotfiles tool by update mechanism and maintain the `update-extra` step list.
+
+## When This Activates
+
+- A tool install is added to `run_onchange_install-packages.sh.tmpl` (brew, curl installer, git clone, npx)
+- A tool is initialized in `dot_zshrc.tmpl` or gains a config under `dot_config/`
+- A tool with an `update-extra` step is removed from the dotfiles
+- The user asks how a tool gets updated
+
+## Workflow
+
+### Step 1: Identify the install path
+
+From the diff or conversation: what installs the tool, and is its version pinned anywhere in the repo (Renovate config, hardcoded tag, pinned installer URL)?
+
+### Step 2: Classify — exactly one class, first match wins
+
+1. **brew-managed** — brew formula or cask → **no action**. `brew upgrade` (omz `bubu`) covers it.
+2. **self-updating** — ships its own updater (opencode, CodeRabbit CLI, Claude Code, oh-my-zsh) → **no action**. Never wrap or duplicate a self-updater; several tools were deliberately moved off brew so their self-update works.
+3. **repo-pinned** — version pinned in the repo: Renovate-managed pins (MCP servers), hardcoded installer tags (nvm, tmux Catppuccin) → update path is **pin bump + `chezmoi apply`**, never `update-extra`.
+4. **manual** — none of the above → **add a step to `update-extra`** in `dot_zshrc.tmpl`.
+
+Settled exclusions, do not re-litigate: mas apps (App Store auto-updates), Node LTS/nvm (runtime management), superpowers-opencode plugin, tmux Catppuccin (pinned by design).
+
+### Step 3: Propose the update-extra edit (manual class only)
+
+Propose the exact one-line step for the `update-extra` function body in `dot_zshrc.tmpl`:
+
+```zsh
+_update_extra_step "<label>" <update command...>
+```
+
+- Verify the update command against the tool's docs — never guess a subcommand.
+- Multi-command updates get a private `_update_extra_<tool>` helper so the function body stays one line per tool (`_update_extra_catppuccin` precedent).
+- On tool removal, propose deleting its step line (and helper, if any).
+- Include the matching spec delta for the `extra-updates-command` capability (its step-list requirement) in a new OpenSpec change, so the main spec stays in sync.
+
+**Wait for user confirmation before editing any files.**
+
+### Step 4: Docs follow-up — delegate
+
+Never edit `README.md` or `docs/manual.html` here. After an `update-extra` change, run the `update-manual` skill (and `update-readme` if tool-level) for documentation follow-up.
+
+## Guardrails
+
+- **Never edit `dot_zshrc.tmpl` without user confirmation**
+- Every new tool gets exactly one class; when ambiguous (e.g. curl installer that also self-updates), ask instead of guessing
+- `update-extra` must never invoke `brew`, a self-updater, or a repo-pinned tool's update path
+- Step add/remove proposals always carry the matching `extra-updates-command` spec delta
+- This skill is repo tooling: `.claude/` is never applied by chezmoi

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ chezmoi git push
 
 ```sh
 bubu            # brew packages: update + upgrade + cleanup
-update-extra    # the rest: gh extensions, omz plugins, skills, themes, tv channels
+update-extra    # the rest: gh extensions, omz plugins, skills, plannotator, themes, tv channels
 ```
 
 Self-updating tools (Claude Code, OpenCode, CodeRabbit) and repo-pinned versions (Renovate-managed) take care of themselves.

--- a/README.md
+++ b/README.md
@@ -169,3 +169,12 @@ chezmoi git add .
 chezmoi git -- commit -m "your message"
 chezmoi git push
 ```
+
+### Updating Tools
+
+```sh
+bubu            # brew packages: update + upgrade + cleanup
+update-extra    # the rest: gh extensions, omz plugins, skills, themes, tv channels
+```
+
+Self-updating tools (Claude Code, OpenCode, CodeRabbit) and repo-pinned versions (Renovate-managed) take care of themselves.

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -1900,6 +1900,32 @@
                             </tr>
                         </tbody>
                     </table>
+
+                    <h3>Extra Updates (non-brew tools)</h3>
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Command</th>
+                                <th>Description</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td><code>update-extra</code></td>
+                                <td>
+                                    Update tools that are neither brew-managed nor self-updating: gh
+                                    extensions, you-should-use, skills.sh globals, plannotator,
+                                    Catppuccin themes, tv channels &mdash; a failing step reports
+                                    and continues; summary at the end
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <div class="flow-only">
+                        <strong>Flow: Full tool maintenance</strong><br />
+                        <code>bubu</code> &rarr; <code>update-extra</code> &rarr; everything current
+                        (self-updating tools handle themselves; pinned tools via Renovate)
+                    </div>
                 </div>
             </details>
 

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -311,6 +311,49 @@ alias jqless="jq -C . | less -R"
 alias pretty-json="jq ."
 alias check-json="jq empty"
 
+# update-extra: single entry point for tools that are neither brew-managed,
+# self-updating, nor repo-pinned (those have their own update paths). Step list
+# is maintained by the classify-tool-updates skill (repo .claude/skills/).
+# A failing step reports and continues; exit is non-zero if any step failed.
+_update_extra_step() {
+  local label="$1"; shift
+  echo "\n→ $label"
+  if "$@"; then
+    echo "✓ $label"
+    (( _ue_ok += 1 ))
+  else
+    echo "✗ $label" >&2
+    (( _ue_failed += 1 ))
+  fi
+}
+
+# Catppuccin Mocha assets — same URLs as run_onchange_install-packages.sh.tmpl.
+_update_extra_catppuccin() {
+  local base="https://raw.githubusercontent.com/catppuccin"
+  curl -fsSLo "$(bat --config-dir)/themes/Catppuccin Mocha.tmTheme" \
+    "$base/bat/main/themes/Catppuccin%20Mocha.tmTheme" &&
+  curl -fsSLo "$HOME/.config/delta/catppuccin.gitconfig" \
+    "$base/delta/main/catppuccin.gitconfig" &&
+  curl -fsSLo "$HOME/.zsh/catppuccin_mocha-zsh-syntax-highlighting.zsh" \
+    "$base/zsh-syntax-highlighting/main/themes/catppuccin_mocha-zsh-syntax-highlighting.zsh" &&
+  curl -fsSLo "$HOME/.config/atuin/themes/catppuccin-mocha-blue.toml" \
+    "$base/atuin/main/themes/mocha/catppuccin-mocha-blue.toml" &&
+  bat cache --build
+}
+
+unalias update-extra 2>/dev/null
+update-extra() {
+  local _ue_ok=0 _ue_failed=0
+  _update_extra_step "gh extensions" gh extension upgrade --all
+  _update_extra_step "you-should-use" git -C "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/you-should-use" pull --ff-only
+  _update_extra_step "skills.sh globals" npx -y skills update -g -y
+  _update_extra_step "plannotator" sh -c 'curl -fsSL https://plannotator.ai/install.sh | bash'
+  _update_extra_step "Catppuccin themes" _update_extra_catppuccin
+  _update_extra_step "television channels" tv update-channels
+  echo "\nupdate-extra: $_ue_ok ok, $_ue_failed failed"
+  (( _ue_failed == 0 ))
+}
+
 # Tool environment
 command -v direnv &>/dev/null && eval "$(direnv hook zsh)"
 

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -341,13 +341,24 @@ _update_extra_catppuccin() {
   bat cache --build
 }
 
+# Download-then-run so a failed download reports ✗ (curl | bash exits 0 when
+# the download fails: bash reads empty stdin).
+_update_extra_plannotator() {
+  local tmp rc
+  tmp="$(mktemp)" || return 1
+  curl -fsSL https://plannotator.ai/install.sh -o "$tmp" && bash "$tmp"
+  rc=$?
+  rm -f "$tmp"
+  return $rc
+}
+
 unalias update-extra 2>/dev/null
 update-extra() {
   local _ue_ok=0 _ue_failed=0
   _update_extra_step "gh extensions" gh extension upgrade --all
   _update_extra_step "you-should-use" git -C "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/you-should-use" pull --ff-only
   _update_extra_step "skills.sh globals" npx -y skills update -g -y
-  _update_extra_step "plannotator" sh -c 'curl -fsSL https://plannotator.ai/install.sh | bash'
+  _update_extra_step "plannotator" _update_extra_plannotator
   _update_extra_step "Catppuccin themes" _update_extra_catppuccin
   _update_extra_step "television channels" tv update-channels
   echo "\nupdate-extra: $_ue_ok ok, $_ue_failed failed"

--- a/openspec/changes/add-extra-updates-command/.openspec.yaml
+++ b/openspec/changes/add-extra-updates-command/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/add-extra-updates-command/design.md
+++ b/openspec/changes/add-extra-updates-command/design.md
@@ -1,0 +1,66 @@
+# Design: add-extra-updates-command
+
+## Context
+
+Tools in this repo split into four update classes: brew-managed (`brew upgrade` / omz `bubu`), self-updating (opencode, CodeRabbit, Claude Code, omz — several deliberately migrated off brew in `2026-05-31-brew-upgrade` so their self-update works), repo-pinned (Renovate-managed MCP pins, pinned installers like nvm and tmux Catppuccin), and manual. The manual class has no entry point today; `run_onchange_install-packages.sh.tmpl` is install-only (skip-if-present; the sole exception is `tv update-channels`, and the script only re-fires when its rendered content changes).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One interactive command that updates the manual class: gh extensions, you-should-use, skills.sh globals, plannotator, Catppuccin theme assets, tv channels.
+- A failing step never aborts the rest; clear per-step output and final summary.
+- A project skill that keeps the step list in sync as tools are added.
+
+**Non-Goals:**
+
+- Touching brew, self-updating, or repo-pinned tools (Renovate/pin-bump owns those).
+- mas apps (App Store auto-updates), Node/nvm (runtime management; installer pinned), superpowers-opencode plugin (user-excluded), tmux Catppuccin (pinned by design).
+- Changing `run_onchange_install-packages.sh.tmpl` or the `chezmoi apply` contract.
+- Scheduling/automation — the command is run on demand.
+
+## Decisions
+
+### D1: zsh function in `dot_zshrc.tmpl`, not a `~/.local/bin` executable
+
+Repo rule (mdview header, `project_customcommand_path_executable`): PATH executables are only for commands that non-interactive callers (lazygit/tv `sh -c`) must reach. `update-extra` is interactive-only → function in the aliases section, before the zoxide init (`dot_zshrc.tmpl:338`, must stay last). Rejected: executable — no non-interactive caller exists.
+
+### D2: name `update-extra`
+
+Ticket's suggestion; no collision in zshrc or omz (brew plugin ships `brewp`/`brews`/`brewsp`/`bubo`/`bubc`/`bubu`, different names). Guard with `unalias update-extra 2>/dev/null` before definition, per the `md()` precedent (`dot_zshrc.tmpl:226`). Rejected: `dotfiles-update` — confusable with `chezmoi update`, which README documents as the dotfiles-repo update flow.
+
+### D3: one-line-per-tool step engine
+
+Private helper `_update_extra_step <label> <command...>` prints the label, runs the command, prints `✓`/`✗`, increments a failure counter. The function body is then a flat list of `_update_extra_step` calls — adding a tool is a one-line mechanical edit, which is what makes the classification skill's job trivial. Output style: `✓` on success (wsh precedent), `✗` + stderr on failure, final `N ok, M failed` summary. Returns non-zero if any step failed.
+
+### D4: step commands (verified against the repo and upstream)
+
+| Step | Command | Source of truth |
+|---|---|---|
+| gh extensions | `gh extension upgrade --all` | installs at `run_onchange_install-packages.sh.tmpl:328-352` |
+| you-should-use | `git -C "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/you-should-use" pull --ff-only` | clone at `:417-425` |
+| skills.sh globals | `npx -y skills update -g -y` | subcommand verified in `skills --help` (alias `upgrade`) |
+| plannotator | `curl -fsSL https://plannotator.ai/install.sh \| bash` | CLI has no update subcommand (v0.19.26); UI banner only notifies; installer is the official upgrade path and removes the old binary |
+| Catppuccin themes | re-curl the 4 assets (bat `:247-248` + `bat cache --build`, delta `:267`, zsh-syntax-highlighting `:284`, atuin `:301`) | same URLs as the install script |
+| tv channels | `tv update-channels` | `:221-224`; also runs when the onchange install script re-fires (content change), so `update-extra` is the only on-demand path |
+
+### D5: skill `classify-tool-updates` as repo tooling
+
+Lives at `.claude/skills/classify-tool-updates/SKILL.md` — same home as `update-manual`/`update-readme`. chezmoi ignores dot-prefixed source dirs automatically, so no `.chezmoiignore` change; the ticket's "repo tooling, not applied config" constraint is satisfied structurally. The skill encodes the **four-way** decision tree (brew / self-updating / repo-pinned / manual), not the ticket's three-way one — without the repo-pinned branch it would misclassify nvm, MCP pins, or tmux Catppuccin into `update-extra` and fight Renovate. Structure copied from `update-manual`: triggers / workflow / propose-then-confirm / guardrails. Docs updates are delegated to `update-manual`/`update-readme`, not duplicated. No companion `/command` wrapper in v1 — the skill auto-triggers; a wrapper can be added later if manual invocation is missed.
+
+## Risks / Trade-offs
+
+- [`curl | bash` re-run executes remote code] → same trust model and identical URLs as the existing install script; no new trust surface.
+- [Upstream moves a theme file / installer URL] → that step fails, is reported, the rest continue; exit code flags it.
+- [`npx -y skills` is unpinned] → consistent with how the install script invokes it (`:1064-1105`); failure is tolerated per-step.
+- [`git pull` on a dirty you-should-use clone] → `--ff-only` fails loudly instead of merging; clone is stock so this should not occur.
+- [Step list drifts from reality as tools come and go] → that is exactly what the classification skill exists to prevent; guardrail in the skill also covers tool *removal*.
+- [Duplicate `tv update-channels` work vs `chezmoi apply`] → seconds of idempotent work; accepted for a complete single entry point.
+
+## Migration Plan
+
+Additive only. Rollback = delete the function block and the skill directory. After editing `dot_zshrc.tmpl`, the live machine needs `chezmoi update` (dev clone ≠ chezmoi source dir).
+
+## Open Questions
+
+None — scope, naming, and step list settled during exploration (DOT-28 thread).

--- a/openspec/changes/add-extra-updates-command/design.md
+++ b/openspec/changes/add-extra-updates-command/design.md
@@ -40,7 +40,7 @@ Private helper `_update_extra_step <label> <command...>` prints the label, runs 
 | gh extensions | `gh extension upgrade --all` | installs at `run_onchange_install-packages.sh.tmpl:328-352` |
 | you-should-use | `git -C "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/you-should-use" pull --ff-only` | clone at `:417-425` |
 | skills.sh globals | `npx -y skills update -g -y` | subcommand verified in `skills --help` (alias `upgrade`) |
-| plannotator | `curl -fsSL https://plannotator.ai/install.sh \| bash` | CLI has no update subcommand (v0.19.26); UI banner only notifies; installer is the official upgrade path and removes the old binary |
+| plannotator | fetch `https://plannotator.ai/install.sh` to a temp file, then `bash` it | CLI has no update subcommand (v0.19.26); UI banner only notifies; installer is the official upgrade path and removes the old binary. Not `curl \| bash`: that exits 0 on a failed download (bash reads empty stdin), masking the failure |
 | Catppuccin themes | re-curl the 4 assets (bat `:247-248` + `bat cache --build`, delta `:267`, zsh-syntax-highlighting `:284`, atuin `:301`) | same URLs as the install script |
 | tv channels | `tv update-channels` | `:221-224`; also runs when the onchange install script re-fires (content change), so `update-extra` is the only on-demand path |
 

--- a/openspec/changes/add-extra-updates-command/proposal.md
+++ b/openspec/changes/add-extra-updates-command/proposal.md
@@ -1,0 +1,44 @@
+# Proposal: add-extra-updates-command
+
+Linear: [DOT-28](https://linear.app/monolab/issue/DOT-28/comando-custom-de-actualizacion-de-herramientas-no-brew-no)
+
+## Why
+
+Tools that are neither brew-managed nor self-updating each need their own manual update command, and there is no single entry point — they get forgotten. `brew upgrade` (omz `bubu`) covers brew; self-updating tools cover themselves; the rest rots.
+
+## What Changes
+
+- New zsh function `update-extra` in `dot_zshrc.tmpl` that runs, in sequence, the update commands for the no-brew / no-self-updating group:
+  - gh extensions → `gh extension upgrade --all`
+  - you-should-use (omz custom plugin) → `git -C "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/you-should-use" pull --ff-only`
+  - skills.sh global skills → `npx -y skills update -g -y`
+  - plannotator CLI → re-run `https://plannotator.ai/install.sh` (official upgrade path; CLI has no update subcommand)
+  - Catppuccin theme assets (bat + `bat cache --build`, delta, zsh-syntax-highlighting, atuin) → re-curl
+  - television channels → `tv update-channels`
+- Resilient execution: a failing step reports and continues; final summary with error count (pattern from `run_onchange_install-packages.sh.tmpl`).
+- New project skill `.claude/skills/classify-tool-updates/` — when a tool is added to the dotfiles, classify it by update mechanism and decide the action:
+  - brew → nothing (covered by `brew upgrade`)
+  - self-updating → nothing (deliberate prior decision, e.g. opencode/CodeRabbit off-brew migration)
+  - repo-pinned (Renovate-managed pins, pinned installers) → pin bump + `chezmoi apply`, never `update-extra`
+  - none of the above → add a step to `update-extra`
+- The skill is repo tooling: `.claude/` is never applied by chezmoi, so no `.chezmoiignore` change needed.
+
+Explicitly out of scope: mas apps (App Store auto-updates), Node LTS/nvm (runtime management, installer pinned in repo), superpowers-opencode plugin (user decision), tmux Catppuccin (pinned by design), anything self-updating or Renovate-managed.
+
+## Capabilities
+
+### New Capabilities
+
+- `extra-updates-command`: the `update-extra` zsh function — step list, per-step output, failure resilience, summary.
+- `classify-tool-updates-skill`: project skill that classifies new tools by update mechanism (brew / self-updating / repo-pinned / manual) and maintains the `update-extra` step list.
+
+### Modified Capabilities
+
+_None. The function and skill are additive; no existing spec requirements change._
+
+## Impact
+
+- `dot_zshrc.tmpl`: new function in the aliases section (before the zoxide init); unconditional `unalias update-extra 2>/dev/null` guard (`md()` precedent).
+- `.claude/skills/classify-tool-updates/SKILL.md`: new skill, following the `update-manual` structure (triggers / workflow / confirmation / guardrails).
+- Docs follow-up during implementation via existing `update-manual` / `update-readme` skills (manual §8 gains the `update-extra` workflow).
+- No changes to `run_onchange_install-packages.sh.tmpl`, Renovate config, or any install spec.

--- a/openspec/changes/add-extra-updates-command/specs/classify-tool-updates-skill/spec.md
+++ b/openspec/changes/add-extra-updates-command/specs/classify-tool-updates-skill/spec.md
@@ -1,0 +1,74 @@
+# Delta: classify-tool-updates-skill
+
+## ADDED Requirements
+
+### Requirement: Skill exists as repo tooling
+
+The system SHALL provide a skill at `.claude/skills/classify-tool-updates/SKILL.md` whose description triggers auto-invocation when a new tool is added to the dotfiles (install script, zshrc-initialized tool, or new config). The skill SHALL live in repo-root `.claude/` (repo tooling), which chezmoi never applies to the system.
+
+#### Scenario: New tool added to install script
+
+- **WHEN** a new tool installation is added to `run_onchange_install-packages.sh.tmpl`
+- **THEN** the skill activates and classifies the tool by update mechanism
+
+#### Scenario: Not applied by chezmoi
+
+- **WHEN** `chezmoi apply` runs
+- **THEN** nothing under repo-root `.claude/` is deployed to `$HOME`
+
+### Requirement: Four-way update classification
+
+The skill SHALL classify each new tool into exactly one of four classes and prescribe the matching action:
+
+1. **brew-managed** → no action (`brew upgrade` covers it)
+2. **self-updating** → no action (do not wrap or duplicate the self-updater)
+3. **repo-pinned** (Renovate-managed pins, version-pinned installers) → update via pin bump + `chezmoi apply`, never via `update-extra`
+4. **manual** (none of the above) → add a step to `update-extra`
+
+#### Scenario: Brew formula added
+
+- **WHEN** the new tool is installed via brew formula or cask
+- **THEN** the skill classifies it brew-managed and proposes no `update-extra` change
+
+#### Scenario: Self-updating tool added
+
+- **WHEN** the new tool ships its own updater (e.g. installed via official curl installer that self-updates)
+- **THEN** the skill classifies it self-updating and proposes no `update-extra` change
+
+#### Scenario: Pinned tool added
+
+- **WHEN** the new tool is installed at a version pinned in the repo (Renovate-managed or hardcoded tag)
+- **THEN** the skill classifies it repo-pinned and points to the pin-bump + `chezmoi apply` path
+
+#### Scenario: Manual tool added
+
+- **WHEN** the new tool is neither brew-managed, self-updating, nor repo-pinned
+- **THEN** the skill classifies it manual and proposes its update command as a new `update-extra` step
+
+### Requirement: update-extra maintenance
+
+For a manual-class tool, the skill SHALL propose the exact one-line step addition (label + update command) for the `update-extra` function in `dot_zshrc.tmpl` and SHALL wait for user confirmation before editing. The skill SHALL also propose step removal when a manual-class tool is removed from the dotfiles. Each step add/remove proposal SHALL include the matching spec delta for the `extra-updates-command` capability, so the main spec's step list stays in sync.
+
+#### Scenario: Step proposed and confirmed
+
+- **WHEN** the skill classifies a tool as manual and the user confirms the proposal
+- **THEN** the step line is added to the `update-extra` function in `dot_zshrc.tmpl`
+
+#### Scenario: User rejects proposal
+
+- **WHEN** the user rejects the proposed step
+- **THEN** `dot_zshrc.tmpl` is not modified
+
+#### Scenario: Manual tool removed
+
+- **WHEN** a tool with an `update-extra` step is removed from the dotfiles
+- **THEN** the skill proposes removing its step
+
+### Requirement: Docs delegation
+
+The skill SHALL NOT edit `README.md` or `docs/manual.html` itself; after an `update-extra` change it SHALL point to the existing `update-manual` and `update-readme` skills for documentation follow-up.
+
+#### Scenario: Docs handled by existing skills
+
+- **WHEN** a step is added to `update-extra`
+- **THEN** the skill defers documentation updates to `update-manual`/`update-readme` instead of editing docs directly

--- a/openspec/changes/add-extra-updates-command/specs/extra-updates-command/spec.md
+++ b/openspec/changes/add-extra-updates-command/specs/extra-updates-command/spec.md
@@ -1,0 +1,90 @@
+# Delta: extra-updates-command
+
+## ADDED Requirements
+
+### Requirement: Single update entry point
+
+The system SHALL provide a zsh function `update-extra`, defined in `dot_zshrc.tmpl`, available in interactive shells, that orchestrates the update commands for tools that are neither brew-managed nor self-updating nor repo-pinned. The definition SHALL be preceded by an `unalias update-extra 2>/dev/null` guard so an alias with the same name cannot break the function definition.
+
+#### Scenario: User runs update-extra
+
+- **WHEN** the user runs `update-extra` in an interactive zsh session
+- **THEN** every configured update step executes in sequence
+
+#### Scenario: Alias name collision
+
+- **WHEN** a plugin defines an alias named `update-extra` before the function definition loads
+- **THEN** the function definition still succeeds because the alias is removed first
+
+### Requirement: Update step coverage
+
+`update-extra` SHALL run every step in its registered step list. The initial (v1) step list SHALL be exactly:
+
+1. gh extensions: `gh extension upgrade --all`
+2. you-should-use omz plugin: `git -C "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/you-should-use" pull --ff-only`
+3. skills.sh global skills: `npx -y skills update -g -y`
+4. plannotator CLI: re-run the official installer `https://plannotator.ai/install.sh`
+5. Catppuccin theme assets: re-download the bat, delta, zsh-syntax-highlighting, and atuin theme files from the same URLs used by `run_onchange_install-packages.sh.tmpl`, followed by `bat cache --build`
+6. television channels: `tv update-channels`
+
+#### Scenario: gh extensions updated
+
+- **WHEN** `update-extra` runs
+- **THEN** `gh extension upgrade --all` executes
+
+#### Scenario: you-should-use updated
+
+- **WHEN** `update-extra` runs
+- **THEN** the you-should-use clone under `$ZSH_CUSTOM/plugins` is fast-forwarded to upstream
+
+#### Scenario: skills.sh globals updated
+
+- **WHEN** `update-extra` runs
+- **THEN** `npx -y skills update -g -y` executes against the global skill set
+
+#### Scenario: plannotator updated
+
+- **WHEN** `update-extra` runs
+- **THEN** the official plannotator installer re-runs, replacing the binary with the latest release
+
+#### Scenario: Catppuccin themes refreshed
+
+- **WHEN** `update-extra` runs
+- **THEN** the four theme assets are re-downloaded and the bat cache is rebuilt
+
+#### Scenario: television channels updated
+
+- **WHEN** `update-extra` runs
+- **THEN** `tv update-channels` executes
+
+### Requirement: Failure resilience
+
+A failing step SHALL NOT abort the remaining steps. `update-extra` SHALL report each failure as it happens, print a final summary with succeeded/failed counts, and return non-zero if any step failed.
+
+#### Scenario: One step fails mid-run
+
+- **WHEN** a step in the middle of the sequence fails
+- **THEN** all subsequent steps still execute, the summary lists the failed step, and the function returns non-zero
+
+#### Scenario: All steps succeed
+
+- **WHEN** every step succeeds
+- **THEN** the summary reports all steps ok and the function returns 0
+
+### Requirement: Per-step progress output
+
+`update-extra` SHALL print each step's name before running it and a `✓` (success) or `✗` (failure) result after it, so the user can tell which tool produced which output.
+
+#### Scenario: Step output labelled
+
+- **WHEN** a step runs
+- **THEN** its label is printed before its output and its ✓/✗ status after
+
+### Requirement: Scope exclusions
+
+`update-extra` SHALL NOT invoke `brew`, any tool's self-updater, or any update path for repo-pinned tools (Renovate-managed MCP pins, pinned installers such as nvm or tmux Catppuccin).
+
+#### Scenario: No overlap with existing update mechanisms
+
+- **WHEN** `update-extra` runs
+- **THEN** no `brew` command executes and no repo-managed pin changes

--- a/openspec/changes/add-extra-updates-command/tasks.md
+++ b/openspec/changes/add-extra-updates-command/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: add-extra-updates-command
+
+## 1. update-extra function
+
+- [x] 1.1 Add `_update_extra_step` helper and `update-extra` function to the aliases section of `dot_zshrc.tmpl` (before the zoxide init at the end), with `unalias update-extra 2>/dev/null` guard
+- [x] 1.2 Wire the six steps with the exact commands from design D4 (gh extensions, you-should-use `--ff-only`, skills.sh `-g -y`, plannotator installer, 4 Catppuccin assets + `bat cache --build`, `tv update-channels`)
+- [x] 1.3 Verify in a fresh interactive zsh: full run prints per-step label + ✓/✗ and summary; force one step to fail and confirm remaining steps run and exit code is non-zero
+
+## 2. classify-tool-updates skill
+
+- [x] 2.1 Create `.claude/skills/classify-tool-updates/SKILL.md` following the `update-manual` structure (When This Activates / Workflow / propose-then-confirm / Guardrails), encoding the four-way classification tree, the one-line step add/remove proposal for `update-extra`, and docs delegation to `update-manual`/`update-readme`
+
+## 3. Docs
+
+- [x] 3.1 Run the `update-manual` skill: add the `update-extra` workflow to docs/manual.html (§8 Brew/maintenance area)
+- [x] 3.2 Run the `update-readme` skill: assess whether README daily workflows need an `update-extra` mention
+
+## 4. Sync and validation
+
+- [ ] 4.1 `chezmoi update` on the live machine (dev clone ≠ chezmoi source dir) and confirm `update-extra` is available in a new shell
+- [ ] 4.2 `openspec validate add-extra-updates-command` passes; run `/opsx:verify` before archiving

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,1 @@
+schema: spec-driven


### PR DESCRIPTION
Linear: [DOT-28](https://linear.app/monolab/issue/DOT-28/comando-custom-de-actualizacion-de-herramientas-no-brew-no)

## What

- `update-extra` zsh function in `dot_zshrc.tmpl`: single entry point for tools that are neither brew-managed, self-updating, nor repo-pinned — gh extensions, you-should-use, skills.sh globals, plannotator, Catppuccin theme assets, tv channels. Per-step ✓/✗ output, failing steps report and continue, final `N ok, M failed` summary, non-zero exit on any failure.
- `classify-tool-updates` project skill (`.claude/skills/`): four-way classification for new tools (brew / self-updating / repo-pinned / manual) that keeps the `update-extra` step list in sync.
- Docs: manual §8 gains an Extra Updates subsection + maintenance flow; README gains an Updating Tools workflow.
- OpenSpec change `add-extra-updates-command` (proposal / design / specs / tasks); archive follows after merge.

## Verification

- Fresh interactive zsh, failure injection: middle step fails → remaining steps run, `5 ok, 1 failed`, exit 1.
- Fresh interactive zsh, real run: `6 ok, 0 failed`, exit 0 (gh dash 4.23.2→4.24.1, gh enhance 0.5.1→0.6.1, you-should-use fast-forwarded, 19 global skills updated, themes re-downloaded + bat cache rebuilt, tv channels refreshed). Plannotator step stubbed in-session (curl|bash permission rule) — exercised on first manual run.
- `openspec validate add-extra-updates-command` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `update-extra` command to update non-brew tooling in a single flow, with per-step success/failure reporting and continued execution even if a step fails.
  * Added an automated skill to classify newly added/removed tools and keep the appropriate update path aligned over time.

* **Documentation**
  * Updated the README and manual to include the new “Updating Tools” workflow and show how to run full maintenance with `bubu` followed by `update-extra`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->