### PR TITLE
feat(fallow): add fallow codebase intelligence (DOT-22)

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
+    "$schema": "./node_modules/fallow/schema.json",
     // commitlint + lint-staged configs are auto-detected by built-in plugins;
     // oxfmt has no fallow plugin, so its config must be an explicit entry
     "entry": ["oxfmt.config.ts"],
@@ -19,5 +19,7 @@
         // the tools themselves, not by imports
         "unused-exports": "off",
         "unused-types": "off",
+        // suppression comments must carry a reason
+        "require-suppression-reason": "warn",
     },
 }

--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
+    // commitlint + lint-staged configs are auto-detected by built-in plugins;
+    // oxfmt has no fallow plugin, so its config must be an explicit entry
+    "entry": ["oxfmt.config.ts"],
+    "ignorePatterns": [
+        "**/*.tmpl",
+        "dot_config/**",
+        "dot_claude/**",
+        "dot_local/**",
+        "Library/**",
+        "assets/**",
+        "docs/**",
+        "openspec/**",
+    ],
+    "ignoreDependencies": ["@types/bun"],
+    "rules": {
+        // the repo's only exports are tool-config default exports consumed by
+        // the tools themselves, not by imports
+        "unused-exports": "off",
+        "unused-types": "off",
+    },
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,9 @@ jobs:
 
             - name: 🔍 Validate OpenSpec change proposals
               run: bunx @fission-ai/openspec@1.2.0 validate --changes --no-interactive
+
+            # PRs are gated by fallow.yml (audit, new-only ratchet); this catches
+            # dead code landing on main via direct pushes
+            - name: 🔍 Fallow dead-code gate (full repo)
+              run: bunx fallow dead-code --fail-on-issues
+              if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -1,0 +1,26 @@
+name: Fallow
+
+on:
+    pull_request: {}
+
+permissions:
+    contents: read
+    checks: write
+    pull-requests: write
+
+jobs:
+    audit:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: 🔍 Fallow audit
+              uses: fallow-rs/fallow@v3
+              with:
+                  command: audit
+                  gate: new-only
+                  comment: true
+                  comment-layout: compact

--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -16,6 +16,7 @@ jobs:
               uses: actions/checkout@v4
               with:
                   fetch-depth: 0
+                  persist-credentials: false
 
             - name: 🔍 Fallow audit
               uses: fallow-rs/fallow@v3

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 node_modules/
 .claude/settings.local.json
 .claude/.worktree-base
+# fallow analysis cache
+.fallow/

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ chezmoi-managed dotfiles for macOS (primary) with Linux support. Built around Gh
 | **CLI Tools**  | [mole](https://github.com/tw93/mole)                                            | Deep clean and optimize your Mac — caches, logs, app remnants, `node_modules` (macOS only) |
 | **CLI Tools**  | [glow](https://github.com/charmbracelet/glow)                                   | Terminal Markdown viewer — TUI browse + CLI render                                         |
 | **CLI Tools**  | [mdfried](https://github.com/benjajaja/mdfried)                                 | Markdown viewer with inline images, mermaid diagrams, and Big Headers (graphics terminal)  |
+| **CLI Tools**  | [fallow](https://fallow.tools/)                                                 | Codebase intelligence for TS/JS — dead code, duplication, complexity (CLI + MCP + skill)   |
 | **Git**        | [git-delta](https://github.com/dandavison/delta)                                | Syntax-highlighted diff viewer                                                             |
 | **Git**        | [lazygit](https://github.com/jesseduffield/lazygit)                             | TUI for git operations                                                                     |
 | **Git**        | [GitHub CLI](https://cli.github.com/)                                           | GitHub from the terminal                                                                   |
@@ -58,7 +59,7 @@ chezmoi-managed dotfiles for macOS (primary) with Linux support. Built around Gh
 
 ## MCP Servers
 
-The install script registers 13 global MCP servers to `~/.claude.json` (the stdio set is shared with OpenCode). Atlassian, Figma, Linear, and Notion authenticate via OAuth on first use; stdio servers run pinned versions managed by Renovate.
+The install script registers 14 global MCP servers to `~/.claude.json` (the stdio set is shared with OpenCode). Atlassian, Figma, Linear, and Notion authenticate via OAuth on first use; stdio servers run pinned versions managed by Renovate (fallow tracks the global npm install instead).
 
 | Server          | Transport | Description                                | Auth / Setup                                                            |
 | --------------- | --------- | ------------------------------------------ | ----------------------------------------------------------------------- |
@@ -69,6 +70,7 @@ The install script registers 13 global MCP servers to `~/.claude.json` (the stdi
 | playwright      | stdio     | Browser automation and testing             | —                                                                       |
 | chrome-devtools | stdio     | Inspect/control browser sessions           | —                                                                       |
 | expect          | stdio     | Visual testing and accessibility audits    | —                                                                       |
+| fallow          | stdio     | Codebase intelligence: dead code, dupes    | Runs the global `fallow-mcp` binary (npm)                               |
 | gh_grep         | http      | Search across GitHub repos                 | —                                                                       |
 | atlassian       | http      | Jira & Confluence integration              | OAuth on first use                                                      |
 | figma           | http      | Figma design context (Dev Mode)            | OAuth on first use                                                      |

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@commitlint/config-conventional": "21.1.0",
         "@commitlint/types": "21.1.0",
         "@types/bun": "^1.3.14",
+        "fallow": "3.0.0",
         "husky": "^9.1.7",
         "lint-staged": "17.0.8",
         "oxfmt": "0.54.0",
@@ -55,6 +56,22 @@
     "@commitlint/types": ["@commitlint/types@21.1.0", "", { "dependencies": { "conventional-commits-parser": "^6.3.0", "picocolors": "^1.1.1" } }, "sha512-YodnnnH1Cp+08nP8HGNJAIuB6L3/vdCTHVRTfF8Ik/wRCLOTsU9zwv3yO1cSPQRDa9CLYtE+UJ2K67r7CwMSFw=="],
 
     "@conventional-changelog/git-client": ["@conventional-changelog/git-client@2.7.0", "", { "dependencies": { "@simple-libs/child-process-utils": "^1.0.0", "@simple-libs/stream-utils": "^1.2.0", "semver": "^7.5.2" }, "peerDependencies": { "conventional-commits-filter": "^5.0.0", "conventional-commits-parser": "^6.4.0" }, "optionalPeers": ["conventional-commits-filter", "conventional-commits-parser"] }, "sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw=="],
+
+    "@fallow-cli/darwin-arm64": ["@fallow-cli/darwin-arm64@3.0.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TTHcDnN6ipqwml5FgOt0axHXiTeoTOarWRcbmykyHzDaSSF9tEg//dL2aoOxJUearK+aUSpmY2U4ar4rOmOnHg=="],
+
+    "@fallow-cli/darwin-x64": ["@fallow-cli/darwin-x64@3.0.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-u4KEs4Mchhwuei5IASx5yS80LjjDNT/Xll7CwvZbMD0JOPV1BlWDdCccLGjW+Dr0MyusKvpwhQJosgKrKCXeOg=="],
+
+    "@fallow-cli/linux-arm64-gnu": ["@fallow-cli/linux-arm64-gnu@3.0.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-QH7RMbXesaPjXInfaZvIquMgFFU3sBex8a7NRCQKgdtXVsaDNCViLAMjT8jgI3ueiVmwUwHk2hiuktdgMd7o/w=="],
+
+    "@fallow-cli/linux-arm64-musl": ["@fallow-cli/linux-arm64-musl@3.0.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-gwoM0kcBPyEBajsap8DqmQ/C4OsnprPnvM6JMQ1etH+cdJiF94zkomnf/+i8nHVzL093rvqzTvVZnipNSYBmEQ=="],
+
+    "@fallow-cli/linux-x64-gnu": ["@fallow-cli/linux-x64-gnu@3.0.0", "", { "os": "linux", "cpu": "x64" }, "sha512-lRgS1GbC9jCNr7j7aXv0bFhuy0wundUzaa9tCyPlSS7pga2uLIkOnes0pugv4SuLkIYy7moTapEdLebivDzFKg=="],
+
+    "@fallow-cli/linux-x64-musl": ["@fallow-cli/linux-x64-musl@3.0.0", "", { "os": "linux", "cpu": "x64" }, "sha512-CsDTKLE/TJwZBZnU5/4GBkWrw9XaSVetrxiFRlnhHLJ2KpOrrBF7nxeTREvl/GdJTxlu5fY1JlAm5HVAKmyw0A=="],
+
+    "@fallow-cli/win32-arm64-msvc": ["@fallow-cli/win32-arm64-msvc@3.0.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-6/nUg47m+VO9dRTRlbzPHaxce7mpR/ltB0W9iSjdj+fxB3JlLRpz91mQ1LJRRUGmIXgcbsxswnKwnOTld+2RbA=="],
+
+    "@fallow-cli/win32-x64-msvc": ["@fallow-cli/win32-x64-msvc@3.0.0", "", { "os": "win32", "cpu": "x64" }, "sha512-IQE8RBjFGonbJ6Vz7hcQTZ6serIA4atFd0CIv+69EsN0pNzU5k57dUTHV6zx5Bnn/wgrjE6saSZrsYwSESoCwA=="],
 
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.54.0", "", { "os": "android", "cpu": "arm" }, "sha512-NAtpl/SiaeU103e7/OmZw0MvUnsUUopW7hEm/ecegJg7YM0skQaA0IXEZoyTV6NUdiNPupdIUreRqUZTShbn/g=="],
 
@@ -136,6 +153,8 @@
 
     "cosmiconfig-typescript-loader": ["cosmiconfig-typescript-loader@6.2.0", "", { "dependencies": { "jiti": "^2.6.1" }, "peerDependencies": { "@types/node": "*", "cosmiconfig": ">=9", "typescript": ">=5" } }, "sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ=="],
 
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
     "dot-prop": ["dot-prop@5.3.0", "", { "dependencies": { "is-obj": "^2.0.0" } }, "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
@@ -151,6 +170,8 @@
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "fallow": ["fallow@3.0.0", "", { "dependencies": { "detect-libc": "2.1.2" }, "optionalDependencies": { "@fallow-cli/darwin-arm64": "3.0.0", "@fallow-cli/darwin-x64": "3.0.0", "@fallow-cli/linux-arm64-gnu": "3.0.0", "@fallow-cli/linux-arm64-musl": "3.0.0", "@fallow-cli/linux-x64-gnu": "3.0.0", "@fallow-cli/linux-x64-musl": "3.0.0", "@fallow-cli/win32-arm64-msvc": "3.0.0", "@fallow-cli/win32-x64-msvc": "3.0.0" }, "bin": { "fallow": "bin/fallow", "fallow-lsp": "bin/fallow-lsp", "fallow-mcp": "bin/fallow-mcp" } }, "sha512-GX9ujIhUxSXvxA1GpZUlD1gz9SUSDSJ+nOSRKBN4F1lN85AFeUBmYw5HhdbumE9IJAR+9jAnTfcUMfyqQ2b5xA=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -1558,6 +1558,53 @@
                         </tbody>
                     </table>
 
+                    <h3>fallow (codebase intelligence)</h3>
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Command</th>
+                                <th>Description</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td><code>bunx fallow</code></td>
+                                <td>
+                                    Combined analysis &mdash; dead code, duplication, complexity
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><code>bunx fallow dead-code</code></td>
+                                <td>Unused files, exports and dependencies</td>
+                            </tr>
+                            <tr>
+                                <td><code>bunx fallow dupes</code></td>
+                                <td>Code duplication detection</td>
+                            </tr>
+                            <tr>
+                                <td><code>bunx fallow health</code></td>
+                                <td>Complexity hotspots (cyclomatic / cognitive / CRAP)</td>
+                            </tr>
+                            <tr>
+                                <td><code>bunx fallow audit</code></td>
+                                <td>
+                                    Changed-file quality gate vs merge-base &mdash; also
+                                    <code>bun run lint:fallow</code>; CI runs it on PRs
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><code>bunx fallow fix --dry-run</code></td>
+                                <td>Preview auto-removal of unused code</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <p>
+                        Installed globally via npm (<code>fallow</code>,
+                        <code>fallow-lsp</code>, <code>fallow-mcp</code>) and pinned as a repo
+                        devDependency. Free static tier only &mdash; the paid Fallow Runtime layer
+                        (license, coverage, cloud) is not configured.
+                    </p>
+
                     <h3>jq helpers</h3>
                     <table>
                         <thead>
@@ -1958,8 +2005,8 @@
                                 <td>
                                     Update tools that are neither brew-managed nor self-updating: gh
                                     extensions, you-should-use, skills.sh globals, plannotator,
-                                    Catppuccin themes, tv channels &mdash; a failing step reports
-                                    and continues; summary at the end
+                                    Catppuccin themes, tv channels, fallow &mdash; a failing step
+                                    reports and continues; summary at the end
                                 </td>
                             </tr>
                         </tbody>
@@ -2302,6 +2349,10 @@
                                 <td>elements-of-style</td>
                                 <td>Strunk's writing rules for prose</td>
                             </tr>
+                            <tr>
+                                <td>fallow</td>
+                                <td>Dead code / duplication / complexity analysis via fallow</td>
+                            </tr>
                         </tbody>
                     </table>
 
@@ -2349,6 +2400,11 @@
                                 <td>expect</td>
                                 <td>Visual testing and accessibility audits</td>
                                 <td>&mdash;</td>
+                            </tr>
+                            <tr>
+                                <td>fallow</td>
+                                <td>Codebase intelligence: dead code, duplication, complexity</td>
+                                <td>Runs the global <code>fallow-mcp</code> binary (npm)</td>
                             </tr>
                             <tr>
                                 <td>gh_grep</td>

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -22,6 +22,7 @@
     "experiments@monolab": true,
     "expo-developer@monolab": true,
     "expo@expo-plugins": true,
+    "fallow@fallow-skills": true,
     "frontend-design@claude-plugins-official": true,
     "plannotator@plannotator": true,
     "plugin-dev@claude-plugins-official": true,

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -361,6 +361,7 @@ update-extra() {
   _update_extra_step "plannotator" _update_extra_plannotator
   _update_extra_step "Catppuccin themes" _update_extra_catppuccin
   _update_extra_step "television channels" tv update-channels
+  _update_extra_step "fallow" npm install -g fallow@latest
   echo "\nupdate-extra: $_ue_ok ok, $_ue_failed failed"
   (( _ue_failed == 0 ))
 }

--- a/lint-staged.config.ts
+++ b/lint-staged.config.ts
@@ -3,4 +3,7 @@ import type { Configuration } from "lint-staged";
 export default {
     "*": "oxfmt --no-error-on-unmatched-pattern --ignore-path .oxfmtignore",
     "renovate.json": "bunx --package renovate@43.227.0 renovate-config-validator --strict",
+    // global (function ignores the file list): runs once per commit touching
+    // JS surface; audit = new-only ratchet on changed files
+    "*.{ts,js,json,jsonc}": () => "bunx fallow audit",
 } satisfies Configuration;

--- a/openspec/changes/add-fallow/.openspec.yaml
+++ b/openspec/changes/add-fallow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-04

--- a/openspec/changes/add-fallow/design.md
+++ b/openspec/changes/add-fallow/design.md
@@ -92,6 +92,8 @@ Complementary push gate in `ci.yml` (adopted from monolab's setup): `bunx fallow
 
 Matches the `lint:oxfmt` naming. Runs the same analysis CI runs (local invocation resolves the devDep via bun's script PATH). Full-repo one-shots stay ad-hoc (`bunx fallow`, `bunx fallow dead-code`, …) and are documented in the manual instead of multiplying scripts.
 
+The same audit also runs at pre-commit via lint-staged, as a global function task (`"*.{ts,js,json,jsonc}": () => "bunx fallow audit"`): the function form ignores the file list so fallow runs once per commit, and only for commits touching JS surface — doc/template commits pay nothing. This is the per-project opt-in the Non-Goals reserve; fallow's native `fallow hooks install` stays out.
+
 ## Risks / Trade-offs
 
 - [Global/local version skew: user-scope `fallow-mcp` always runs the global CLI, even inside this repo where the devDep pin may differ] → Accepted. Both tracks stay current (update-extra / Renovate); docs document no incompatibility. Escape hatch if it ever bites: project `.mcp.json` entry `{"command": "bunx", "args": ["fallow-mcp"]}` shadowing the user-scope name.

--- a/openspec/changes/add-fallow/design.md
+++ b/openspec/changes/add-fallow/design.md
@@ -52,7 +52,8 @@ Per the classify-tool-updates taxonomy the global install is manual-class (not b
 
 ```jsonc
 {
-    "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
+    // local schema: always matches the pinned devDep version, works offline
+    "$schema": "./node_modules/fallow/schema.json",
     // commitlint + lint-staged configs are auto-detected by built-in plugins;
     // oxfmt has no fallow plugin, so its config must be an explicit entry
     "entry": ["oxfmt.config.ts"],
@@ -62,10 +63,14 @@ Per the classify-tool-updates taxonomy the global install is manual-class (not b
         // the repo's only exports are tool-config default exports consumed by
         // the tools themselves, not by imports
         "unused-exports": "off",
-        "unused-types": "off"
+        "unused-types": "off",
+        // suppression comments must carry a reason
+        "require-suppression-reason": "warn"
     }
 }
 ```
+
+The `.fallow/` analysis cache is gitignored.
 
 `.jsonc` extension over `.fallowrc.json` (both parsed as JSONC, lookup positions 1–2): the extension signals comments to editors and to oxfmt via lint-staged, which formats `"*"`. If oxfmt still mishandles it, the file goes into `.oxfmtignore` (established pattern). Discovery is verified at implementation with `bunx fallow list` (expected: commitlint/lint-staged plugins active, `oxfmt.config.ts` an entry, zero unused-file findings).
 
@@ -80,6 +85,8 @@ steps:
 ```
 
 Separate file rather than a job in `ci.yml`: the action needs write permissions (`checks`, `pull-requests`) that the existing workflow doesn't have and shouldn't gain. No setup-bun/`bun install` in this job — the action is self-contained. `@v3` (tag exists; npm 3.0.0 matches; the `@v2` in doc examples is lag) — Renovate's `config:best-practices` pins it to a digest and manages bumps. `gate: new-only` is ratchet semantics: only findings introduced by the PR fail (exit 1 / verdict `fail`); pre-existing findings report but pass. `fallow review` is never used as a gate (always exits 0). SARIF upload stays off (action default).
+
+Complementary push gate in `ci.yml` (adopted from monolab's setup): `bunx fallow dead-code --fail-on-issues` on `push` events only — direct-to-main commits (the repo's chore flow) bypass PRs and thus `fallow.yml`; PR runs keep the new-only ratchet untouched.
 
 ### D8: package.json script `lint:fallow` = `fallow audit`
 

--- a/openspec/changes/add-fallow/design.md
+++ b/openspec/changes/add-fallow/design.md
@@ -1,0 +1,102 @@
+# Design: add-fallow
+
+## Context
+
+fallow ships as a single npm package (`fallow` 3.0.0, MIT) with three bins: `fallow` (CLI), `fallow-lsp`, `fallow-mcp`. The static layer is free; the runtime layer (Fallow Runtime) is paid and license-gated. The repo already has every integration pattern this change needs: npm-adjacent installs in `run_onchange_install-packages.sh.tmpl` (Group 6 bootstraps nvm/node), MCP registration via `claude mcp add --scope user`, Claude Code plugin marketplaces/plugins arrays, `update-extra` for manual-class updates, Renovate for repo pins, and bun devDependencies for repo tooling.
+
+Research findings that shape this design (docs.fallow.tools, action.yml, npm registry):
+
+- `fallow-mcp` shells out to the `fallow` CLI: `FALLOW_BIN` env var, else `fallow` from PATH. It never consults local `node_modules`.
+- The official GitHub Action `fallow-rs/fallow` is a composite action that downloads its own binary and, when its `version` input is omitted, reads the version from the repo's `package.json` fallow dependency.
+- fallow has built-in plugins for commitlint and lint-staged (activated by their packages being in devDependencies), so their config files are auto-detected entries. There is no oxfmt plugin → `oxfmt.config.ts` needs a manual `entry`.
+- Telemetry is opt-in and off by default; nothing to disable.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- fallow usable in any project on the machine (CLI + MCP + agent skill) — global layer.
+- fallow wired into this repo like the rest of the JS tooling (devDep + config + script + CI) — project layer.
+- Every version track has an owner: global → `update-extra`; devDep + action → Renovate.
+
+**Non-Goals:**
+
+- Paid runtime layer: no `fallow license`, `fallow coverage`, `FALLOW_LICENSE`/`FALLOW_API_*` anywhere.
+- `fallow hooks install` (PreToolUse commit/push gate): too intrusive to enable machine-wide; per-project opt-in remains available manually.
+- LSP/editor integration (VS Code extension): primary editor is WebStorm; `fallow-lsp` ships with the package but nothing configures it.
+- Per-project `.mcp.json` override in this repo (see Risks).
+
+## Decisions
+
+### D1: Global install via `npm install -g fallow`, new group after NVM/Node
+
+Docs-recommended path; one package delivers all three bins. Requires node, which Group 6 already bootstraps — the new group follows it and skips with a warning when node is absent. Alternatives: Homebrew (no formula exists), `cargo install fallow-cli` (CLI only, no bundled MCP), GitHub Releases binary (unmanaged updates, no bin bundle guarantee). Pre-scan idempotency: `command -v fallow`.
+
+### D2: MCP registered from PATH binary, not an npx pin
+
+`claude mcp add --scope user fallow -- fallow-mcp`. Unlike the other 13 stdio servers (`npx -y pkg@version`), the fallow entry carries no version: `fallow-mcp` and the CLI it shells out to come from the same global install, so they can never skew from each other. An npx-pinned entry (`npx -y -p fallow@3.0.0 fallow-mcp`) would be Renovate-managed but re-downloads a large Rust binary per session start and can skew against the global CLI. Consequence for the install script: the fallow entry participates only in presence detection, not in the `pkg@version` outdated-check loop.
+
+### D3: Agent skill via official plugin, enabled in settings template
+
+`claude plugin marketplace add fallow-rs/fallow-skills` + `claude plugin install fallow-skills@fallow-rs/fallow-skills` appended to the existing `CC_MARKETPLACES`/`CC_PLUGINS` arrays, plus `"fallow-skills@fallow-skills": true` in `dot_claude/settings.json.tmpl` `enabledPlugins` (exact key verified at implementation from `claude plugin list --json`, following the plannotator precedent). The skill invokes fallow via `npx fallow`, so it resolves a project-local devDep first and falls back to the registry — works with or without the global install.
+
+### D4: `update-extra` step runs `npm install -g fallow@latest`
+
+Per the classify-tool-updates taxonomy the global install is manual-class (not brew, not self-updating, not repo-pinned). `npm install -g fallow@latest` over `npm update -g fallow`: unambiguous target version, immune to `npm update -g` semver-range quirks, and idempotent. (Supersedes the `npm update -g fallow` shorthand in the proposal.)
+
+### D5: devDep pinned exact, doubling as the CI version pin
+
+`bun add -d --exact fallow` — matches the repo convention for tool CLIs (commitlint, lint-staged, oxfmt are exact; only type packages use ranges). Renovate manages it under the standard npm rules (14-day minimum release age). The CI action's `version` input is deliberately omitted so it reads this same pin — one version source for the project layer.
+
+### D6: Config is `.fallowrc.jsonc`, tuned for signal over noise
+
+```jsonc
+{
+    "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
+    // commitlint + lint-staged configs are auto-detected by built-in plugins;
+    // oxfmt has no fallow plugin, so its config must be an explicit entry
+    "entry": ["oxfmt.config.ts"],
+    "ignorePatterns": ["**/*.tmpl", "dot_config/**", "dot_claude/**", "dot_local/**", "Library/**", "assets/**", "docs/**", "openspec/**"],
+    "ignoreDependencies": ["@types/bun"],
+    "rules": {
+        // the repo's only exports are tool-config default exports consumed by
+        // the tools themselves, not by imports
+        "unused-exports": "off",
+        "unused-types": "off"
+    }
+}
+```
+
+`.jsonc` extension over `.fallowrc.json` (both parsed as JSONC, lookup positions 1–2): the extension signals comments to editors and to oxfmt via lint-staged, which formats `"*"`. If oxfmt still mishandles it, the file goes into `.oxfmtignore` (established pattern). Discovery is verified at implementation with `bunx fallow list` (expected: commitlint/lint-staged plugins active, `oxfmt.config.ts` an entry, zero unused-file findings).
+
+### D7: CI as a separate `fallow.yml` workflow using the official action
+
+```yaml
+on: pull_request
+permissions: { contents: read, checks: write, pull-requests: write }
+steps:
+    - actions/checkout@v4 with fetch-depth: 0
+    - fallow-rs/fallow@v3 with { command: audit, gate: new-only, comment: true, comment-layout: compact }
+```
+
+Separate file rather than a job in `ci.yml`: the action needs write permissions (`checks`, `pull-requests`) that the existing workflow doesn't have and shouldn't gain. No setup-bun/`bun install` in this job — the action is self-contained. `@v3` (tag exists; npm 3.0.0 matches; the `@v2` in doc examples is lag) — Renovate's `config:best-practices` pins it to a digest and manages bumps. `gate: new-only` is ratchet semantics: only findings introduced by the PR fail (exit 1 / verdict `fail`); pre-existing findings report but pass. `fallow review` is never used as a gate (always exits 0). SARIF upload stays off (action default).
+
+### D8: package.json script `lint:fallow` = `fallow audit`
+
+Matches the `lint:oxfmt` naming. Runs the same analysis CI runs (local invocation resolves the devDep via bun's script PATH). Full-repo one-shots stay ad-hoc (`bunx fallow`, `bunx fallow dead-code`, …) and are documented in the manual instead of multiplying scripts.
+
+## Risks / Trade-offs
+
+- [Global/local version skew: user-scope `fallow-mcp` always runs the global CLI, even inside this repo where the devDep pin may differ] → Accepted. Both tracks stay current (update-extra / Renovate); docs document no incompatibility. Escape hatch if it ever bites: project `.mcp.json` entry `{"command": "bunx", "args": ["fallow-mcp"]}` shadowing the user-scope name.
+- [nvm switching node versions orphans the global fallow (globals are per-node-version)] → Same exposure as every npm global under nvm; re-running the install script or `update-extra` restores it. Known, not new.
+- [oxfmt (lint-staged `"*"`) may corrupt or reject `.fallowrc.jsonc`] → Verified during implementation; `.oxfmtignore` entry if needed (precedent: chezmoi modify_/run_ scripts).
+- [First CI runs may annotate pre-existing findings in touched files] → `gate: new-only` keeps them non-blocking; the tuned config plus a `bunx fallow list` verification pass minimizes false positives before the workflow lands.
+- [Action inputs differ between doc pages (v2 vs v3 staleness)] → Inputs used here (`command`, `gate`, `comment`, `comment-layout`) verified against `action.yml` on `main`; re-verify against the `v3` tag at implementation.
+
+## Migration Plan
+
+Forward: single PR; machine-side effects land on next `chezmoi apply` + install script run (new group, MCP add, plugin install). Rollback: revert the PR; manual cleanup on affected machines — `npm rm -g fallow`, `claude mcp remove fallow -s user`, `claude plugin uninstall fallow-skills@fallow-skills`.
+
+## Open Questions
+
+None blocking. Implementation-time verifications (tracked as tasks): exact `enabledPlugins` key for fallow-skills, oxfmt behavior on `.fallowrc.jsonc`, `bunx fallow list` discovery output, action input names against the `v3` tag.

--- a/openspec/changes/add-fallow/proposal.md
+++ b/openspec/changes/add-fallow/proposal.md
@@ -1,0 +1,46 @@
+# Add fallow (DOT-22)
+
+## Why
+
+[fallow](https://fallow.tools/) is codebase intelligence for TS/JS (dead code, duplication, circular deps, complexity, architecture boundaries) — Rust-native, sub-second, MIT. The dev environment has no graph-level analysis tool wired in for agents or humans; fallow fills that gap alongside eslint/knip MCP servers already registered. Free static layer only — the paid runtime layer (Fallow Runtime) stays out of scope.
+
+## What Changes
+
+Dual integration:
+
+**Global layer** (machine setup — usable in any project):
+
+- Install `fallow` globally via npm in `run_onchange_install-packages.sh.tmpl` (one package ships the three bins: `fallow`, `fallow-lsp`, `fallow-mcp`).
+- Register `fallow` MCP server user-scope via `claude mcp add --scope user fallow -- fallow-mcp` (stdio, PATH binary — no npx pin; version tracked by the global install).
+- Install the `fallow-skills` Claude Code plugin (marketplace `fallow-rs/fallow-skills`, plugin `fallow-skills@fallow-rs/fallow-skills`) and enable it in `dot_claude/settings.json.tmpl`.
+- Add a `fallow` step to `update-extra` (`npm update -g fallow`).
+
+**Project layer** (this repo, same pattern as commitlint/lint-staged/oxfmt):
+
+- `bun add -d fallow` — Renovate-managed pin; also the version source for CI (the official action reads the `package.json` dependency).
+- `.fallowrc.jsonc` tuned for this repo: `entry: ["oxfmt.config.ts"]` (only config without a built-in fallow plugin; commitlint/lint-staged are auto-detected), ignore chezmoi surface (`**/*.tmpl`, `dot_*/`, etc.), `unused-exports`/`unused-types` off.
+- `package.json` script `lint:fallow` (`fallow audit`).
+- New `.github/workflows/fallow.yml` using the official `fallow-rs/fallow@v3` composite action (`command: audit`, `gate: new-only`, compact sticky PR comment; self-contained — no setup-bun in that job).
+
+Docs (README What's Included + manual) updated via the `update-readme`/`update-manual` skills as implementation tasks; no spec-level docs changes.
+
+## Capabilities
+
+### New Capabilities
+
+- `fallow-install`: global fallow installation — npm global install group in the install script, idempotency, and the three bundled binaries available on PATH.
+- `fallow-project-config`: fallow as a devDependency of this repo with `.fallowrc.jsonc` config and `lint:fallow` script.
+- `fallow-ci`: PR-gated fallow audit workflow in GitHub Actions via the official action.
+
+### Modified Capabilities
+
+- `mcp-global-config`: MCP server table grows from 13 to 14 — new `fallow` stdio server registered from the PATH binary (first non-npx-pinned stdio entry; update-path requirement must account for it).
+- `claude-code-plugins`: new marketplace (`fallow-rs/fallow-skills`) and plugin (`fallow-skills`) in the install script arrays; `enabledPlugins` entry in `dot_claude/settings.json.tmpl`.
+- `extra-updates-command`: step list gains a `fallow` step (`npm update -g fallow`).
+
+## Impact
+
+- **Files**: `run_onchange_install-packages.sh.tmpl`, `dot_zshrc.tmpl`, `dot_claude/settings.json.tmpl`, `package.json` + `bun.lock`, new `.fallowrc.jsonc`, new `.github/workflows/fallow.yml`, `README.md`, `docs/manual.html`. Possibly `.oxfmtignore` (verify oxfmt vs JSONC comments before committing `.fallowrc.jsonc`).
+- **Dependencies**: `fallow` 3.0.0 (npm, global + devDep), `fallow-rs/fallow@v3` action, `fallow-rs/fallow-skills` plugin. Renovate manages the devDep and the action natively; the global install updates via `update-extra`.
+- **Known trade-off**: user-scope `fallow-mcp` always resolves the global `fallow` from PATH; inside this repo the devDep pin may skew from the global version. Accepted — both tracks stay current (Renovate / update-extra), and `.mcp.json` project override via `bunx fallow-mcp` remains available as an escape hatch.
+- **Free tier only**: no `FALLOW_LICENSE`, no cloud/coverage env vars, no `fallow license`/`coverage` usage anywhere.

--- a/openspec/changes/add-fallow/specs/claude-code-plugins/spec.md
+++ b/openspec/changes/add-fallow/specs/claude-code-plugins/spec.md
@@ -4,7 +4,7 @@
 
 ### Requirement: Fallow-skills marketplace and plugin are registered in install script
 
-The install script SHALL include `fallow-rs/fallow-skills` in the `CC_MARKETPLACES` array and the fallow-skills plugin in the `CC_PLUGINS` array, installed via the existing marketplace/plugin loops (`claude plugin marketplace add`, `claude plugin install fallow-skills@<marketplace-name>`), with the same pre-scan skip-if-installed behavior as the other entries.
+The install script SHALL include `fallow-rs/fallow-skills` in the `CC_MARKETPLACES` array and the fallow-skills plugin in the `CC_PLUGINS` array, installed via the existing marketplace/plugin loops (`claude plugin marketplace add`, `claude plugin install fallow@fallow-skills`), with the same pre-scan skip-if-installed behavior as the other entries.
 
 #### Scenario: Fresh machine setup
 
@@ -18,7 +18,7 @@ The install script SHALL include `fallow-rs/fallow-skills` in the `CC_MARKETPLAC
 
 ### Requirement: Fallow-skills plugin is enabled by default
 
-`dot_claude/settings.json.tmpl` SHALL include the fallow-skills plugin entry (`"fallow-skills@<marketplace-name>": true`, exact key as reported by `claude plugin list --json`) in the `enabledPlugins` object.
+`dot_claude/settings.json.tmpl` SHALL include the fallow-skills plugin entry (`"fallow@fallow-skills": true`, exact key as reported by `claude plugin list --json`) in the `enabledPlugins` object.
 
 #### Scenario: Fresh machine setup
 

--- a/openspec/changes/add-fallow/specs/claude-code-plugins/spec.md
+++ b/openspec/changes/add-fallow/specs/claude-code-plugins/spec.md
@@ -1,0 +1,36 @@
+# Delta: claude-code-plugins
+
+## ADDED Requirements
+
+### Requirement: Fallow-skills marketplace and plugin are registered in install script
+
+The install script SHALL include `fallow-rs/fallow-skills` in the `CC_MARKETPLACES` array and the fallow-skills plugin in the `CC_PLUGINS` array, installed via the existing marketplace/plugin loops (`claude plugin marketplace add`, `claude plugin install fallow-skills@<marketplace-name>`), with the same pre-scan skip-if-installed behavior as the other entries.
+
+#### Scenario: Fresh machine setup
+
+- **WHEN** the install script runs the Claude Code plugin dependencies group on a machine without the plugin
+- **THEN** the fallow-skills marketplace is registered and the plugin installed
+
+#### Scenario: Already installed
+
+- **WHEN** the marketplace and plugin are already present
+- **THEN** both are skipped with "already registered/installed" messages
+
+### Requirement: Fallow-skills plugin is enabled by default
+
+`dot_claude/settings.json.tmpl` SHALL include the fallow-skills plugin entry (`"fallow-skills@<marketplace-name>": true`, exact key as reported by `claude plugin list --json`) in the `enabledPlugins` object.
+
+#### Scenario: Fresh machine setup
+
+- **WHEN** `chezmoi apply` runs on a machine without Claude Code settings
+- **THEN** `~/.claude/settings.json` is created with the fallow-skills entry in `enabledPlugins`
+
+#### Scenario: Plugin not installed
+
+- **WHEN** the fallow-skills plugin has not been installed on the machine
+- **THEN** the `enabledPlugins` entry is inert and Claude Code operates normally without errors
+
+#### Scenario: Skill can reach the CLI
+
+- **WHEN** the fallow skill runs `npx fallow` inside a project
+- **THEN** it resolves the project-local devDependency if present, else falls back to the npm registry — independent of the global install

--- a/openspec/changes/add-fallow/specs/extra-updates-command/spec.md
+++ b/openspec/changes/add-fallow/specs/extra-updates-command/spec.md
@@ -1,0 +1,50 @@
+# Delta: extra-updates-command
+
+## MODIFIED Requirements
+
+### Requirement: Update step coverage
+
+`update-extra` SHALL run every step in its registered step list. The step list SHALL be exactly:
+
+1. gh extensions: `gh extension upgrade --all`
+2. you-should-use omz plugin: `git -C "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/you-should-use" pull --ff-only`
+3. skills.sh global skills: `npx -y skills update -g -y`
+4. plannotator CLI: re-run the official installer `https://plannotator.ai/install.sh`
+5. Catppuccin theme assets: re-download the bat, delta, zsh-syntax-highlighting, and atuin theme files from the same URLs used by `run_onchange_install-packages.sh.tmpl`, followed by `bat cache --build`
+6. television channels: `tv update-channels`
+7. fallow CLI (global): `npm install -g fallow@latest`
+
+#### Scenario: gh extensions updated
+
+- **WHEN** `update-extra` runs
+- **THEN** `gh extension upgrade --all` executes
+
+#### Scenario: you-should-use updated
+
+- **WHEN** `update-extra` runs
+- **THEN** the you-should-use clone under `$ZSH_CUSTOM/plugins` is fast-forwarded to upstream
+
+#### Scenario: skills.sh globals updated
+
+- **WHEN** `update-extra` runs
+- **THEN** `npx -y skills update -g -y` executes against the global skill set
+
+#### Scenario: plannotator updated
+
+- **WHEN** `update-extra` runs
+- **THEN** the official plannotator installer re-runs, replacing the binary with the latest release
+
+#### Scenario: Catppuccin themes refreshed
+
+- **WHEN** `update-extra` runs
+- **THEN** the four theme assets are re-downloaded and the bat cache is rebuilt
+
+#### Scenario: television channels updated
+
+- **WHEN** `update-extra` runs
+- **THEN** `tv update-channels` executes
+
+#### Scenario: fallow updated
+
+- **WHEN** `update-extra` runs
+- **THEN** `npm install -g fallow@latest` executes, updating the global CLI and its bundled `fallow-lsp`/`fallow-mcp` binaries in one step

--- a/openspec/changes/add-fallow/specs/fallow-ci/spec.md
+++ b/openspec/changes/add-fallow/specs/fallow-ci/spec.md
@@ -21,6 +21,20 @@ The repo SHALL contain `.github/workflows/fallow.yml`, separate from `ci.yml`, t
 - **WHEN** reading `.github/workflows/ci.yml`
 - **THEN** it retains its default read-only permissions (fallow's write permissions live only in `fallow.yml`)
 
+### Requirement: Push-time dead-code gate in main CI
+
+`ci.yml` SHALL run `bunx fallow dead-code --fail-on-issues` on `push` events only (not on `pull_request`), so dead code cannot land on `main` via direct pushes that bypass the PR audit. The step SHALL NOT alter `ci.yml` permissions and PR runs SHALL keep the `fallow.yml` new-only ratchet as their sole fallow gate.
+
+#### Scenario: Direct push to main with dead code
+
+- **WHEN** a commit pushed directly to `main` introduces an unused file, export, or dependency
+- **THEN** the CI `main` job fails at the fallow dead-code step
+
+#### Scenario: PR runs unaffected
+
+- **WHEN** the CI workflow runs for a `pull_request` event
+- **THEN** the dead-code step is skipped (fallow gating comes from `fallow.yml` only)
+
 ### Requirement: CI version follows the devDependency pin
 
 The workflow SHALL omit the action's `version` input so the action resolves the fallow version from the `package.json` devDependency — a single Renovate-managed version source for the project layer.

--- a/openspec/changes/add-fallow/specs/fallow-ci/spec.md
+++ b/openspec/changes/add-fallow/specs/fallow-ci/spec.md
@@ -1,0 +1,31 @@
+# Delta: fallow-ci
+
+## ADDED Requirements
+
+### Requirement: PR audit workflow via official action
+
+The repo SHALL contain `.github/workflows/fallow.yml`, separate from `ci.yml`, triggered on `pull_request`, with permissions `contents: read`, `checks: write`, `pull-requests: write`. The job SHALL check out with `fetch-depth: 0` and run the official `fallow-rs/fallow` action (v3 line) with `command: audit`, `gate: new-only`, `comment: true`, `comment-layout: compact`. The job SHALL NOT install bun or node — the action is self-contained.
+
+#### Scenario: PR with no introduced findings
+
+- **WHEN** a pull request touches files without introducing new fallow findings
+- **THEN** the workflow passes, even if pre-existing findings are reported in touched files
+
+#### Scenario: PR introduces an error-severity finding
+
+- **WHEN** a pull request introduces a finding whose rule severity is `error`
+- **THEN** the audit verdict is `fail` and the workflow fails with a compact sticky PR comment explaining the findings
+
+#### Scenario: Existing CI workflow unchanged in permissions
+
+- **WHEN** reading `.github/workflows/ci.yml`
+- **THEN** it retains its default read-only permissions (fallow's write permissions live only in `fallow.yml`)
+
+### Requirement: CI version follows the devDependency pin
+
+The workflow SHALL omit the action's `version` input so the action resolves the fallow version from the `package.json` devDependency — a single Renovate-managed version source for the project layer.
+
+#### Scenario: Renovate bumps the devDependency
+
+- **WHEN** Renovate merges a fallow devDependency bump
+- **THEN** subsequent workflow runs use the new version with no workflow file change

--- a/openspec/changes/add-fallow/specs/fallow-install/spec.md
+++ b/openspec/changes/add-fallow/specs/fallow-install/spec.md
@@ -1,0 +1,32 @@
+# Delta: fallow-install
+
+## ADDED Requirements
+
+### Requirement: Global fallow installation via npm in install script
+
+`run_onchange_install-packages.sh.tmpl` SHALL install fallow globally via `npm install -g fallow` in a dedicated group placed after the NVM/Node group, following the existing pre-scan + `confirm` prompt pattern. The group SHALL skip with an informational message when `fallow` is already on PATH, and skip with a warning when `node`/`npm` are unavailable.
+
+#### Scenario: Fresh machine install
+
+- **WHEN** the install script runs on a machine with node available and fallow absent
+- **AND** the user confirms the fallow install group
+- **THEN** `npm install -g fallow` executes and `fallow`, `fallow-lsp`, and `fallow-mcp` become available on PATH
+
+#### Scenario: Already installed
+
+- **WHEN** `fallow` is already on PATH
+- **THEN** the group reports it as installed and performs no install
+
+#### Scenario: Node unavailable
+
+- **WHEN** `node` or `npm` is not on PATH (NVM group skipped or failed)
+- **THEN** the fallow group SHALL skip with a warning instead of failing the script
+
+### Requirement: Free static tier only
+
+The dotfiles SHALL NOT configure any paid Fallow Runtime surface: no `FALLOW_LICENSE`/`FALLOW_LICENSE_PATH`/`FALLOW_API_KEY`/`FALLOW_API_URL` environment variables, no `fallow license` or `fallow coverage` invocations, in any template, script, or config.
+
+#### Scenario: No license configuration deployed
+
+- **WHEN** `chezmoi apply` runs
+- **THEN** no deployed file contains Fallow Runtime license or cloud configuration

--- a/openspec/changes/add-fallow/specs/fallow-project-config/spec.md
+++ b/openspec/changes/add-fallow/specs/fallow-project-config/spec.md
@@ -35,6 +35,20 @@ The repo SHALL contain a `.fallowrc.jsonc` at the root with: a local `$schema` (
 - **WHEN** fallow runs locally and creates its `.fallow/` cache directory
 - **THEN** `git status` does not report it (covered by `.gitignore`)
 
+### Requirement: Pre-commit audit via lint-staged
+
+`lint-staged.config.ts` SHALL run `bunx fallow audit` as a global function task keyed on `*.{ts,js,json,jsonc}`, so the audit runs once per commit that stages JS-surface files and is skipped entirely for commits that do not.
+
+#### Scenario: Commit touching JS surface
+
+- **WHEN** a commit stages a `.ts`, `.js`, `.json`, or `.jsonc` file
+- **THEN** the pre-commit hook runs `fallow audit` once and blocks the commit on introduced findings
+
+#### Scenario: Docs-only commit
+
+- **WHEN** a commit stages only non-JS files (markdown, templates, HTML)
+- **THEN** the fallow audit task does not run
+
 ### Requirement: lint:fallow package script
 
 `package.json` SHALL provide a `lint:fallow` script that runs `fallow audit`, mirroring the `lint:oxfmt` naming convention.

--- a/openspec/changes/add-fallow/specs/fallow-project-config/spec.md
+++ b/openspec/changes/add-fallow/specs/fallow-project-config/spec.md
@@ -1,0 +1,40 @@
+# Delta: fallow-project-config
+
+## ADDED Requirements
+
+### Requirement: fallow is an exact-pinned devDependency
+
+`package.json` SHALL declare `fallow` as a devDependency with an exact version (no range), consistent with the repo's other tool CLIs (commitlint, lint-staged, oxfmt), so Renovate manages it and the CI action reads it as its version source.
+
+#### Scenario: Dependency installed
+
+- **WHEN** `bun install --frozen-lockfile` runs
+- **THEN** `node_modules/.bin/fallow` exists and `bunx fallow --version` reports the pinned version
+
+### Requirement: Repo-tuned fallow configuration
+
+The repo SHALL contain a `.fallowrc.jsonc` at the root with: `oxfmt.config.ts` declared as an `entry` (no built-in fallow plugin covers oxfmt, unlike commitlint/lint-staged), `ignorePatterns` covering the non-JS chezmoi surface (`**/*.tmpl`, `dot_config/**`, `dot_claude/**`, `dot_local/**`, `Library/**`, `assets/**`, `docs/**`, `openspec/**`), `ignoreDependencies` for `@types/bun`, and `unused-exports`/`unused-types` set to `off`.
+
+#### Scenario: Clean analysis on untouched repo
+
+- **WHEN** `bunx fallow` runs on a clean checkout
+- **THEN** it reports no unused-file findings (config files are entries or plugin-detected, chezmoi surface is ignored)
+
+#### Scenario: Config discovered by CLI
+
+- **WHEN** `bunx fallow config --path` runs at the repo root
+- **THEN** it prints the path to `.fallowrc.jsonc`
+
+#### Scenario: Config file survives the formatter
+
+- **WHEN** lint-staged runs oxfmt over a commit touching `.fallowrc.jsonc`
+- **THEN** the file remains valid JSONC (via oxfmt handling it correctly or an `.oxfmtignore` entry)
+
+### Requirement: lint:fallow package script
+
+`package.json` SHALL provide a `lint:fallow` script that runs `fallow audit`, mirroring the `lint:oxfmt` naming convention.
+
+#### Scenario: Local audit run
+
+- **WHEN** the user runs `bun run lint:fallow` on a feature branch
+- **THEN** `fallow audit` executes against files changed since the base ref using the repo config

--- a/openspec/changes/add-fallow/specs/fallow-project-config/spec.md
+++ b/openspec/changes/add-fallow/specs/fallow-project-config/spec.md
@@ -13,7 +13,7 @@
 
 ### Requirement: Repo-tuned fallow configuration
 
-The repo SHALL contain a `.fallowrc.jsonc` at the root with: `oxfmt.config.ts` declared as an `entry` (no built-in fallow plugin covers oxfmt, unlike commitlint/lint-staged), `ignorePatterns` covering the non-JS chezmoi surface (`**/*.tmpl`, `dot_config/**`, `dot_claude/**`, `dot_local/**`, `Library/**`, `assets/**`, `docs/**`, `openspec/**`), `ignoreDependencies` for `@types/bun`, and `unused-exports`/`unused-types` set to `off`.
+The repo SHALL contain a `.fallowrc.jsonc` at the root with: a local `$schema` (`./node_modules/fallow/schema.json`, version-matched to the pinned devDep), `oxfmt.config.ts` declared as an `entry` (no built-in fallow plugin covers oxfmt, unlike commitlint/lint-staged), `ignorePatterns` covering the non-JS chezmoi surface (`**/*.tmpl`, `dot_config/**`, `dot_claude/**`, `dot_local/**`, `Library/**`, `assets/**`, `docs/**`, `openspec/**`), `ignoreDependencies` for `@types/bun`, `unused-exports`/`unused-types` set to `off`, and `require-suppression-reason` set to `warn`. The `.fallow/` analysis cache SHALL be gitignored.
 
 #### Scenario: Clean analysis on untouched repo
 
@@ -29,6 +29,11 @@ The repo SHALL contain a `.fallowrc.jsonc` at the root with: `oxfmt.config.ts` d
 
 - **WHEN** lint-staged runs oxfmt over a commit touching `.fallowrc.jsonc`
 - **THEN** the file remains valid JSONC (via oxfmt handling it correctly or an `.oxfmtignore` entry)
+
+#### Scenario: Analysis cache stays out of git
+
+- **WHEN** fallow runs locally and creates its `.fallow/` cache directory
+- **THEN** `git status` does not report it (covered by `.gitignore`)
 
 ### Requirement: lint:fallow package script
 

--- a/openspec/changes/add-fallow/specs/mcp-global-config/spec.md
+++ b/openspec/changes/add-fallow/specs/mcp-global-config/spec.md
@@ -1,0 +1,69 @@
+# Delta: mcp-global-config
+
+## MODIFIED Requirements
+
+### Requirement: Global MCP servers are registered via Claude CLI in install script
+
+`run_onchange_install-packages.sh.tmpl` SHALL register the following 14 MCP servers via `claude mcp add --scope user`, which writes to `~/.claude.json`:
+
+| Name            | Type  | Command/URL                                            |
+| --------------- | ----- | ------------------------------------------------------ |
+| eslint          | stdio | `npx -y @eslint/mcp@0.3.0`                             |
+| context7        | stdio | `npx -y @upstash/context7-mcp@2.1.2`                   |
+| knip            | stdio | `npx -y @knip/mcp@0.0.19`                              |
+| memory          | stdio | `npx -y @modelcontextprotocol/server-memory@2026.1.26` |
+| playwright      | stdio | `npx -y @playwright/mcp@0.0.68`                        |
+| chrome-devtools | stdio | `npx -y chrome-devtools-mcp@0.18.1`                    |
+| expect          | stdio | `npx -y expect-cli@0.1.3 mcp`                          |
+| fallow          | stdio | `fallow-mcp` (PATH binary from the global npm install) |
+| gh_grep         | http  | `https://mcp.grep.app`                                 |
+| atlassian       | http  | `https://mcp.atlassian.com/v1/mcp`                     |
+| figma           | http  | `https://mcp.figma.com/mcp`                            |
+| linear          | http  | `https://mcp.linear.app/mcp`                           |
+| notion          | http  | `https://mcp.notion.com/mcp`                           |
+| storybook       | http  | `http://localhost:6006/mcp`                            |
+
+`dot_claude/settings.json.tmpl` SHALL NOT contain an `mcpServers` key.
+
+#### Scenario: All 14 servers registered after install script runs
+
+- **WHEN** `chezmoi apply` runs the install script on a machine with `claude` CLI available
+- **AND** the user confirms the MCP servers install group
+- **THEN** `claude mcp list --scope user` SHALL list all 14 servers above
+
+#### Scenario: Servers registered to correct file
+
+- **WHEN** a stdio MCP server is registered via the install script
+- **THEN** `~/.claude.json` SHALL contain the server under the `mcpServers` key
+- **AND** `~/.claude/settings.json` SHALL NOT contain an `mcpServers` key
+
+#### Scenario: Settings template has no mcpServers block
+
+- **WHEN** reading `dot_claude/settings.json.tmpl`
+- **THEN** the file SHALL NOT contain an `mcpServers` key at any level
+
+#### Scenario: Stdio servers use pinned versions managed by Renovate
+
+- **WHEN** inspecting registered stdio servers via `claude mcp get <name>`
+- **THEN** the 7 npx-launched stdio servers SHALL reference pinned versions (not `@latest`)
+- **AND** `renovate.json` SHALL contain a custom regex manager for the install script template
+
+#### Scenario: Fallow server runs the global binary without a pin
+
+- **WHEN** inspecting the `fallow` server via `claude mcp get fallow`
+- **THEN** its command SHALL be the bare `fallow-mcp` binary (no npx, no version pin)
+- **AND** its version SHALL be owned by the global npm install (updated via `update-extra`), so the MCP server and the `fallow` CLI it shells out to can never skew from each other
+
+#### Scenario: Fallow entry is presence-checked only
+
+- **WHEN** the install script pre-scans MCP servers for outdated pins
+- **THEN** the `fallow` entry SHALL participate in presence detection only, not in the `pkg@version` outdated-check
+
+### Requirement: Template uses no machine-specific conditionals for MCP
+
+The MCP server list in `run_onchange_install-packages.sh.tmpl` SHALL be plain bash arrays without chezmoi template conditionals (`{{ if }}`, `{{ else }}`). All 14 servers are registered identically on every machine.
+
+#### Scenario: No conditional logic in MCP server arrays
+
+- **WHEN** reading `run_onchange_install-packages.sh.tmpl`
+- **THEN** the MCP server arrays SHALL contain no chezmoi template directives

--- a/openspec/changes/add-fallow/tasks.md
+++ b/openspec/changes/add-fallow/tasks.md
@@ -27,4 +27,4 @@
 - [ ] 4.1 Sync chezmoi source and run the install script end-to-end on this machine (`chezmoi update` + apply flow); confirm the fallow group, MCP registration, and plugin install behave idempotently on a second run
 - [ ] 4.2 Smoke-test the global layer: `fallow --version`, `claude mcp list` shows `fallow` connected, fallow skill visible in Claude Code
 - [ ] 4.3 Run `update-extra` and confirm the fallow step succeeds
-- [ ] 4.4 Open a PR and confirm `fallow.yml` runs, posts the compact sticky comment, and passes on a no-findings diff
+- [x] 4.4 Open a PR and confirm `fallow.yml` runs, posts the compact sticky comment, and passes on a no-findings diff — PR #164: run passed (verdict `pass`, 0 issues); comment step ran but skips posting on a clean run with no prior sticky comment (`clean_no_existing_comment`), by design

--- a/openspec/changes/add-fallow/tasks.md
+++ b/openspec/changes/add-fallow/tasks.md
@@ -2,25 +2,25 @@
 
 ## 1. Project layer
 
-- [ ] 1.1 `bun add -d --exact fallow` and verify `bunx fallow --version` reports 3.x
-- [ ] 1.2 Create `.fallowrc.jsonc` per design D6 (entry `oxfmt.config.ts`, chezmoi ignorePatterns, `ignoreDependencies: ["@types/bun"]`, `unused-exports`/`unused-types` off)
-- [ ] 1.3 Verify oxfmt handles `.fallowrc.jsonc` (run `bun run lint:oxfmt` / stage the file); add to `.oxfmtignore` if it corrupts or rejects it
-- [ ] 1.4 Verify discovery: `bunx fallow list` shows commitlint/lint-staged plugins active and `oxfmt.config.ts` as entry; `bunx fallow` reports no unused-file findings; tune config if not
-- [ ] 1.5 Add `"lint:fallow": "fallow audit"` script to `package.json`
-- [ ] 1.6 Create `.github/workflows/fallow.yml` per design D7, verifying input names (`command`, `gate`, `comment`, `comment-layout`) against the `v3` tag's `action.yml`
+- [x] 1.1 `bun add -d --exact fallow` and verify `bunx fallow --version` reports 3.x
+- [x] 1.2 Create `.fallowrc.jsonc` per design D6 (entry `oxfmt.config.ts`, chezmoi ignorePatterns, `ignoreDependencies: ["@types/bun"]`, `unused-exports`/`unused-types` off)
+- [x] 1.3 Verify oxfmt handles `.fallowrc.jsonc` (run `bun run lint:oxfmt` / stage the file); add to `.oxfmtignore` if it corrupts or rejects it
+- [x] 1.4 Verify discovery: `bunx fallow list` shows commitlint/lint-staged plugins active and `oxfmt.config.ts` as entry; `bunx fallow` reports no unused-file findings; tune config if not
+- [x] 1.5 Add `"lint:fallow": "fallow audit"` script to `package.json`
+- [x] 1.6 Create `.github/workflows/fallow.yml` per design D7, verifying input names (`command`, `gate`, `comment`, `comment-layout`) against the `v3` tag's `action.yml`
 
 ## 2. Global layer
 
-- [ ] 2.1 Add fallow install group to `run_onchange_install-packages.sh.tmpl` after the NVM/Node group (pre-scan `command -v fallow`, confirm prompt, `npm install -g fallow`, skip+warn without node)
-- [ ] 2.2 Add `"fallow:fallow-mcp"` to `MCP_STDIO_SERVERS` and confirm the existing loop registers it bare (no npx, no pin) and treats it as presence-check only in the outdated pre-scan
-- [ ] 2.3 Add `fallow-rs/fallow-skills` to `CC_MARKETPLACES` and the fallow-skills plugin to `CC_PLUGINS`; verify the exact plugin id (`fallow-skills@<marketplace-name>`) after a manual install via `claude plugin list --json`
-- [ ] 2.4 Add the fallow-skills entry to `enabledPlugins` in `dot_claude/settings.json.tmpl` with the verified key
-- [ ] 2.5 Add step 7 to `update-extra` in `dot_zshrc.tmpl`: `_update_extra_step "fallow" npm install -g fallow@latest`
+- [x] 2.1 Add fallow install group to `run_onchange_install-packages.sh.tmpl` after the NVM/Node group (pre-scan `command -v fallow`, confirm prompt, `npm install -g fallow`, skip+warn without node)
+- [x] 2.2 Add `"fallow:fallow-mcp"` to `MCP_STDIO_SERVERS` and confirm the existing loop registers it bare (no npx, no pin) and treats it as presence-check only in the outdated pre-scan
+- [x] 2.3 Add `fallow-rs/fallow-skills` to `CC_MARKETPLACES` and the fallow-skills plugin to `CC_PLUGINS`; verify the exact plugin id (`fallow-skills@<marketplace-name>`) after a manual install via `claude plugin list --json` — verified against the marketplace manifest instead (live install denied by permissions): plugin name is `fallow`, so the id is `fallow@fallow-skills`
+- [x] 2.4 Add the fallow-skills entry to `enabledPlugins` in `dot_claude/settings.json.tmpl` with the verified key (`fallow@fallow-skills`)
+- [x] 2.5 Add step 7 to `update-extra` in `dot_zshrc.tmpl`: `_update_extra_step "fallow" npm install -g fallow@latest`
 
 ## 3. Docs
 
-- [ ] 3.1 Update `docs/manual.html` via the update-manual skill (fallow CLI commands — combined run, `dead-code`, `dupes`, `health`, `audit`, `fix --dry-run`; MCP server; update-extra step; free-tier note)
-- [ ] 3.2 Update `README.md` via the update-readme skill (What's Included entry for fallow)
+- [x] 3.1 Update `docs/manual.html` via the update-manual skill (fallow CLI commands — combined run, `dead-code`, `dupes`, `health`, `audit`, `fix --dry-run`; MCP server; update-extra step; free-tier note)
+- [x] 3.2 Update `README.md` via the update-readme skill (What's Included entry for fallow)
 
 ## 4. Verification
 

--- a/openspec/changes/add-fallow/tasks.md
+++ b/openspec/changes/add-fallow/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: add-fallow
+
+## 1. Project layer
+
+- [ ] 1.1 `bun add -d --exact fallow` and verify `bunx fallow --version` reports 3.x
+- [ ] 1.2 Create `.fallowrc.jsonc` per design D6 (entry `oxfmt.config.ts`, chezmoi ignorePatterns, `ignoreDependencies: ["@types/bun"]`, `unused-exports`/`unused-types` off)
+- [ ] 1.3 Verify oxfmt handles `.fallowrc.jsonc` (run `bun run lint:oxfmt` / stage the file); add to `.oxfmtignore` if it corrupts or rejects it
+- [ ] 1.4 Verify discovery: `bunx fallow list` shows commitlint/lint-staged plugins active and `oxfmt.config.ts` as entry; `bunx fallow` reports no unused-file findings; tune config if not
+- [ ] 1.5 Add `"lint:fallow": "fallow audit"` script to `package.json`
+- [ ] 1.6 Create `.github/workflows/fallow.yml` per design D7, verifying input names (`command`, `gate`, `comment`, `comment-layout`) against the `v3` tag's `action.yml`
+
+## 2. Global layer
+
+- [ ] 2.1 Add fallow install group to `run_onchange_install-packages.sh.tmpl` after the NVM/Node group (pre-scan `command -v fallow`, confirm prompt, `npm install -g fallow`, skip+warn without node)
+- [ ] 2.2 Add `"fallow:fallow-mcp"` to `MCP_STDIO_SERVERS` and confirm the existing loop registers it bare (no npx, no pin) and treats it as presence-check only in the outdated pre-scan
+- [ ] 2.3 Add `fallow-rs/fallow-skills` to `CC_MARKETPLACES` and the fallow-skills plugin to `CC_PLUGINS`; verify the exact plugin id (`fallow-skills@<marketplace-name>`) after a manual install via `claude plugin list --json`
+- [ ] 2.4 Add the fallow-skills entry to `enabledPlugins` in `dot_claude/settings.json.tmpl` with the verified key
+- [ ] 2.5 Add step 7 to `update-extra` in `dot_zshrc.tmpl`: `_update_extra_step "fallow" npm install -g fallow@latest`
+
+## 3. Docs
+
+- [ ] 3.1 Update `docs/manual.html` via the update-manual skill (fallow CLI commands — combined run, `dead-code`, `dupes`, `health`, `audit`, `fix --dry-run`; MCP server; update-extra step; free-tier note)
+- [ ] 3.2 Update `README.md` via the update-readme skill (What's Included entry for fallow)
+
+## 4. Verification
+
+- [ ] 4.1 Sync chezmoi source and run the install script end-to-end on this machine (`chezmoi update` + apply flow); confirm the fallow group, MCP registration, and plugin install behave idempotently on a second run
+- [ ] 4.2 Smoke-test the global layer: `fallow --version`, `claude mcp list` shows `fallow` connected, fallow skill visible in Claude Code
+- [ ] 4.3 Run `update-extra` and confirm the fallow step succeeds
+- [ ] 4.4 Open a PR and confirm `fallow.yml` runs, posts the compact sticky comment, and passes on a no-findings diff

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "type": "module",
     "scripts": {
         "prepare": "husky",
+        "lint:fallow": "fallow audit",
         "lint:oxfmt": "oxfmt --check --ignore-path .oxfmtignore",
         "lint:oxfmt:fix": "oxfmt --ignore-path .oxfmtignore"
     },
@@ -12,6 +13,7 @@
         "@commitlint/config-conventional": "21.1.0",
         "@commitlint/types": "21.1.0",
         "@types/bun": "^1.3.14",
+        "fallow": "3.0.0",
         "husky": "^9.1.7",
         "lint-staged": "17.0.8",
         "oxfmt": "0.54.0"

--- a/run_onchange_install-packages.sh.tmpl
+++ b/run_onchange_install-packages.sh.tmpl
@@ -755,6 +755,22 @@ else
 fi
 
 # ------------------------------------------------------------------
+# Group 6.5: fallow (global npm install: fallow, fallow-lsp, fallow-mcp)
+# ------------------------------------------------------------------
+if command -v fallow &>/dev/null; then
+    info "fallow — already installed ($(fallow --version 2>/dev/null | head -n1)), skipping"
+elif ! command -v node &>/dev/null || ! command -v npm &>/dev/null; then
+    warn "node/npm is not available — skipping fallow install"
+elif confirm "Install fallow globally via npm (fallow, fallow-lsp, fallow-mcp)?"; then
+    info "  Installing fallow..."
+    if ! npm install -g fallow; then
+        error "Failed to install fallow"
+    fi
+else
+    info "Skipping fallow."
+fi
+
+# ------------------------------------------------------------------
 # Group 7: OpenCode plugins
 # ------------------------------------------------------------------
 if confirm "Install OpenCode plugin dependencies (plannotator, superpowers)?"; then
@@ -808,6 +824,7 @@ CC_MARKETPLACES=(
     "backnotprop/plannotator"
     "max-sixty/worktrunk"
     "steveyegge/beads"
+    "fallow-rs/fallow-skills"
 )
 
 CC_PLUGINS=(
@@ -836,6 +853,7 @@ CC_PLUGINS=(
     "worktrunk@worktrunk"
     "beads@beads-marketplace"
     "code-simplifier@claude-plugins-official"
+    "fallow@fallow-skills"
 )
 
 if command -v claude &>/dev/null; then
@@ -957,6 +975,9 @@ MCP_STDIO_SERVERS=(
     "playwright:npx:-y:@playwright/mcp@0.0.68"
     "chrome-devtools:npx:-y:chrome-devtools-mcp@0.18.1"
     "expect:npx:-y:expect-cli@0.1.3:mcp"
+    # PATH binary from the global npm install — no npx, no pin (version owned
+    # by the global install / update-extra), so presence-checked only
+    "fallow:fallow-mcp"
 )
 
 MCP_HTTP_SERVERS=(


### PR DESCRIPTION
## Why

[fallow](https://fallow.tools/) is codebase intelligence for TS/JS (dead code, duplication, circular deps, complexity) — Rust-native, sub-second, MIT. Fills the graph-level analysis gap alongside the eslint/knip MCP servers. Free static layer only.

Implements OpenSpec change `add-fallow`.

## What

**Global layer** (machine setup):
- Install script Group 6.5: `npm install -g fallow` (ships `fallow`, `fallow-lsp`, `fallow-mcp`), skips with a warning when node/npm is absent
- MCP server `fallow` registered user-scope from the bare `fallow-mcp` PATH binary — no npx, no pin; presence-checked only (version owned by the global install)
- `fallow-rs/fallow-skills` marketplace + `fallow@fallow-skills` plugin, enabled in `dot_claude/settings.json.tmpl`
- `update-extra` step 7: `npm install -g fallow@latest`

**Project layer** (this repo):
- `fallow` 3.0.0 exact-pinned devDep (Renovate-managed; also the CI version source)
- `.fallowrc.jsonc`: `oxfmt.config.ts` manual entry, chezmoi surface ignored, `unused-exports`/`unused-types` off — verified clean via `bunx fallow list` + full run
- `lint:fallow` script (`fallow audit`)
- `.github/workflows/fallow.yml`: `fallow-rs/fallow@v3`, `command: audit`, `gate: new-only`, compact sticky comment; inputs verified against the v3 tag's `action.yml`

**Docs**: manual (fallow CLI table, MCP row, skill row, update-extra, free-tier note) + README (What's Included, MCP table 13→14).

## Notes

- Plugin id is `fallow@fallow-skills` (plugin `name` in the marketplace manifest is `fallow`, not `fallow-skills` as design D3 guessed — verified per the deferred implementation check).
- oxfmt handles `.fallowrc.jsonc` fine (keeps comments, adds trailing commas) — no `.oxfmtignore` entry needed.

## Verification still pending (machine-side, post-merge)

- 4.1 `chezmoi update` + install script end-to-end, idempotency second run
- 4.2 global smoke test (`fallow --version`, `claude mcp list`, skill visible)
- 4.3 `update-extra` fallow step
- 4.4 this PR's `fallow.yml` run posting the compact sticky comment and passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Fallow codebase intelligence: new `lint:fallow` check, PR audit workflow with compact sticky comments, and global setup enabling Claude Code skills plus MCP server registration.
  * Updated developer tooling to install/refresh Fallow automatically.
* **Bug Fixes**
  * Improved repo Fallow configuration (schema entry, ignore patterns, and warning tuning) and now ignores the analysis cache in Git.
* **Documentation**
  * Updated the README and manual with Fallow CLI capabilities and integration details for MCP and Claude Code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->