### PR TITLE
fix(aoe): mirror tmux mouse instead of forcing it off

### DIFF
--- a/dot_config/private_agent-of-empires/modify_private_config.toml
+++ b/dot_config/private_agent-of-empires/modify_private_config.toml
@@ -50,7 +50,9 @@ MANAGED = [
     (("worktree", "init_submodules"), False, False),
     (("tmux", "status_bar"), "disabled", False),
     (("tmux", "clipboard"), "enabled", False),
-    (("tmux", "mouse"), "disabled", False),
+    # "auto" mirrors ~/.tmux.conf into each session; "disabled" applies `mouse
+    # off`, shadowing it. Pinned so `chezmoi apply` reverts a stray value.
+    (("tmux", "mouse"), "auto", False),
     (("updates", "update_check_mode"), "off", False),
     (("sound", "enabled"), True, False),
     (("status_hooks", "enabled"), True, False),

--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -1,4 +1,5 @@
-# Mouse support (click to select pane, resize, scroll)
+# Mouse support (click to select pane, resize, scroll). aoe sessions follow this
+# too — their [tmux].mouse = "auto" mirrors it instead of setting its own value
 set -g mouse on
 
 # Fix terminal compatibility with Ghostty

--- a/openspec/changes/fix-aoe-tmux-mouse/.openspec.yaml
+++ b/openspec/changes/fix-aoe-tmux-mouse/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-02

--- a/openspec/changes/fix-aoe-tmux-mouse/design.md
+++ b/openspec/changes/fix-aoe-tmux-mouse/design.md
@@ -1,0 +1,116 @@
+## Context
+
+See proposal.md — Why. This section records only what was measured, because the fix is a one-value edit and all its weight rests on the diagnosis being right.
+
+Measured on aoe 1.12.0 / tmux 3.7b / Ghostty, with three live aoe sessions:
+
+```
+tmux show-options -g mouse            → mouse on      (dot_tmux.conf:2)
+tmux show-options -t <each session>   → mouse off     (×3, session-local)
+```
+
+A session-local option beats the global, so every aoe session runs with the mouse off. That is AoE acting on `[tmux].mouse = "disabled"` from `modify_private_config.toml`, not tmux misreading `~/.tmux.conf`.
+
+AoE's settings schema documents the enum:
+
+> `tmux.mouse` — "Control mouse scrolling (**Auto respects your tmux config**)."
+
+The values were also probed against a throwaway `XDG_CONFIG_HOME`:
+
+| value | `aoe settings explain tmux.mouse` |
+| --- | --- |
+| `"enabled"` | `source: user value` |
+| `"disabled"` | `source: user value` |
+| `"auto"` | `source: schema default` |
+| `"bogus"` | `source: schema default` |
+
+So `auto` is reported as if unset, and an invalid value degrades silently to `auto` rather than failing the config load.
+
+Measured after applying the fix, against a throwaway scratch session: `auto` does **not** stop AoE writing the option — the new session carries a session-local `mouse on`, mirroring `~/.tmux.conf`, where a non-aoe session carries no session-local value at all. So `auto` means "read the user's config and apply what it says", not "abstain". The DOT-40 symptoms go away either way; the requirement is worded against mirroring, not abstention.
+
+Corroborating field evidence: a second machine of the user's runs `mouse = "auto"` and has none of the DOT-40 symptoms.
+
+Pane state at the time of measurement:
+
+```
+aoe panes (Claude Code):  alternate_on=0  mouse_any=0
+gh-dash pane:             alternate_on=1  mouse_any=1
+```
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the shipped value match the behavior the `agent-manager` spec already claims to want.
+- Leave exactly one place that decides mouse behavior for aoe panes.
+- Reach the DOT-40 policy (wheel drives pane scrollback by default, cedable to apps that ask) with no tmux bindings of our own.
+
+**Non-Goals:**
+
+- Changing `set -g mouse on` itself. It is already correct; this change only specifies it and stops AoE from shadowing it.
+- Auditing `default-terminal`, `click_action`, `*_attach_mode`, or `AOE_MOUSE_CAPTURE`. See D4.
+- Changing behavior of non-aoe tmux sessions. They already inherit the global `mouse on` and are untouched.
+
+## Decisions
+
+### D1: `"auto"`, not `"enabled"`
+
+Both values fix DOT-40 on a host whose `~/.tmux.conf` sets `mouse on`. They differ in where the decision lives.
+
+`improve-aoe-config` D1 chose `"disabled"` as the deterministic counterpart to `"auto"`, reasoning by analogy with `status_bar = "disabled"`. The analogy breaks: for `status_bar`, "disabled" means "don't draw AoE's bar" — a genuine opt-out, protecting the user's Catppuccin status line. For `mouse`, the same word means "apply `mouse off`" — an opt-*in* to the opposite behavior. AoE spells the actual opt-out `auto`, and documents it as "respects your tmux config".
+
+The tempting repair is `"enabled"`: it is pinned, it survives the probe as a `user value`, and it yields `mouse on`. It was the first candidate here and was rejected. Both values leave AoE writing a session-local option (measured above) — the difference is where the value comes from. Under `auto` it is read from `dot_tmux.conf`, so the two cannot disagree. `"enabled"` re-establishes two independent sources of truth for the mouse, with AoE's session-local write outranking `dot_tmux.conf` silently. That is structurally the arrangement that produced this bug — a value in the AoE config quietly overriding the file the reader believes is authoritative. Fixing the symptom by rebuilding the mechanism is a worse outcome than fixing it by removing the mechanism, even though today the two are observationally identical.
+
+The determinism the original design wanted was not wrong; it was applied at the wrong layer. Under `auto` it moves to where it belongs: `dot_tmux.conf` gets an explicit requirement (`tmux-config` delta) so the `mouse on` line is protected by spec rather than by habit. One authority, specified.
+
+Rejected: deleting the key entirely. Behaviorally identical to `auto`, but it drops the record of a decision this repo has now got wrong once, and it gives up chezmoi's ability to revert a stray `disabled` written into the live config later. Keeping the key at `auto` is a *pinned no-op* — determinism about not interfering.
+
+### D2: No custom wheel bindings
+
+DOT-40 proposes binding `WheelUpPane`/`WheelDownPane` conditionally on alternate-screen. tmux 3.7b already ships exactly that as a default root binding:
+
+```
+WheelUpPane     if-shell -F "#{||:#{alternate_on},#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { copy-mode -e }
+MouseDown1Pane  select-pane -t = ; send-keys -M
+```
+
+Against the measured pane state: aoe agent panes (`alternate_on=0, mouse_any=0`) fall to `copy-mode -e` — the pane's own scrollback. The gh-dash pane (`alternate_on=1, mouse_any=1`) falls to `send-keys -M` — forwarded untouched. That is the requested policy verbatim, so writing our own binding would only be a slightly-worse copy that we then have to maintain against tmux's defaults.
+
+Rejected: adding the bindings anyway "for explicitness". It would shadow a default that already tracks upstream, and the two would drift.
+
+### D3: Accept tmux ownership of drag-select
+
+This is the only user-visible regression, and it is inherent to the mouse being active — not avoidable by tuning, and identical under `auto` or `enabled`.
+
+| | before (`mouse off`) | after (mouse on) |
+| --- | --- | --- |
+| drag handled by | Ghostty | tmux copy-mode |
+| selection spans | whole window | one pane |
+| lands in | system clipboard via `copy-on-select` | tmux buffer → system clipboard via OSC 52 |
+
+The OSC 52 leg already works: `[tmux].clipboard = "enabled"` sets `set-clipboard on` + `allow-passthrough on`, shipped by `improve-aoe-config` D1 and unchanged here. Ghostty's native selection stays reachable with Shift+drag, the standard bypass.
+
+Accepted because the two symptoms in DOT-40 are hit constantly and drag-select has a one-key workaround, while the reverse is not true. The user's second machine has run with the mouse active for some time without this being reported as a problem, which is the best evidence available that the trade is tolerable. If it turns out not to be, the fallback is reverting, not patching around it — no configuration gives tmux the wheel and Ghostty the drag.
+
+Note `[tmux].clipboard` deliberately stays `"enabled"` rather than following the mouse to `auto`: `auto` would defer to `~/.tmux.conf`, and `dot_tmux.conf` sets neither `set-clipboard` nor (for this purpose) an equivalent — `allow-passthrough on` is there for Kitty graphics, not OSC 52. There is nothing to defer to, so pinning is correct there and deferring is correct here. The two keys differ because the underlying facts differ, not by inconsistency.
+
+### D4: Leave `default-terminal`, `click_action`, `*_attach_mode`, `AOE_MOUSE_CAPTURE` alone
+
+DOT-40 lists the first three as suspects. None can produce the symptoms:
+
+- `default-terminal` sets the TERM advertised to applications *inside* panes. Mouse tracking between tmux and Ghostty is negotiated on the outer side, from the TERM tmux itself was launched under. It cannot gate whether tmux binds the wheel. (`tmux-256color` may still be the more correct value than `xterm-256color`, but that is a different defect with a different failure mode — separate change if wanted.)
+- `click_action` and the `*_attach_mode` keys govern the AoE dashboard TUI — what happens when you click a *session row* in the list. They never reach tmux's pane mouse handling. They also sit at schema default and are not in `MANAGED`, so touching them would widen what this repo owns for no diagnosed reason.
+- `AOE_MOUSE_CAPTURE` / the dashboard's mouse-capture setting turned up while reading the schema and is worth naming so it is not re-investigated later: it makes the AoE *dashboard* request xterm mouse tracking for its own preview-pane scroll and row selection. Also not pane handling.
+
+## Risks / Trade-offs
+
+- **Drag-select changes under the user's hands (D3)** → Shift+drag restores Ghostty selection; documented in tasks.md verification so it is confirmed working before archive, not assumed.
+- **The fix now depends on an unrelated line staying put** — under `auto`, deleting `set -g mouse on` from `dot_tmux.conf` silently reintroduces DOT-40, since tmux's own default for `mouse` is `off` → the `tmux-config` delta specifies the line and its comment records why it is load-bearing.
+- **Running sessions keep `mouse off`** — AoE applied the option at session creation, so the fix looks like it did nothing until sessions are recreated → verification starts from a *new* session; existing ones can be fixed in place with `tmux set-option -t <session> mouse on`.
+- **Silent degradation on typo** — an invalid value falls back to `auto` with no error. Under this change that happens to be the desired value, so a typo would *hide* itself rather than break anything → verification asserts the resolved tmux option on a live session, not the config text.
+- **Copy-mode is a mode** — the wheel now leaves the pane in copy-mode, and keystrokes go to copy-mode until `q`. Normal tmux behavior, but new inside aoe panes and will read as a stuck pane the first time → called out in verification.
+- **`allow-passthrough` regression** — tmux owning the mouse does not touch passthrough, but mdfried's Kitty graphics are the canary for anything that does → verified explicitly.
+
+## Migration Plan
+
+One-way and trivially reversible: restore the previous value and re-run `chezmoi apply`. No state migration; no data at risk. Sessions created between apply and revert carry whichever value was live at their creation.

--- a/openspec/changes/fix-aoe-tmux-mouse/proposal.md
+++ b/openspec/changes/fix-aoe-tmux-mouse/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+`improve-aoe-config` pinned `[tmux].mouse = "disabled"` intending "AoE never touches tmux mouse mode, leaving the user-owned `~/.tmux.conf` (`mouse on`) authoritative" (the spec's own words). In AoE that value means the opposite: **apply `mouse off`** to every session it creates. AoE writes it as a session-local tmux option, which shadows the global `mouse on` from `dot_tmux.conf:2`, killing click-to-select-pane and handing the scroll wheel to the agent TUI instead of the pane's scrollback (DOT-40).
+
+The value that means what the spec wanted is `"auto"` — AoE's own schema documents it as *"Auto respects your tmux config"*.
+
+## What Changes
+
+- Change `(("tmux", "mouse"), ...)` in `dot_config/private_agent-of-empires/modify_private_config.toml` from `"disabled"` to `"auto"`, so AoE mirrors the global `mouse on` into each session it creates instead of forcing `off`.
+- Rewrite the `agent-manager` requirement that encodes the misreading, so the spec mandates the value that produces the behavior it already describes.
+- Specify the setting the fix now depends on: `dot_tmux.conf` SHALL set `mouse on`. It is there today but unspecified, so nothing currently protects it — and under `auto` it becomes the single authority for mouse behavior in aoe panes.
+
+Not a breaking change to any interface, but it **does change daily mouse behavior**: with the mouse active, tmux owns drag-select inside aoe panes (copy-mode, confined to one pane, reaching the system clipboard via the already-enabled OSC 52 passthrough) instead of Ghostty's native selection. Shift+drag remains the escape hatch. See design D3.
+
+Explicitly **not** changing:
+
+- Not `"enabled"`. It fixes the symptom but restores a second source of truth for the mouse, with AoE silently outranking `dot_tmux.conf` — structurally the same arrangement that produced this bug. See design D1.
+- No custom `WheelUpPane`/`WheelDownPane` bindings. tmux 3.7b's default root table already implements the policy DOT-40 asks for (wheel → pane scrollback unless the app is in alternate-screen or requested mouse reporting). See design D2.
+- No `default-terminal` change. It sets the TERM *inside* panes; mouse is negotiated against the outer terminal. Unrelated to the symptoms.
+- No `session.click_action` / `*_attach_mode` change, and no `AOE_MOUSE_CAPTURE` change. Those govern the AoE dashboard TUI (clicking a session row, the dashboard's own wheel capture), not pane mouse handling. See design D4.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `agent-manager`: the "AoE tmux mouse mode is deterministic" requirement changes the mandated value from `"disabled"` to `"auto"` and restates the rationale, because the current requirement's stated goal and its mandated value contradict each other.
+- `tmux-config`: adds a requirement that `dot_tmux.conf` sets `mouse on`. The file has carried this since inception but no requirement covers it; the `agent-manager` change above makes it load-bearing rather than incidental.
+
+## Impact
+
+- **Code touched**: `dot_config/private_agent-of-empires/modify_private_config.toml` (one entry in `MANAGED`), `dot_tmux.conf` (comment only — the `mouse on` line itself is already correct).
+- **Runtime effect**: applies to aoe sessions created *after* the change. Sessions already running keep their session-local `mouse off` until recreated, or until `tmux set-option -t <session> mouse on` is run by hand.
+- **Interaction with `tmux.clipboard = "enabled"`**: unchanged and load-bearing — it already sets `set-clipboard on` + `allow-passthrough on`, which is what carries tmux copy-mode selections to the system clipboard once tmux owns the drag. Note this key deliberately stays pinned rather than moving to `auto`: unlike the mouse, no setting in `dot_tmux.conf` provides it.
+- **External deps**: none. No new brew packages, no aoe version bump.
+- **Concurrent changes**: `update-brew-deps` also carries an `agent-manager` delta but does not touch the mouse requirement, so the two deltas do not overlap.
+- **Platform**: macOS, same as the parent change. Requires tmux ≥ 3.x for the default wheel binding relied on (verified on 3.7b).

--- a/openspec/changes/fix-aoe-tmux-mouse/proposal.md
+++ b/openspec/changes/fix-aoe-tmux-mouse/proposal.md
@@ -15,7 +15,7 @@ Not a breaking change to any interface, but it **does change daily mouse behavio
 Explicitly **not** changing:
 
 - Not `"enabled"`. It fixes the symptom but restores a second source of truth for the mouse, with AoE silently outranking `dot_tmux.conf` — structurally the same arrangement that produced this bug. See design D1.
-- No custom `WheelUpPane`/`WheelDownPane` bindings. tmux 3.7b's default root table already implements the policy DOT-40 asks for (wheel → pane scrollback unless the app is in alternate-screen or requested mouse reporting). See design D2.
+- No custom `WheelUpPane`/`WheelDownPane` bindings. tmux's default root table already implements the policy DOT-40 asks for: `WheelUpPane` → pane scrollback unless the app is in alternate-screen or requested mouse reporting. There is no default `WheelDownPane`; scrolling back down is handled by copy-mode's own table once copy-mode is entered. See design D2.
 - No `default-terminal` change. It sets the TERM *inside* panes; mouse is negotiated against the outer terminal. Unrelated to the symptoms.
 - No `session.click_action` / `*_attach_mode` change, and no `AOE_MOUSE_CAPTURE` change. Those govern the AoE dashboard TUI (clicking a session row, the dashboard's own wheel capture), not pane mouse handling. See design D4.
 
@@ -37,4 +37,4 @@ None.
 - **Interaction with `tmux.clipboard = "enabled"`**: unchanged and load-bearing — it already sets `set-clipboard on` + `allow-passthrough on`, which is what carries tmux copy-mode selections to the system clipboard once tmux owns the drag. Note this key deliberately stays pinned rather than moving to `auto`: unlike the mouse, no setting in `dot_tmux.conf` provides it.
 - **External deps**: none. No new brew packages, no aoe version bump.
 - **Concurrent changes**: `update-brew-deps` also carries an `agent-manager` delta but does not touch the mouse requirement, so the two deltas do not overlap.
-- **Platform**: macOS, same as the parent change. Requires tmux ≥ 3.x for the default wheel binding relied on (verified on 3.7b).
+- **Platform**: macOS, same as the parent change. Requires tmux ≥ 3.6: the default `WheelUpPane` binding only gained the `alternate_on` test in 3.6 (3.5a has just `pane_in_mode`/`mouse_any_flag`). Verified on 3.7b.

--- a/openspec/changes/fix-aoe-tmux-mouse/specs/agent-manager/spec.md
+++ b/openspec/changes/fix-aoe-tmux-mouse/specs/agent-manager/spec.md
@@ -1,0 +1,42 @@
+# agent-manager Delta
+
+## MODIFIED Requirements
+
+### Requirement: AoE tmux mouse mode is deterministic
+
+The AoE config SHALL set `[tmux].mouse = "auto"`, the value AoE documents as respecting the user's tmux config: AoE still writes a session-local `mouse` option, but mirrors the value resolved from `~/.tmux.conf` instead of asserting one of its own. `~/.tmux.conf` SHALL remain the single authority for mouse behavior inside aoe panes.
+
+The value SHALL NOT be `"disabled"`: in AoE that means "apply `mouse off`", written as a session-local tmux option, which shadows the global setting rather than deferring to it.
+
+The value SHALL NOT be `"enabled"` either. It produces the same observable behavior as `"auto"` on a host whose `~/.tmux.conf` sets `mouse on`, but it does so by having AoE assert the value independently, so the two configs can silently disagree — the arrangement that caused this requirement to be wrong in the first place. Under `"auto"` the session-local value is derived from `~/.tmux.conf`, so it cannot disagree with it.
+
+The key SHALL remain present in the chezmoi-managed config rather than being omitted. Omission is behaviorally identical to `"auto"`, but an explicit entry pins the no-op: it records the decision and lets `chezmoi apply` revert any value written into the live config by hand or by AoE.
+
+Because the mouse is active inside aoe panes, this requirement depends on the tmux clipboard passthrough requirement remaining satisfied: tmux copy-mode selections reach the system clipboard only via `set-clipboard on` + `allow-passthrough on`.
+
+#### Scenario: Mouse mode pinned to auto
+
+- **WHEN** the AoE config is rendered by chezmoi
+- **THEN** it contains `mouse = "auto"` under a `[tmux]` table
+
+#### Scenario: AoE mirrors the tmux mouse option rather than overriding it
+
+- **WHEN** a new aoe session is created after the config is applied
+- **THEN** the session resolves `mouse` to `on`
+- **AND** any session-local `mouse` value equals the global one set by `~/.tmux.conf`, so it never shadows it with a different value
+
+#### Scenario: Clicking a pane selects it
+
+- **WHEN** the user clicks a pane in an aoe session
+- **THEN** that pane becomes the active pane
+
+#### Scenario: Wheel scrolls the pane, not the agent
+
+- **WHEN** the user scrolls the wheel over an aoe pane running an agent that is neither in alternate-screen nor requesting mouse reporting
+- **THEN** the pane enters copy-mode and scrolls its own scrollback
+- **AND** the agent's TUI does not receive the scroll as input
+
+#### Scenario: Applications that request the mouse still receive it
+
+- **WHEN** the user scrolls the wheel over an aoe pane whose application is in alternate-screen or has enabled mouse reporting
+- **THEN** the wheel events are forwarded to that application unchanged

--- a/openspec/changes/fix-aoe-tmux-mouse/specs/tmux-config/spec.md
+++ b/openspec/changes/fix-aoe-tmux-mouse/specs/tmux-config/spec.md
@@ -1,0 +1,21 @@
+# tmux-config Delta
+
+## ADDED Requirements
+
+### Requirement: Mouse support
+
+`dot_tmux.conf` SHALL include `set -g mouse on` so tmux handles click-to-select-pane, border drag-to-resize, and wheel-to-scrollback.
+
+This setting is the single authority for mouse behavior in tmux sessions, including sessions created by AoE: the `agent-manager` capability requires AoE's `[tmux].mouse` to be `"auto"` precisely so that nothing overrides this line. Removing or disabling it therefore also disables the mouse inside aoe panes, with no second setting to fall back on.
+
+Per the existing comment-style requirement, the setting SHALL carry an explanatory comment above it, and that comment SHALL note that AoE defers to this setting rather than applying its own.
+
+#### Scenario: Setting present in config
+
+- **WHEN** `dot_tmux.conf` is applied via chezmoi
+- **THEN** tmux resolves the global `mouse` option to `on`
+
+#### Scenario: Comment records the AoE relationship
+
+- **WHEN** reading `dot_tmux.conf`
+- **THEN** `set -g mouse on` has a comment above it describing what the mouse controls and noting that AoE sessions inherit this setting rather than setting their own

--- a/openspec/changes/fix-aoe-tmux-mouse/tasks.md
+++ b/openspec/changes/fix-aoe-tmux-mouse/tasks.md
@@ -1,0 +1,36 @@
+## 1. Baseline
+
+- [x] 1.1 Record the pre-change state so the fix is provably the cause: `tmux show-options -g mouse` (expect `on`) and `tmux show-options -t <an aoe session> mouse` (expect `off`).
+- [ ] 1.2 Reproduce both DOT-40 symptoms in a live aoe session and note which is which: clicking a pane does not focus it; the wheel moves the agent's chat instead of the pane scrollback.
+
+## 2. Implementation
+
+- [x] 2.1 In `dot_config/private_agent-of-empires/modify_private_config.toml`, change the `MANAGED` entry `(("tmux", "mouse"), "disabled", False)` to `"auto"`.
+- [x] 2.2 Replace the stale rationale near that entry with the real semantics: `"auto"` = AoE respects `~/.tmux.conf` (its documented meaning); `"disabled"` = AoE applies `mouse off`, not "don't manage"; `"enabled"` = AoE asserts `mouse on` independently. Note the entry is kept deliberately as a pinned no-op so `chezmoi apply` reverts any stray value.
+- [x] 2.3 In `dot_tmux.conf`, extend the comment above `set -g mouse on` to state that aoe sessions inherit this setting rather than applying their own — the `tmux-config` delta requires the comment to record that relationship. Keep the existing one-line comment style.
+- [x] 2.4 Confirm `set -g mouse on` is present and unmodified (`tmux-config` delta requires it; it is load-bearing under `auto`).
+- [x] 2.5 Run `chezmoi diff` and confirm the only change to `~/.config/agent-of-empires/config.toml` is the single `mouse` line — AoE's runtime writeback tables must round-trip untouched (the `modify_` script's whole purpose).
+- [x] 2.6 `chezmoi apply`.
+
+## 3. Verify the fix
+
+Start from a **newly created** aoe session — AoE applied the option at session creation, so pre-existing sessions keep `mouse off` (design, Risks).
+
+- [x] 3.1 `tmux show-options -t <new aoe session> mouse` resolves to `on`, and any session-local value matches `tmux show-options -g mouse` rather than shadowing it. — DONE via a throwaway `aoe add --scratch --cmd claude --cmd-override sleep` session (no agent started, purged after): `local=[mouse on]`, `resolved=on`, vs non-aoe session `3` `local=[]`. Note `auto` mirrors `~/.tmux.conf` into the session; it does **not** abstain — artifacts corrected accordingly.
+- [ ] 3.2 Clicking a pane selects/focuses it.
+- [ ] 3.3 The wheel over an agent pane enters copy-mode and scrolls that pane's scrollback; the agent's chat does not move.
+- [ ] 3.4 `q` exits copy-mode and keystrokes reach the agent again (the mode is new inside aoe panes and reads as a stuck pane the first time).
+- [ ] 3.5 The wheel over a pane running a mouse-reporting TUI (gh-dash) still drives that TUI, not copy-mode.
+
+## 4. Verify nothing else broke
+
+- [ ] 4.1 Drag-select inside a pane lands in the **system** clipboard (tmux buffer → OSC 52, via the untouched `tmux.clipboard = "enabled"`).
+- [ ] 4.2 Shift+drag still yields Ghostty's native selection spanning the window (the D3 escape hatch — confirm it works before archiving, do not assume).
+- [ ] 4.3 mdfried renders Kitty graphics inside a pane — the canary for `allow-passthrough` (design, Risks).
+- [ ] 4.4 A non-aoe tmux session still behaves as before.
+
+## 5. Close out
+
+- [x] 5.1 `openspec validate fix-aoe-tmux-mouse --strict`.
+- [ ] 5.2 Update DOT-40 with the root cause (the `"disabled"` misreading in `improve-aoe-config` D1), why `"enabled"` was rejected in favour of `"auto"` (D1), and the D3 drag-select trade-off — so the ticket records why the wheel-binding approach it proposed was not needed.
+- [ ] 5.3 Note the D4 leftover — `default-terminal = "xterm-256color"` vs `tmux-256color` — as a separate ticket if still wanted; it is unrelated to the mouse.


### PR DESCRIPTION
## Why

`improve-aoe-config` pinned `[tmux].mouse = "disabled"` intending *"AoE never touches tmux mouse mode, leaving the user-owned `~/.tmux.conf` (`mouse on`) authoritative"*. In AoE that value means the opposite: **apply `mouse off`** as a session-local option, which shadows the global `mouse on` — killing click-to-select-pane and handing the wheel to the agent TUI instead of the pane scrollback (DOT-40).

Measured before the fix:

```
global                   mouse on
4 aoe sessions           mouse off   (session-local)
non-aoe session          (no override)
```

## What changed

- `dot_config/private_agent-of-empires/modify_private_config.toml` — `[tmux].mouse`: `"disabled"` → `"auto"`.
- `dot_tmux.conf` — comment only; `set -g mouse on` untouched but now spec'd, since it is load-bearing under `auto`.
- `openspec/changes/fix-aoe-tmux-mouse/` — proposal, design, spec deltas, tasks.

## Finding: `auto` mirrors, it does not abstain

Verified on a throwaway `--scratch` session (no agent started, purged after): under `auto` AoE **still writes a session-local `mouse`** — it just mirrors the value resolved from `~/.tmux.conf` (`local=[mouse on]`, `resolved=on`) instead of forcing `off`. The artifacts were written assuming abstention and have been corrected. D1's argument for `auto` over `enabled` survives: the value is derived from `~/.tmux.conf`, so the two cannot disagree.

## Trade-off (design D3)

With the mouse active, tmux owns drag-select inside aoe panes (copy-mode, one pane, to the system clipboard via the already-enabled OSC 52 passthrough) instead of Ghostty's native selection. Shift+drag is the escape hatch. Not avoidable by tuning.

## Verification

- [x] Baseline recorded; `chezmoi diff` shows exactly one changed line in the aoe config, runtime writeback tables round-trip untouched; applied
- [x] `aoe settings explain tmux.mouse` → `"auto"`; new session resolves `mouse on`
- [x] `openspec validate fix-aoe-tmux-mouse --strict`
- [ ] Manual, needs a hand on the mouse in a **newly created** session: click-to-focus, wheel → copy-mode, `q` exits, gh-dash still gets the wheel, drag-select → system clipboard, Shift+drag, mdfried Kitty graphics, non-aoe session unchanged

Existing sessions keep their `mouse off` until recreated — `tmux set-option -t <session> mouse on` fixes them in place.

Closes DOT-40 pending the manual checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mouse support in AoE tmux sessions.
  * Scrolling, pane selection, and mouse interactions now follow the global tmux setting.
  * Applications requesting mouse input continue receiving events.
  * Clipboard behavior and unrelated tmux settings remain unchanged.

* **Documentation**
  * Added guidance on mouse behavior, compatibility, verification, and recovery.
  * Documented that AoE sessions inherit the global tmux mouse setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->