### PR TITLE
fix(aoe): bajar la retención de la papelera a 10 días (DOT-38)

### DIFF
--- a/docs/manual.html
+++ b/docs/manual.html
@@ -2707,6 +2707,14 @@
                                 </td>
                             </tr>
                             <tr>
+                                <td>Trash retention</td>
+                                <td>
+                                    <code>trash_retention_days = 10</code> &mdash; a trashed session
+                                    keeps its transcript and worktree for 10 days, then AoE purges
+                                    it (schema default is 30)
+                                </td>
+                            </tr>
+                            <tr>
                                 <td>Rate-limit auto-resume</td>
                                 <td>
                                     <code>[acp] rate_limit_auto_resume = true</code> &mdash; ACP

--- a/dot_config/private_agent-of-empires/modify_private_config.toml
+++ b/dot_config/private_agent-of-empires/modify_private_config.toml
@@ -43,6 +43,9 @@ MANAGED = [
     (("session", "agent_status_hooks"), True, False),
     # Confirmation guard before deleting a session from the TUI (aoe 1.12.0).
     (("session", "confirm_delete"), True, False),
+    # Days a trashed session (transcript + worktree) survives before AoE purges
+    # it. Pinned here so the schema default (30) can't drift back in.
+    (("session", "trash_retention_days"), 10, False),
     # Auto-resume ACP sessions once the adapter-reported rate-limit reset
     # passes (aoe 1.10.1, opt-in; +15s default grace). Terminal/tmux-view
     # sessions are unaffected; status_hooks below still notify.

--- a/openspec/changes/aoe-trash-retention-10d/.openspec.yaml
+++ b/openspec/changes/aoe-trash-retention-10d/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/aoe-trash-retention-10d/design.md
+++ b/openspec/changes/aoe-trash-retention-10d/design.md
@@ -1,0 +1,57 @@
+## Context
+
+Ver `proposal.md` — Why. El config de AoE lo genera un script `modify_` de chezmoi (`dot_config/private_agent-of-empires/modify_private_config.toml`) que recibe el fichero vivo por stdin y superpone **solo** las claves de la lista `MANAGED` con tomlkit, dejando intacto el writeback en runtime de AoE. Cualquier knob nueva es una entrada más en esa lista.
+
+El ticket DOT-38 dejaba abierta una incógnita bloqueante: `aoe settings explain session.trash_retention_days` reportaba `source: schema default` **aunque** `~/.config/agent-of-empires/config.toml` ya contuviera `trash_retention_days = 30`. Si AoE estuviese leyendo la ruta legacy `~/.agent-of-empires/config.toml`, tocar los dotfiles no serviría de nada. Resuelto empíricamente contra AoE 1.12.0 — ver D3.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Fijar la retención a 10 días como knob gestionada, resistente a cambios de default y al writeback de AoE.
+- Cerrar la incógnita de la ruta con evidencia, y dejar el spec `agent-manager` describiendo la ruta real.
+
+**Non-Goals:**
+
+- No se gestiona ninguna otra clave de `[session]` que hoy caiga en defaults (`auto_stop_idle_secs`, `snooze_duration_minutes`, …).
+- No se toca `delete_to_trash`: seguir mandando a la papelera en vez de borrar es justo lo que hace útil la retención.
+- No se automatiza el vaciado de la Trash desde los dotfiles; la purga la hace AoE en su propio barrido.
+
+## Decisions
+
+### D1. Añadir a `MANAGED`, no escribir la tabla `[session]` entera
+
+El merge hace *check-then-set*: si el valor en disco ya coincide, no toca el nodo, así que `chezmoi diff` queda en silencio y el re-apply es idempotente. Gestionar la tabla completa obligaría a fijar ~24 claves que AoE expande por defecto y convertiría cada release suya en un conflicto de diff. Alternativa descartada: un `run_once_` que llame a `aoe settings set` — introduce un segundo escritor sobre el mismo fichero y rompe la garantía de fuente única que da el `modify_`.
+
+### D2. 10 días, no los 15 del ticket
+
+DOT-38 pedía 15; el usuario baja a 10 (decisión de esta iteración). No hay restricción técnica: el schema acepta cualquier entero, y el único efecto es cuándo AoE purga. Hay que actualizar el ticket para que no quede contradiciendo al spec.
+
+### D3. La ruta XDG es la correcta — se corrige el spec, no el target de chezmoi
+
+Verificación contra AoE 1.12.0:
+
+- `~/.agent-of-empires/config.toml` (legacy) **no existe** en la máquina.
+- `~/.config/agent-of-empires/config.toml` sí existe, en modo `0600`, gestionado por el `modify_`.
+- `aoe settings explain` sobre claves que sí gestionamos (`session.default_tool`, `updates.update_check_mode`, `session.confirm_delete`, `theme.name`) reporta en todas `source: user value` con exactamente el valor de los dotfiles.
+
+Luego AoE lee la ruta XDG y el `modify_` ya apunta al sitio correcto: no hay que relocalizar nada. Lo que está mal es el spec, que sigue documentando la ruta legacy y un `private_dot_agent-of-empires/config.toml` que ya no existe en el árbol fuente.
+
+### D4. El `source: schema default` era una coincidencia de valores, no un problema de ruta
+
+`trash_retention_days` valía 30 en disco y el schema default también es 30, así que AoE colapsa los candidatos y solo muestra el default — no hay candidato `user value` que enseñar. Se distingue de un fallo de lectura precisamente por D3: las claves cuyo valor difiere del default sí aparecen como `user value`. Corolario que hace de test: al pasar a 10 (≠ 30) el `explain` **debe** cambiar a `source: user value`. Si tras aplicar siguiera diciendo `schema default`, entonces sí habría un problema de ruta y esta decisión estaría equivocada.
+
+## Risks / Trade-offs
+
+- **La purga es irreversible: al aplicar, las sesiones en la Trash con más de 10 días se pierden en el siguiente barrido** → revisar la Trash de AoE y restaurar lo que interese *antes* de `chezmoi apply` (primera tarea de `tasks.md`).
+- **10 días puede quedarse corto para recuperar una sesión abandonada** → el valor ya es una knob gestionada; cambiarlo es editar una línea y re-aplicar.
+- **Una release de AoE renombra o resemantiza la clave** → el merge no falla (tomlkit escribe la clave igual), pero quedaría una clave huérfana ignorada por AoE. Lo detecta el mismo `explain` de la verificación.
+- **El spec `agent-manager` acumulaba drift sin que nadie lo notara** → esta corrección lo pone al día, pero no añade ningún guardarraíl que impida que vuelva a pasar.
+
+## Migration Plan
+
+1. Revisar la Trash de AoE y restaurar lo que se quiera conservar.
+2. Editar `MANAGED`, `chezmoi diff` y confirmar que el único cambio es la línea `trash_retention_days`.
+3. `chezmoi apply` y verificar con `aoe settings explain`.
+
+Rollback: no basta con quitar la entrada de `MANAGED`. El `modify_` solo superpone lo que declara; si se borra la entrada, el `10` ya escrito permanece en disco. Para volver atrás hay que fijar explícitamente el valor deseado en `MANAGED` y re-aplicar. Lo ya purgado no se recupera.

--- a/openspec/changes/aoe-trash-retention-10d/proposal.md
+++ b/openspec/changes/aoe-trash-retention-10d/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+AoE no borra las sesiones descartadas: las manda a la Trash, conservando transcript y worktree hasta que expira la retención. Hoy esa retención son 30 días y viene del *schema default* de AoE — los dotfiles no la fijan, así que basura de sesiones muertas ocupa disco un mes entero y el valor puede cambiar bajo nuestros pies en cualquier release. Queremos 10 días, fijados deliberadamente.
+
+## What Changes
+
+- Añadir `session.trash_retention_days = 10` a la lista `MANAGED` de `dot_config/private_agent-of-empires/modify_private_config.toml`, junto al resto de claves `[session]`.
+- Corregir la ruta del config en el spec `agent-manager`: sigue documentando `~/.agent-of-empires/config.toml` (legacy) cuando la realidad — y lo que chezmoi gestiona — es `~/.config/agent-of-empires/config.toml`. Verificado contra AoE 1.12.0 (ver `design.md`); la ruta legacy ya ni existe en la máquina.
+- Documentar la retención en la tabla de AoE de `docs/manual.html`, al lado de `confirm_delete`.
+
+No es un 30 → 10 sobre algo ya gestionado: el `trash_retention_days = 30` que aparece hoy en el fichero es expansión de defaults escrita por el writeback de AoE. Esto **añade** una clave a `MANAGED`.
+
+## Capabilities
+
+### New Capabilities
+
+Ninguna.
+
+### Modified Capabilities
+
+- `agent-manager`: la retención de la papelera pasa a ser una knob gestionada y fijada a 10 días; y la requirement de ubicación del config se corrige de la ruta legacy a la ruta XDG que AoE lee de verdad.
+
+## Impact
+
+- `dot_config/private_agent-of-empires/modify_private_config.toml` — una entrada nueva en `MANAGED`.
+- `docs/manual.html` — una fila en la tabla de configuración de AoE.
+- `openspec/specs/agent-manager/spec.md` — vía delta.
+- Efecto en runtime: las sesiones en la papelera con más de 10 días se purgan en el siguiente barrido de AoE. Irreversible para lo ya caducado, de ahí la revisión de la Trash antes de aplicar (ver `tasks.md`).
+- Sin dependencias nuevas: el merge sigue corriendo sobre `uv run --with tomlkit`.

--- a/openspec/changes/aoe-trash-retention-10d/specs/agent-manager/spec.md
+++ b/openspec/changes/aoe-trash-retention-10d/specs/agent-manager/spec.md
@@ -1,0 +1,56 @@
+## RENAMED Requirements
+
+- FROM: `### Requirement: AoE configuration is chezmoi-managed at `~/.agent-of-empires/config.toml``
+- TO: `### Requirement: AoE configuration is chezmoi-managed at `~/.config/agent-of-empires/config.toml``
+
+## ADDED Requirements
+
+### Requirement: AoE trash retention is pinned to 10 days
+
+Descartar una sesión en AoE la mueve a la Trash, no la borra: transcript y worktree sobreviven hasta que expira la retención. Ese plazo SHALL ser una knob gestionada por los dotfiles y fijada a `10`, no heredada del schema default de AoE (`30`), de modo que ni una release de AoE ni el writeback en runtime puedan cambiarlo silenciosamente.
+
+#### Scenario: Retention pinned in the managed config
+
+- **WHEN** chezmoi materializa `~/.config/agent-of-empires/config.toml`
+- **THEN** el fichero contiene `trash_retention_days = 10` bajo la tabla `[session]`
+
+#### Scenario: AoE resolves the value as a user value
+
+- **WHEN** el usuario ejecuta `aoe settings explain session.trash_retention_days` tras `chezmoi apply`
+- **THEN** el valor resuelto es `10`
+- **AND** el `source` es `user value`, no `schema default`
+
+#### Scenario: Retention survives AoE runtime writeback
+
+- **WHEN** AoE reescribe el config en runtime y después se ejecuta `chezmoi apply`
+- **THEN** `trash_retention_days` vuelve a `10` si AoE lo hubiera alterado
+- **AND** el resto de tablas escritas por AoE se conservan intactas
+
+## MODIFIED Requirements
+
+### Requirement: AoE configuration is chezmoi-managed at `~/.config/agent-of-empires/config.toml`
+
+El árbol fuente de los dotfiles SHALL contener `dot_config/private_agent-of-empires/modify_private_config.toml`, apuntando a `~/.config/agent-of-empires/config.toml`. AoE 1.12.0 lee esta ruta XDG; la ruta legacy `~/.agent-of-empires/config.toml` documentada originalmente ya no se usa. El fichero SHALL aplicarse incondicionalmente en `chezmoi apply` (sin gating por host).
+
+#### Scenario: Config file present after chezmoi apply
+
+- **WHEN** the user runs `chezmoi apply` on any supported host
+- **THEN** `~/.config/agent-of-empires/config.toml` SHALL exist and be readable by the current user
+
+#### Scenario: Config file is private (chezmoi `private_` prefix)
+
+- **WHEN** `chezmoi apply` materializes the file
+- **THEN** the resulting `~/.config/agent-of-empires/config.toml` SHALL have permissions `0600` or stricter
+
+#### Scenario: AoE reads the managed file
+
+- **WHEN** el usuario ejecuta `aoe settings explain <clave gestionada>` para cualquier clave de `MANAGED`
+- **THEN** AoE reporta el valor de los dotfiles con `source: user value`, confirmando que la ruta gestionada es la que lee
+
+## REMOVED Requirements
+
+### Requirement: AoE config path is verified at first install
+
+**Reason**: Requisito de bootstrap ya cumplido, y su expectativa quedó desmentida. La verificación se hizo contra AoE 1.12.0: la ruta real es `~/.config/agent-of-empires/config.toml` y la legacy `~/.agent-of-empires/` ni siquiera existe. El escenario "Verified path is `~/.agent-of-empires/`" afirmaba lo contrario, así que mantenerlo documenta una ruta falsa.
+
+**Migration**: El delta de esta misma capability corrige la requirement de ubicación a la ruta XDG, y su escenario "AoE reads the managed file" cubre de forma permanente lo que este requisito verificaba una sola vez.

--- a/openspec/changes/aoe-trash-retention-10d/specs/agent-manager/spec.md
+++ b/openspec/changes/aoe-trash-retention-10d/specs/agent-manager/spec.md
@@ -7,7 +7,7 @@
 
 ### Requirement: AoE trash retention is pinned to 10 days
 
-Descartar una sesión en AoE la mueve a la Trash, no la borra: transcript y worktree sobreviven hasta que expira la retención. Ese plazo SHALL ser una knob gestionada por los dotfiles y fijada a `10`, no heredada del schema default de AoE (`30`), de modo que ni una release de AoE ni el writeback en runtime puedan cambiarlo silenciosamente.
+Descartar una sesión en AoE la mueve a la Trash, no la borra: transcript y worktree sobreviven hasta que expira la retención. Ese plazo SHALL ser una knob gestionada por los dotfiles y fijada a `10`, no heredada del schema default de AoE (`30`). AoE puede reescribir el valor vivo entre aplicaciones; `chezmoi apply` SHALL restablecerlo a `10`.
 
 #### Scenario: Retention pinned in the managed config
 
@@ -44,8 +44,9 @@ El árbol fuente de los dotfiles SHALL contener `dot_config/private_agent-of-emp
 
 #### Scenario: AoE reads the managed file
 
-- **WHEN** el usuario ejecuta `aoe settings explain <clave gestionada>` para cualquier clave de `MANAGED`
+- **WHEN** el usuario ejecuta `aoe settings explain <clave>` para una clave de `MANAGED` cuyo valor difiere del schema default de AoE
 - **THEN** AoE reporta el valor de los dotfiles con `source: user value`, confirmando que la ruta gestionada es la que lee
+- **AND** para una clave de `MANAGED` cuyo valor coincide con el schema default, AoE reporta `source: schema default` sin que eso implique que el fichero no se lea
 
 ## REMOVED Requirements
 

--- a/openspec/changes/aoe-trash-retention-10d/tasks.md
+++ b/openspec/changes/aoe-trash-retention-10d/tasks.md
@@ -1,0 +1,25 @@
+## 1. Salvaguarda antes de aplicar
+
+- [ ] 1.1 Abrir la sección Trash de AoE y restaurar cualquier sesión de más de 10 días que interese conservar — al aplicar, el siguiente barrido las purga sin vuelta atrás (design.md, Risks)
+
+## 2. Implementación
+
+- [ ] 2.1 Añadir `(("session", "trash_retention_days"), 10, False),` a la lista `MANAGED` de `dot_config/private_agent-of-empires/modify_private_config.toml`, junto a las demás claves de `[session]` (`default_tool`, `agent_status_hooks`, `confirm_delete`)
+- [ ] 2.2 Comentar la entrada en una línea: la retención la fijan los dotfiles, el default del schema de AoE es 30
+
+## 3. Verificación (pre-merge, contra el clon de desarrollo)
+
+- [ ] 3.1 `chezmoi diff --source . ~/.config/agent-of-empires/config.toml` → confirmar que el único cambio es `trash_retention_days = 30` → `10`, sin drift en las tablas de writeback de AoE (`[app_state]`, `[web]`, `[cockpit]`, `[logging]`)
+- [ ] 3.2 Confirmar que el fichero sigue ignorado por oxfmt: `dot_config/private_agent-of-empires/modify_private_config.toml` ya está en `.oxfmtignore` — verificar que un commit con lint-staged no lo reformatea
+
+## 4. Aplicar y verificar en la máquina
+
+- [ ] 4.1 Tras mergear, sincronizar la fuente real (`chezmoi update`) — `chezmoi apply` lee de `~/.local/share/chezmoi`, no de este clon
+- [ ] 4.2 `chezmoi apply` y comprobar que `~/.config/agent-of-empires/config.toml` conserva permisos `0600`
+- [ ] 4.3 `aoe settings explain session.trash_retention_days` → debe devolver `10` con `source: user value`. Si sigue diciendo `schema default`, la conclusión de design.md D3/D4 sobre la ruta es falsa: parar y reabrir la investigación antes de cerrar el cambio
+- [ ] 4.4 Re-ejecutar `chezmoi diff` → debe salir vacío (el check-then-set hace el re-apply idempotente)
+
+## 5. Documentación
+
+- [ ] 5.1 Añadir una fila `Trash retention` a la tabla de configuración de AoE en `docs/manual.html`, junto a `Delete guard` (`confirm_delete`)
+- [ ] 5.2 Actualizar DOT-38 en Linear: pedía 15 días, el valor implementado es 10

--- a/openspec/changes/aoe-trash-retention-10d/tasks.md
+++ b/openspec/changes/aoe-trash-retention-10d/tasks.md
@@ -4,13 +4,13 @@
 
 ## 2. Implementación
 
-- [ ] 2.1 Añadir `(("session", "trash_retention_days"), 10, False),` a la lista `MANAGED` de `dot_config/private_agent-of-empires/modify_private_config.toml`, junto a las demás claves de `[session]` (`default_tool`, `agent_status_hooks`, `confirm_delete`)
-- [ ] 2.2 Comentar la entrada en una línea: la retención la fijan los dotfiles, el default del schema de AoE es 30
+- [x] 2.1 Añadir `(("session", "trash_retention_days"), 10, False),` a la lista `MANAGED` de `dot_config/private_agent-of-empires/modify_private_config.toml`, junto a las demás claves de `[session]` (`default_tool`, `agent_status_hooks`, `confirm_delete`)
+- [x] 2.2 Comentar la entrada en una línea: la retención la fijan los dotfiles, el default del schema de AoE es 30
 
 ## 3. Verificación (pre-merge, contra el clon de desarrollo)
 
-- [ ] 3.1 `chezmoi diff --source . ~/.config/agent-of-empires/config.toml` → confirmar que el único cambio es `trash_retention_days = 30` → `10`, sin drift en las tablas de writeback de AoE (`[app_state]`, `[web]`, `[cockpit]`, `[logging]`)
-- [ ] 3.2 Confirmar que el fichero sigue ignorado por oxfmt: `dot_config/private_agent-of-empires/modify_private_config.toml` ya está en `.oxfmtignore` — verificar que un commit con lint-staged no lo reformatea
+- [x] 3.1 `chezmoi diff --source . ~/.config/agent-of-empires/config.toml` → confirmar que el único cambio es `trash_retention_days = 30` → `10`, sin drift en las tablas de writeback de AoE (`[app_state]`, `[web]`, `[cockpit]`, `[logging]`)
+- [x] 3.2 Confirmar que el fichero sigue ignorado por oxfmt: `dot_config/private_agent-of-empires/modify_private_config.toml` ya está en `.oxfmtignore` — verificar que un commit con lint-staged no lo reformatea
 
 ## 4. Aplicar y verificar en la máquina
 
@@ -21,5 +21,5 @@
 
 ## 5. Documentación
 
-- [ ] 5.1 Añadir una fila `Trash retention` a la tabla de configuración de AoE en `docs/manual.html`, junto a `Delete guard` (`confirm_delete`)
-- [ ] 5.2 Actualizar DOT-38 en Linear: pedía 15 días, el valor implementado es 10
+- [x] 5.1 Añadir una fila `Trash retention` a la tabla de configuración de AoE en `docs/manual.html`, junto a `Delete guard` (`confirm_delete`)
+- [x] 5.2 Actualizar DOT-38 en Linear: pedía 15 días, el valor implementado es 10

--- a/openspec/changes/aoe-trash-retention-10d/tasks.md
+++ b/openspec/changes/aoe-trash-retention-10d/tasks.md
@@ -14,7 +14,7 @@
 
 ## 4. Aplicar y verificar en la máquina
 
-- [ ] 4.1 Tras mergear, sincronizar la fuente real (`chezmoi update`) — `chezmoi apply` lee de `~/.local/share/chezmoi`, no de este clon
+- [ ] 4.1 Tras mergear, sincronizar la fuente real **sin aplicar**: `chezmoi update --apply=false` (o `chezmoi git pull -- --autostash --rebase`) — `chezmoi apply` lee de `~/.local/share/chezmoi`, no de este clon. `chezmoi update` a secas aplica por defecto y purgaría la papelera antes de la revisión de 1.1
 - [ ] 4.2 `chezmoi apply` y comprobar que `~/.config/agent-of-empires/config.toml` conserva permisos `0600`
 - [ ] 4.3 `aoe settings explain session.trash_retention_days` → debe devolver `10` con `source: user value`. Si sigue diciendo `schema default`, la conclusión de design.md D3/D4 sobre la ruta es falsa: parar y reabrir la investigación antes de cerrar el cambio
 - [ ] 4.4 Re-ejecutar `chezmoi diff` → debe salir vacío (el check-then-set hace el re-apply idempotente)


### PR DESCRIPTION
Closes DOT-38.

Baja la retención de la papelera de AoE de 30 a 10 días, fijándola desde los dotfiles en vez de heredar el default del schema.

## Qué cambia

- `dot_config/private_agent-of-empires/modify_private_config.toml` — `(("session", "trash_retention_days"), 10, False)` en `MANAGED`. Es un **añadir** a la lista, no un 30→10 sobre algo ya gestionado: el `30` que hay hoy en el config es expansión de defaults escrita por el writeback de AoE.
- `docs/manual.html` — fila `Trash retention` en la tabla de AoE.
- `openspec/changes/aoe-trash-retention-10d/` — proposal, spec delta, design y tasks.

## Corrección de spec incluida

El spec `agent-manager` seguía documentando la ruta legacy `~/.agent-of-empires/config.toml` y un `private_dot_agent-of-empires/config.toml` que ya no existe en el árbol fuente. El delta lo corrige (RENAMED + MODIFIED) y elimina la requirement de verificación de ruta, que era de bootstrap y ya quedó cumplida.

Su propia requirement ordenaba corregirlo vía delta si la verificación daba otra ruta; nunca se hizo.

## Verificación de la ruta (la incógnita del ticket)

`aoe settings explain` reportaba `source: schema default` pese a que el config XDG ya traía `trash_retention_days = 30`. No es un problema de ruta:

- `~/.agent-of-empires/config.toml` (legacy) **no existe** en la máquina.
- Las claves que sí gestionamos (`session.default_tool`, `updates.update_check_mode`, `session.confirm_delete`, `theme.name`) resuelven todas a `source: user value` con nuestros valores exactos → AoE lee la ruta XDG que gestiona chezmoi.
- El `schema default` era coincidencia: 30 en disco == 30 del schema, así que AoE colapsa los candidatos. Al pasar a 10 debe cambiar a `user value`.

## Probado

- `chezmoi diff --source .` → exactamente una línea (`30` → `10`), sin drift en las tablas de writeback (`[app_state]`, `[web]`, `[cockpit]`, `[logging]`), modo `0600` intacto.
- oxfmt matchea 0 ficheros sobre el `modify_` script (ya está en `.oxfmtignore`) y el md5 no cambia.
- `openspec validate aoe-trash-retention-10d --strict` → válido, 4 deltas.

## Sin aplicar todavía

`chezmoi apply` está deliberadamente fuera de este PR. El primer barrido tras aplicarlo purga **17 sesiones** de la papelera con ≥10 días (transcript + worktree, irreversible), así que las tareas 1.1 y 4.1–4.4 quedan abiertas para revisar la Trash antes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configured trashed sessions to be retained for 10 days before automatic cleanup.
  * Expired sessions, transcripts, and associated worktrees are removed during the next cleanup cycle.

* **Documentation**
  * Updated configuration documentation with the retention policy.
  * Corrected the documented configuration location and added verification details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->