### PR TITLE
feat(slack): add Slack MCP to Claude Code and OpenCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ chezmoi-managed dotfiles for macOS (primary) with Linux support. Built around Gh
 | **CLI Tools**  | [tickrs](https://github.com/tarkah/tickrs)                                      | Real-time stock ticker TUI with curated 42-symbol watchlist                                |
 | **CLI Tools**  | [ticker](https://github.com/achannarasappa/ticker)                              | Terminal stock tracker with cost-basis positions and sector groups                         |
 | **CLI Tools**  | [age](https://age-encryption.org/)                                              | Modern encryption tool backing the chezmoi-managed secrets workflow                        |
+| **CLI Tools**  | zsh secrets                                                                     | age-encrypted `~/.config/zsh/secrets.zsh` sourced at shell start for API tokens            |
 | **CLI Tools**  | [mole](https://github.com/tw93/mole)                                            | Deep clean and optimize your Mac — caches, logs, app remnants, `node_modules` (macOS only) |
 | **CLI Tools**  | [glow](https://github.com/charmbracelet/glow)                                   | Terminal Markdown viewer — TUI browse + CLI render                                         |
 | **CLI Tools**  | [mdfried](https://github.com/benjajaja/mdfried)                                 | Markdown viewer with inline images, mermaid diagrams, and Big Headers (graphics terminal)  |
@@ -56,6 +57,7 @@ chezmoi-managed dotfiles for macOS (primary) with Linux support. Built around Gh
 | **AI Tooling** | [OpenCode](https://github.com/anomalyco/opencode)                               | AI code editor                                                                             |
 | **AI Tooling** | [Agent of Empires](https://github.com/njbrake/agent-of-empires)                 | tmux-native TUI for managing parallel AI agent sessions (`aoe`)                            |
 | **AI Tooling** | [CodeRabbit](https://www.coderabbit.ai/)                                        | AI code review CLI                                                                         |
+| **AI Tooling** | [Slack MCP](https://github.com/slackapi/slack-mcp-plugin)                       | Slack search and channel/thread reads in Claude Code and OpenCode (read-only by default)   |
 | **Network**    | [Tailscale](https://tailscale.com/)                                             | Mesh VPN (WireGuard-based) for secure device-to-device networking                          |
 
 ## MCP Servers
@@ -78,6 +80,8 @@ The install script registers 14 global MCP servers to `~/.claude.json` (the stdi
 | linear          | http      | Linear issues & projects                   | OAuth on first use                                                      |
 | notion          | http      | Notion pages & databases                   | OAuth on first use                                                      |
 | storybook       | http      | Local Storybook component context          | Needs `@storybook/addon-mcp` in each project + `storybook dev` on :6006 |
+
+Slack is deliberately absent from that table. It advertises no `registration_endpoint`, so Dynamic Client Registration — the only OAuth path `claude mcp add --transport http` knows — can never complete. Claude Code gets Slack from the `slack@claude-plugins-official` plugin instead, which ships a pre-registered client and authenticates via OAuth on first use (`/mcp`). OpenCode reaches the same hosted server with a Slack user token exported as `SLACK_MCP_TOKEN` from the age-encrypted `~/.config/zsh/secrets.zsh`. Either way, a workspace admin must have approved the Slack MCP connector first.
 
 ## Setup
 
@@ -108,7 +112,7 @@ The install script registers 14 global MCP servers to `~/.claude.json` (the stdi
 
     Restore `~/.config/chezmoi/key.txt` from your password manager (`chmod 600`).
 
-    > ⚠️ Lose this file without a backup and the encrypted artifacts in the repo (e.g. `encrypted_dot_ticker.yaml.age`) become **irrecoverable**.
+    > ⚠️ Lose this file without a backup and the encrypted artifacts in the repo (e.g. `encrypted_dot_ticker.yaml.age`, `encrypted_private_dot_config/zsh/secrets.zsh.age`) become **irrecoverable**.
 
 3. Initialize and apply:
 

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -2015,6 +2015,17 @@
                             </tr>
                             <tr>
                                 <td>
+                                    <code>chezmoi add --encrypt ~/.config/zsh/secrets.zsh</code>
+                                </td>
+                                <td>
+                                    Encrypt the shell secrets file (exports
+                                    <code>SLACK_MCP_TOKEN</code> and any other API token) &mdash;
+                                    deployed at mode 0600 and sourced from <code>.zshrc</code> when
+                                    present
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
                                     <code
                                         >mkdir -p ~/.config/chezmoi &amp;&amp; age-keygen -o
                                         ~/.config/chezmoi/key.txt &amp;&amp; chmod 600
@@ -2033,6 +2044,15 @@
                         <code>$EDITOR ~/.ticker.yaml</code> &rarr;
                         <code>chezmoi re-add --encrypt ~/.ticker.yaml</code> &rarr;
                         <code>chezmoi git add encrypted_dot_ticker.yaml.age</code> &rarr; commit
+                    </div>
+                    <div class="flow-only">
+                        <strong>Flow: Add a new API token</strong><br />
+                        <code>$EDITOR ~/.config/zsh/secrets.zsh</code> &rarr;
+                        <code>chezmoi re-add --encrypt ~/.config/zsh/secrets.zsh</code> &rarr;
+                        <code
+                            >chezmoi git add encrypted_private_dot_config/zsh/secrets.zsh.age</code
+                        >
+                        &rarr; commit
                     </div>
                     <div class="flow-only">
                         <strong>Flow: Bootstrap new machine</strong><br />
@@ -2527,8 +2547,29 @@
                                     <code>storybook dev</code> on :6006
                                 </td>
                             </tr>
+                            <tr>
+                                <td>slack</td>
+                                <td>
+                                    Search public channels; read channels, threads, canvases and
+                                    user profiles
+                                </td>
+                                <td>
+                                    Comes from the
+                                    <code>slack@claude-plugins-official</code> plugin, not from
+                                    <code>claude mcp add</code> &mdash; OAuth on first use via
+                                    <code>/mcp</code>, and a workspace admin must have approved the
+                                    Slack connector
+                                </td>
+                            </tr>
                         </tbody>
                     </table>
+                    <p>
+                        The seven read-only Slack tools are pre-approved in
+                        <code>permissions.allow</code>, so searches and reads run without a prompt.
+                        <code>slack_search_public_and_private</code> and every write tool
+                        (<code>slack_send_message</code>, <code>slack_create_canvas</code> and the
+                        rest) stay out of the allowlist and still ask.
+                    </p>
 
                     <h3>OpenSpec workflow</h3>
                     <table>
@@ -2710,6 +2751,15 @@
                             <tr>
                                 <td>expect</td>
                                 <td>Visual testing and accessibility audits</td>
+                            </tr>
+                            <tr>
+                                <td>slack</td>
+                                <td>
+                                    Slack search and reads through the hosted remote server
+                                    (<code>https://mcp.slack.com/mcp</code>) &mdash; bearer token
+                                    from <code>$SLACK_MCP_TOKEN</code>, OAuth auto-detection turned
+                                    off
+                                </td>
                             </tr>
                         </tbody>
                     </table>

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -27,6 +27,7 @@
     "plannotator@plannotator": true,
     "plugin-dev@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
+    "slack@claude-plugins-official": true,
     "superpowers-chrome@superpowers-marketplace": true,
     "superpowers-developing-for-claude-code@superpowers-marketplace": true,
     "superpowers-lab@superpowers-marketplace": true,
@@ -294,7 +295,14 @@
       "mcp__memory__read_graph",
       "mcp__memory__search_nodes",
       "mcp__memory__open_nodes",
-      "mcp__gh_grep__searchGitHub"
+      "mcp__gh_grep__searchGitHub",
+      "mcp__plugin_slack_slack__slack_search_public",
+      "mcp__plugin_slack_slack__slack_search_channels",
+      "mcp__plugin_slack_slack__slack_search_users",
+      "mcp__plugin_slack_slack__slack_read_channel",
+      "mcp__plugin_slack_slack__slack_read_thread",
+      "mcp__plugin_slack_slack__slack_read_canvas",
+      "mcp__plugin_slack_slack__slack_read_user_profile"
     ],
     "defaultMode": "auto",
     "deny": [

--- a/dot_config/opencode/opencode.jsonc
+++ b/dot_config/opencode/opencode.jsonc
@@ -21,6 +21,21 @@
             "command": ["npx", "-y", "expect-cli@latest", "mcp"],
             "enabled": true,
         },
+        // oauth: false is load-bearing — Slack advertises no registration_endpoint
+        // (no Dynamic Client Registration) and only client_secret_post on its token
+        // endpoint, so OpenCode's auto-detected flow can never complete. Turning it
+        // off is what makes the Authorization header below the deciding factor.
+        // SLACK_MCP_TOKEN is a Slack user token (xoxp-) exported from
+        // ~/.config/zsh/secrets.zsh; unset, only this server fails to connect.
+        "slack": {
+            "type": "remote",
+            "url": "https://mcp.slack.com/mcp",
+            "enabled": true,
+            "oauth": false,
+            "headers": {
+                "Authorization": "Bearer {env:SLACK_MCP_TOKEN}",
+            },
+        },
     },
     "formatter": {
         "oxfmt": {

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -96,6 +96,13 @@ export OPENCODE_ENABLE_EXA=true
 export OPENCODE_EXPERIMENTAL_OXFMT=true
 export OPENCODE_EXPERIMENTAL_FILEWATCHER=true
 
+# API tokens and other per-user secrets. Deployed by chezmoi from the age
+# ciphertext encrypted_private_dot_config/zsh/secrets.zsh.age at mode 0600 and
+# never committed in plaintext; holds SLACK_MCP_TOKEN for the Slack MCP server
+# in OpenCode. Guarded with the same idiom as the Catppuccin line above, so a
+# host without the file (or without the age key) starts silently.
+[[ -f ~/.config/zsh/secrets.zsh ]] && source ~/.config/zsh/secrets.zsh
+
 test -e "${HOME}/.iterm2_shell_integration.zsh" && source "${HOME}/.iterm2_shell_integration.zsh"
 
 # pnpm

--- a/openspec/changes/add-slack-mcp/.openspec.yaml
+++ b/openspec/changes/add-slack-mcp/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-09

--- a/openspec/changes/add-slack-mcp/design.md
+++ b/openspec/changes/add-slack-mcp/design.md
@@ -1,0 +1,107 @@
+# Design: add-slack-mcp
+
+## Context
+
+See proposal.md — Why. The constraint that shapes everything here is Slack's OAuth metadata, verified against the live endpoint:
+
+```
+GET https://mcp.slack.com/.well-known/oauth-authorization-server
+  issuer                              https://mcp.slack.com
+  authorization_endpoint              https://slack.com/oauth/v2_user/authorize
+  token_endpoint                      https://slack.com/api/oauth.v2.user.access
+  grant_types_supported               authorization_code, refresh_token
+  token_endpoint_auth_methods_supported   client_secret_post
+  code_challenge_methods_supported    S256
+  registration_endpoint               (absent)
+```
+
+Three facts follow, and every decision below is downstream of them:
+
+1. **No `registration_endpoint`** → no Dynamic Client Registration (RFC 7591). Any client that expects to mint its own `clientId` on the fly cannot talk to this server.
+2. **`client_secret_post` is the only token-endpoint auth method** → even with PKCE (`S256` is offered), the token exchange carries a client secret. There is no purely public client path.
+3. **Slack ships pre-registered `clientId`s to specific vendors.** The official Claude Code plugin (`slackapi/slack-mcp-plugin`, vendored through `anthropics/claude-plugins-official`) carries `clientId 1601185624273.8899143856786` with `callbackPort 3118` in its `.mcp.json`; its plugin id is `slack` and its MCP server key is `slack`, which fixes the Claude tool namespace at `mcp__plugin_slack_slack__*`.
+
+Existing machinery this change rides on: `CC_MARKETPLACES`/`CC_PLUGINS` arrays and the `run_claude_step` PTY wrapper in `run_onchange_install-packages.sh.tmpl`; `enabledPlugins` and `permissions.allow` in `dot_claude/settings.json.tmpl`; the `mcp` object in `dot_config/opencode/opencode.jsonc` (today a single `local` server, `expect`); age encryption already proven by `encrypted_dot_ticker.yaml.age`. Versions on this host: Claude Code 2.1.222, OpenCode 1.18.11.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One Slack integration reachable from both agents, each through the authentication path its client actually supports.
+- Zero secret material in the repository, and no secret in any file chezmoi renders as plaintext.
+- Failure isolation: an unapproved workspace, a missing token or a revoked plugin degrades to "Slack unavailable", never to a broken shell, a failed `chezmoi apply`, or a broken MCP server list.
+
+**Non-Goals:**
+
+- Symmetry between the two clients. Claude Code gets OAuth-through-plugin, OpenCode gets a bearer token; forcing one mechanism on both is what this design deliberately avoids.
+- Automating the workspace-admin approval or the Slack app creation — both live outside the repo, and both are one-time.
+- Scope minimisation logic in code. Which scopes the token carries is decided once, when the Slack app is installed; nothing in the dotfiles can enforce it.
+
+## Decisions
+
+### D1: Claude Code gets Slack from the official plugin, not from `claude mcp add --transport http`
+
+`claude mcp add --scope user --transport http slack https://mcp.slack.com/mcp` is the shape every other HTTP server in this repo uses (`atlassian`, `figma`, `linear`, `notion`), and it is the wrong tool here. That path has no field for a `clientId`; it discovers one via DCR, which fact (1) rules out. The registration would succeed, `~/.claude.json` would gain a `slack` entry, and every tool call would fail authentication — the worst failure mode available, because it looks configured.
+
+The plugin instead ships the pre-registered `clientId` in its own `.mcp.json`, and Claude Code performs the authorization-code flow against `slack.com/oauth/v2_user/authorize` with the callback on port 3118. Consequence: `slack` appears in `/mcp` but never in `claude mcp list --scope user`, which is why the spec pins that asymmetry down explicitly — otherwise a later audit of "integrations vs. registered MCP servers" reads it as an omission and re-adds it.
+
+Alternative considered: registering the HTTP server *and* letting the plugin's OAuth credentials cover it. They are separate configuration namespaces in Claude Code; the plugin's `clientId` does not apply to a user-scope server of the same name. Rejected.
+
+### D2: OpenCode gets a bearer token, with `oauth: false` set explicitly
+
+OpenCode's `McpRemoteConfig` does support a static OAuth client — `oauth: { clientId, clientSecret, scope, callbackPort, redirectUri }` — so the naive reading ("OpenCode needs DCR, therefore OAuth is impossible") is wrong and worth correcting here. Three concrete paths existed:
+
+- **Reuse the Claude plugin's `clientId`.** Requires our redirect URI to be one Slack registered for Anthropic's client. Borrowed credentials, unilaterally revocable, and a support burden nobody signed up for. Rejected.
+- **Register our own Slack app and configure `oauth.clientId` + `oauth.clientSecret`.** Legitimate, but fact (2) means the token exchange needs the client secret, and `opencode.jsonc` is a chezmoi-managed file committed in plaintext. Only `headers` values are documented to interpolate `{env:…}`; putting a secret in `oauth.clientSecret` would either commit it or depend on undocumented interpolation. Rejected on the secret-handling goal alone.
+- **User token in the `Authorization` header.** The same Slack app produces a `xoxp-` user token directly; it carries exactly the same scopes the OAuth flow would have granted, and `headers` interpolation keeps it in the environment. Chosen.
+
+`oauth: false` is not decoration: without it OpenCode auto-detects the OAuth-protected resource, starts a flow that cannot complete, and the explicit `Authorization` header is never the deciding factor. The flag turns auto-detection off so the header is used as-is.
+
+### D3: The token arrives through a new age-encrypted zsh secrets file
+
+`SLACK_MCP_TOKEN` is this repo's first long-lived API secret in the shell environment; `dot_zshrc.tmpl` currently exports nothing of the kind. Rather than invent a Slack-specific hack, the change introduces the general mechanism as its own capability (`zsh-secrets`): `encrypted_private_dot_config/zsh/secrets.zsh.age` → `~/.config/zsh/secrets.zsh` (mode `0600`), sourced from `dot_zshrc.tmpl` behind the same `[[ -f … ]] && source …` guard already used for the Catppuccin syntax-highlighting theme.
+
+Alternatives: the macOS Keychain via `security find-generic-password` (per-host manual setup, no chezmoi story, a subprocess on every shell start); 1Password CLI `op read` (no `op` usage anywhere in this repo today — a new dependency for one token); a chezmoi `{{ onepasswordRead }}` template (same dependency, plus it makes `chezmoi apply` fail when 1Password is locked). Age wins because the repo already carries an age recipient, an encrypted file, and a documented key-bootstrap procedure — the marginal cost is one file and one `source` line.
+
+Accepted limitation: only processes descended from an interactive zsh see the variable. OpenCode is a terminal application, so this is a non-issue in practice; a GUI-launched client would not see the token. Documented, not engineered around.
+
+### D4: Allowlist read-only tools only, and keep the private search out of it
+
+The Slack MCP server exposes 14 tools. Split by effect:
+
+- **Read, allowlisted:** `slack_search_public`, `slack_search_channels`, `slack_search_users`, `slack_read_channel`, `slack_read_thread`, `slack_read_canvas`, `slack_read_user_profile`.
+- **Read, deliberately not allowlisted:** `slack_search_public_and_private` — it reaches private channels and DMs, and the tool's own contract asks for explicit per-call user consent. Auto-approving it would override a consent boundary the server itself draws.
+- **Write, not allowlisted:** `slack_send_message`, `slack_send_message_draft`, `slack_schedule_message`, `slack_create_canvas`, `slack_update_canvas`. Same rule already applied to memory writes, playwright and chrome-devtools.
+
+Ids follow the plugin-provided namespace `mcp__plugin_<plugin>_<server>__<tool>`; both segments are `slack`, hence `mcp__plugin_slack_slack__slack_search_public`. The doubled prefix looks like a typo and is not — worth a comment at implementation time. A wrong id fails safe: the rule simply never matches and Claude asks, so this cannot produce an over-permission.
+
+### D5: Nothing new for Renovate
+
+The hosted server has no version. The plugin's version is managed by the marketplace's `autoUpdate: true`, exactly like `code-simplifier@claude-plugins-official`. So unlike the stdio servers pinned as `pkg@version` and tracked by the custom regex manager, this change adds no `renovate.json` manager and no pin to maintain.
+
+### D6: The install script gains one plugin id and one printed line, nothing else
+
+`CC_PLUGINS` gains `slack@claude-plugins-official`; the existing loop handles pre-scan, skip-if-installed, PTY wrapping and non-fatal failure. `CC_MARKETPLACES` is untouched. The only other edit is a Slack line in the "Manual Installation Required" section, next to the Atlassian/Figma/Linear/Notion OAuth notes, because three prerequisites are outside the script's reach: the OAuth consent, the workspace admin approval, and the OpenCode token.
+
+## Risks / Trade-offs
+
+- **Workspace admin has not approved the Slack MCP connector** → every client fails OAuth and the change is inert. Mitigation: the manual-instructions line states it as a prerequisite; the install script neither checks nor fails on it, so `chezmoi apply` stays green.
+- **`SLACK_MCP_TOKEN` is visible to every process started from the shell** → any tool running under that shell can read the user's Slack surface. Mitigation: minimum viable scopes on the Slack app, `0600` on the secrets file, and a token that is trivially revocable from Slack's app settings without touching this repo.
+- **Losing the age private key makes the encrypted token unrecoverable** → same blast radius already documented for `encrypted_dot_ticker.yaml.age`; the recovery path is regenerating the Slack token, not recovering the file. No new mitigation needed.
+- **Plugin updates could rename tools and silently break the allowlist** → the failure mode is an extra confirmation prompt, never an unintended action. Mitigation: verify ids via `/mcp` when implementing, and treat drift as a follow-up chore.
+- **The 8 Slack skills come bundled with the plugin** → only `slack-search` needs the MCP connection; the rest (`block-kit`, `slack-api`, `slack-cli`, `create-slack-app`, …) load on demand and cost nothing when unused. Accepted as a package deal; the plugin is not separable.
+- **The two clients authenticate differently** → two things to debug instead of one, and a token that expires only on the OpenCode side. Accepted: the alternative is either borrowed credentials or a committed client secret.
+
+## Migration Plan
+
+1. Create the Slack app in the workspace with the read scopes the allowlisted tools need (`search:read.public`, `search:read.users`, `channels:history`, `groups:history`, `im:history`, `mpim:history`, `channels:read`, `canvases:read`, `users:read`), plus `chat:write` only if message sending is wanted; issue the `xoxp-` user token.
+2. Add `SLACK_MCP_TOKEN` to the age-encrypted secrets file, apply, and confirm a fresh shell exports it.
+3. Land the Claude Code side (`CC_PLUGINS` + `enabledPlugins` + `permissions.allow`), run the install script, and complete the OAuth flow from `/mcp`.
+4. Land the OpenCode side (`mcp.slack` entry), restart OpenCode, confirm the server connects and tools list.
+5. Update `README.md` and `docs/manual.html` last, once the observed behaviour matches the specs.
+
+Rollback is per-side and independent: remove the `enabledPlugins` entry (or `claude plugin uninstall`) for Claude Code; set `enabled: false` or delete the `mcp.slack` entry for OpenCode; revoke the token in Slack. Removing the token alone disables OpenCode without touching Claude Code. The `zsh-secrets` capability survives any Slack rollback — it is the general mechanism, not Slack plumbing.
+
+## Open Questions
+
+- Whether OpenCode's `{env:…}` interpolation extends beyond `headers` to the `oauth` fields. Irrelevant to this design (D2 rejects the OAuth path for other reasons too), but it would reopen the question if Slack ever adds DCR or a public-client token endpoint.

--- a/openspec/changes/add-slack-mcp/proposal.md
+++ b/openspec/changes/add-slack-mcp/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+The dev environment wires 14 MCP servers across the whole work surface — Linear, Notion and Atlassian for tracking, Figma for design, `gh_grep` for code — but not Slack, which is where most of that context is actually discussed and decided. Agents cannot search a thread, read a channel or post a summary without the user copy-pasting. Slack now ships an official remote MCP server (`https://mcp.slack.com/mcp`) and an official Claude Code plugin published on `anthropics/claude-plugins-official`, a marketplace this repo already registers — so the Claude Code side is a two-line change against machinery that exists.
+
+## What Changes
+
+**Claude Code — via the official plugin**
+
+- Add `slack@claude-plugins-official` to `CC_PLUGINS` in `run_onchange_install-packages.sh.tmpl`. No new marketplace: `anthropics/claude-plugins-official` is already in `CC_MARKETPLACES`.
+- Add `"slack@claude-plugins-official": true` to `enabledPlugins` in `dot_claude/settings.json.tmpl`.
+- The plugin self-configures the MCP server (`type: http`, `https://mcp.slack.com/mcp`, `oauth.clientId 1601185624273.8899143856786`, `callbackPort 3118`) and prompts for OAuth on first use. It also ships 8 Slack skills (`block-kit`, `slack-api`, `slack-cli`, `slack-messaging`, `slack-search`, `create-slack-app`, …), of which only `slack-search` needs the MCP connection.
+- **`slack` is deliberately NOT added to `MCP_HTTP_SERVERS`.** `https://mcp.slack.com/.well-known/oauth-authorization-server` advertises no `registration_endpoint`: Slack does not support Dynamic Client Registration, the only OAuth path `claude mcp add --transport http` knows. Registration would appear to succeed and the server would then fail to authenticate. The plugin is what supplies the pre-registered `clientId` that makes the flow complete.
+
+**OpenCode — remote server plus bearer token**
+
+- Add a `slack` entry to the `mcp` object in `dot_config/opencode/opencode.jsonc`: `type: "remote"`, `url: "https://mcp.slack.com/mcp"`, `oauth: false`, `headers.Authorization: "Bearer {env:SLACK_MCP_TOKEN}"`, `enabled: true`. First `remote`-type server in that file (`expect` is `local`).
+- OAuth is switched off on purpose: OpenCode's automatic flow depends on DCR (unavailable), the `clientId`s Slack publishes are bound to Claude's and Cursor's redirect URIs, and Slack's token endpoint advertises only `client_secret_post`, which rules out a public PKCE client too.
+- `SLACK_MCP_TOKEN` is a Slack user token (`xoxp-`) from a workspace app holding the approved scopes (`search:read.*`, `channels:history`, `users:read`, `chat:write`, …).
+
+**Secret plumbing**
+
+- New `encrypted_private_dot_config/zsh/secrets.zsh.age` → `~/.config/zsh/secrets.zsh`, sourced from `dot_zshrc.tmpl` when present. Same age convention already behind `encrypted_dot_ticker.yaml.age`; no plaintext token in the repo.
+- Graceful degradation: with no token exported, `{env:SLACK_MCP_TOKEN}` resolves empty and OpenCode reports `slack` as failed to connect — the behaviour already accepted for `storybook` — without affecting other servers.
+
+**Permissions and docs**
+
+- Read-only Slack MCP tools (search/read) go into `permissions.allow` in `dot_claude/settings.json.tmpl`; write tools (message posting, canvas and file writes) stay at the default ask level. Exact tool ids are resolved in the specs phase from `claude mcp get slack` once the plugin is loaded.
+- The manual-instructions section of the install script gains a Slack line (OAuth on first use, admin approval, `SLACK_MCP_TOKEN` for OpenCode). README "What's Included" and `docs/manual.html` are updated via the `update-readme` / `update-manual` skills as implementation tasks; no spec-level docs changes.
+
+## Capabilities
+
+### New Capabilities
+
+- `zsh-secrets`: age-encrypted environment-secret file deployed by chezmoi and conditionally sourced from `dot_zshrc.tmpl` — the mechanism that puts `SLACK_MCP_TOKEN` (and future tokens) in the shell without committing plaintext, including the no-file and empty-value paths.
+
+### Modified Capabilities
+
+- `claude-code-plugins`: `CC_PLUGINS` and the `enabledPlugins` object gain `slack@claude-plugins-official`; the marketplace list is unchanged.
+- `mcp-global-config`: the OpenCode `mcp` object gains a `slack` remote entry, and a new requirement records that Slack is intentionally absent from `MCP_STDIO_SERVERS` / `MCP_HTTP_SERVERS` and from the 13-server table, with the DCR rationale, so a later audit does not "fix" the omission by registering it.
+- `claude-user-preferences`: `permissions.allow` gains the read-only Slack MCP tools; write tools stay out, consistent with the existing rule for memory/playwright/chrome-devtools.
+
+## Impact
+
+- **Files**: `run_onchange_install-packages.sh.tmpl`, `dot_claude/settings.json.tmpl`, `dot_config/opencode/opencode.jsonc`, `dot_zshrc.tmpl`, new `encrypted_private_dot_config/zsh/secrets.zsh.age`, `README.md`, `docs/manual.html`.
+- **Dependencies**: hosted Slack MCP server (no version to pin, so nothing for Renovate to track, unlike the npx-pinned stdio servers) and the `slack@claude-plugins-official` plugin. Requires Claude Code with plugin support and OpenCode ≥ 1.18 (`oauth` and `{env:…}` support in remote MCP config).
+- **Prerequisite outside this repo**: a workspace admin must approve the Slack MCP connector. Without approval OAuth fails for every client and the change is inert — this is a setup note for the manual section, not something the install script can verify.
+- **Security**: scope breadth is decided when the Slack app is installed; keep it to the minimum the skills need. The token grants the user's own Slack surface, so the age private key remains the single per-host secret to protect.
+- **Non-goals**: community servers (`@slack/mcp-server`, `korotovsky/slack-mcp-server`), bot-token or socket-mode deployments, per-project `.mcp.json` overrides, and the root `opencode.json` of this repo.

--- a/openspec/changes/add-slack-mcp/specs/claude-code-plugins/spec.md
+++ b/openspec/changes/add-slack-mcp/specs/claude-code-plugins/spec.md
@@ -1,0 +1,73 @@
+# Delta: claude-code-plugins
+
+## ADDED Requirements
+
+### Requirement: Slack plugin is installed via the install script
+
+The install script (`run_onchange_install-packages.sh.tmpl`) SHALL include `slack@claude-plugins-official` in the `CC_PLUGINS` array, installed by the existing plugin loop (`claude plugin install`) with the same pre-scan skip-if-installed behaviour as every other entry. The `CC_MARKETPLACES` array SHALL NOT gain a new entry: `anthropics/claude-plugins-official` is already registered there.
+
+The plugin supplies the Slack MCP server definition (`type: http`, `https://mcp.slack.com/mcp`, a pre-registered OAuth `clientId`, and a fixed OAuth callback port) plus the Slack agent skills. The install script SHALL NOT configure the Slack MCP server itself.
+
+#### Scenario: Fresh machine setup
+
+- **WHEN** the install script runs the Claude Code plugin dependencies group on a machine where the plugin is absent
+- **AND** the user confirms the group
+- **THEN** `slack@claude-plugins-official` SHALL be installed via the existing plugin loop
+
+#### Scenario: Already installed
+
+- **WHEN** `claude plugin list --json` already contains `slack@claude-plugins-official`
+- **THEN** the installation SHALL be skipped with an "already installed" message
+
+#### Scenario: No new marketplace is registered
+
+- **WHEN** `run_onchange_install-packages.sh.tmpl` is inspected
+- **THEN** `CC_MARKETPLACES` SHALL be unchanged by this change and SHALL still contain `anthropics/claude-plugins-official` exactly once
+
+#### Scenario: Claude CLI not available
+
+- **WHEN** `claude` is not on PATH during `chezmoi apply`
+- **THEN** the whole plugin group — including the Slack plugin — SHALL be skipped with the existing warning
+
+### Requirement: Slack plugin is enabled by default
+
+The Claude Code settings dotfile (`dot_claude/settings.json.tmpl`) SHALL include `"slack@claude-plugins-official": true` in the `enabledPlugins` object. Auto-update is inherited from the existing `claude-plugins-official` entry in `extraKnownMarketplaces`; no per-plugin auto-update field is added.
+
+#### Scenario: Fresh machine setup
+
+- **WHEN** `chezmoi apply` is run on a machine without Claude Code settings
+- **THEN** `~/.claude/settings.json` SHALL be created with `slack@claude-plugins-official` listed in `enabledPlugins`
+
+#### Scenario: Existing settings updated
+
+- **WHEN** `chezmoi apply` is run on a machine with an older version of the managed settings file
+- **THEN** the file SHALL be updated to include the `slack@claude-plugins-official` entry alongside all other existing plugins
+
+#### Scenario: Plugin not installed
+
+- **WHEN** the Slack plugin has not been installed on the machine
+- **THEN** the `enabledPlugins` entry SHALL be inert and Claude Code SHALL operate normally without errors
+
+#### Scenario: Marketplace already configured
+
+- **WHEN** the `claude-plugins-official` marketplace is already present in `extraKnownMarketplaces`
+- **THEN** no additional marketplace entry SHALL be needed for the Slack plugin
+
+### Requirement: Slack MCP connection is authenticated through the plugin's OAuth flow
+
+Authentication for the Slack MCP server in Claude Code SHALL happen through the OAuth flow the plugin triggers (on first tool use or via `/mcp`), using the `clientId` the plugin ships. No token, client secret, or environment variable SHALL be required on the Claude Code side.
+
+#### Scenario: First use prompts for OAuth
+
+- **WHEN** a Slack MCP tool is invoked for the first time on a machine where the plugin is installed and enabled
+- **THEN** Claude Code SHALL start the Slack OAuth flow in the browser and store the resulting credentials itself
+
+#### Scenario: Connection status is inspectable
+
+- **WHEN** the user runs `/mcp` after authenticating
+- **THEN** the `slack` server SHALL be listed as connected and its tools SHALL be available
+
+#### Scenario: Workspace has not approved the connector
+
+- **WHEN** the Slack workspace administrator has not approved the Slack MCP connector
+- **THEN** the OAuth flow SHALL fail, the `slack` server SHALL report as not connected, and no other MCP server or plugin SHALL be affected

--- a/openspec/changes/add-slack-mcp/specs/claude-user-preferences/spec.md
+++ b/openspec/changes/add-slack-mcp/specs/claude-user-preferences/spec.md
@@ -1,0 +1,65 @@
+# Delta: claude-user-preferences
+
+## MODIFIED Requirements
+
+### Requirement: MCP read-only tools are allowed
+
+The chezmoi template SHALL include the following MCP tool allow rules in `permissions.allow`:
+
+- `mcp__context7__resolve-library-id`
+- `mcp__context7__query-docs`
+- `mcp__plugin_episodic-memory_episodic-memory__search`
+- `mcp__plugin_episodic-memory_episodic-memory__read`
+- `mcp__knip__knip-run`
+- `mcp__knip__knip-docs`
+- `mcp__eslint__lint-files`
+- `mcp__memory__read_graph`
+- `mcp__memory__search_nodes`
+- `mcp__memory__open_nodes`
+- `mcp__gh_grep__searchGitHub`
+- `mcp__plugin_slack_slack__slack_search_public`
+- `mcp__plugin_slack_slack__slack_search_channels`
+- `mcp__plugin_slack_slack__slack_search_users`
+- `mcp__plugin_slack_slack__slack_read_channel`
+- `mcp__plugin_slack_slack__slack_read_thread`
+- `mcp__plugin_slack_slack__slack_read_canvas`
+- `mcp__plugin_slack_slack__slack_read_user_profile`
+
+MCP write tools (memory create/delete, playwright, chrome-devtools) SHALL NOT be in the allow list and SHALL remain at the default ask level.
+
+The Slack rules follow the plugin-provided naming scheme `mcp__plugin_<plugin>_<server>__<tool>`, already used for episodic-memory; for the `slack` plugin both the plugin and its MCP server are named `slack`. Slack write tools (`slack_send_message`, `slack_send_message_draft`, `slack_schedule_message`, `slack_create_canvas`, `slack_update_canvas`) SHALL NOT be allowlisted. `mcp__plugin_slack_slack__slack_search_public_and_private` SHALL also stay out of the allow list: the tool reaches private conversations and its own contract asks for explicit user consent per call.
+
+#### Scenario: context7 doc lookup runs without prompt
+
+- **WHEN** Claude Code attempts to call `mcp__context7__query-docs`
+- **THEN** the tool call SHALL execute without prompting the user
+
+#### Scenario: memory write prompts
+
+- **WHEN** Claude Code attempts to call `mcp__memory__create_entities`
+- **THEN** the tool call SHALL prompt the user for confirmation
+
+#### Scenario: Slack public search runs without prompt
+
+- **WHEN** Claude Code attempts to call `mcp__plugin_slack_slack__slack_search_public`
+- **THEN** the tool call SHALL execute without prompting the user
+
+#### Scenario: Slack channel and thread reads run without prompt
+
+- **WHEN** Claude Code attempts to call `mcp__plugin_slack_slack__slack_read_channel` or `mcp__plugin_slack_slack__slack_read_thread`
+- **THEN** the tool call SHALL execute without prompting the user
+
+#### Scenario: Slack private search prompts
+
+- **WHEN** Claude Code attempts to call `mcp__plugin_slack_slack__slack_search_public_and_private`
+- **THEN** no allow rule SHALL match and the tool call SHALL prompt the user for confirmation
+
+#### Scenario: Slack message send prompts
+
+- **WHEN** Claude Code attempts to call `mcp__plugin_slack_slack__slack_send_message`
+- **THEN** the tool call SHALL prompt the user for confirmation
+
+#### Scenario: Slack canvas write prompts
+
+- **WHEN** Claude Code attempts to call `mcp__plugin_slack_slack__slack_create_canvas` or `mcp__plugin_slack_slack__slack_update_canvas`
+- **THEN** the tool call SHALL prompt the user for confirmation

--- a/openspec/changes/add-slack-mcp/specs/mcp-global-config/spec.md
+++ b/openspec/changes/add-slack-mcp/specs/mcp-global-config/spec.md
@@ -1,0 +1,74 @@
+# Delta: mcp-global-config
+
+## ADDED Requirements
+
+### Requirement: Slack is deliberately excluded from the Claude CLI MCP registration arrays
+
+`run_onchange_install-packages.sh.tmpl` SHALL NOT contain a `slack` entry in `MCP_STDIO_SERVERS` or `MCP_HTTP_SERVERS`, and the server table registered via `claude mcp add --scope user` SHALL NOT include Slack. Claude Code receives the Slack MCP server exclusively from the `slack@claude-plugins-official` plugin.
+
+The reason is technical, not stylistic: `https://mcp.slack.com/.well-known/oauth-authorization-server` advertises no `registration_endpoint`, so Slack does not support Dynamic Client Registration — the only OAuth path available to a server registered with `claude mcp add --transport http`. Such a registration would report success and then fail to authenticate on every use. The plugin is what supplies the pre-registered `clientId` that lets the flow complete.
+
+#### Scenario: Install script contains no Slack MCP entry
+
+- **WHEN** `run_onchange_install-packages.sh.tmpl` is inspected
+- **THEN** neither `MCP_STDIO_SERVERS` nor `MCP_HTTP_SERVERS` SHALL contain a `slack` element
+- **AND** the count reported by the MCP pre-scan SHALL be unchanged by this change
+
+#### Scenario: No user-scope Slack server after apply
+
+- **WHEN** `claude mcp list --scope user` is run after `chezmoi apply`
+- **THEN** no `slack` server SHALL be listed at user scope
+- **AND** `/mcp` inside Claude Code SHALL still show `slack`, provided by the plugin
+
+#### Scenario: Rationale is recorded next to the arrays
+
+- **WHEN** a future audit compares the MCP server list against the set of configured integrations
+- **THEN** the install script SHALL carry a comment stating that Slack is intentionally absent because Slack does not support Dynamic Client Registration and is provided by the plugin instead
+
+### Requirement: Slack MCP server is registered as a remote server in OpenCode config
+
+`dot_config/opencode/opencode.jsonc` SHALL contain a `slack` entry inside its `mcp` object with type `"remote"`, url `"https://mcp.slack.com/mcp"`, `enabled: true`, `oauth: false`, and an `Authorization` header of `"Bearer {env:SLACK_MCP_TOKEN}"`.
+
+OAuth SHALL be disabled explicitly: OpenCode's automatic flow depends on Dynamic Client Registration, which Slack does not offer, and Slack's token endpoint advertises only `client_secret_post`, which rules out a public PKCE client as well. The bearer token is therefore the only workable authentication path on the OpenCode side.
+
+#### Scenario: Slack entry present after chezmoi apply
+
+- **WHEN** `chezmoi apply` is run on a new machine
+- **THEN** `~/.config/opencode/opencode.jsonc` SHALL contain an `mcp.slack` object of type `"remote"` pointing at `https://mcp.slack.com/mcp`, with `enabled: true`, `oauth: false`, and the `Authorization` header set to `Bearer {env:SLACK_MCP_TOKEN}`
+
+#### Scenario: Token resolved from the environment
+
+- **WHEN** OpenCode starts from a shell where `SLACK_MCP_TOKEN` is exported
+- **THEN** the `{env:SLACK_MCP_TOKEN}` placeholder SHALL be substituted with the token value
+- **AND** the `slack` server SHALL connect and expose its tools
+
+#### Scenario: Token missing
+
+- **WHEN** OpenCode starts with `SLACK_MCP_TOKEN` unset
+- **THEN** the `slack` server SHALL report as failed to connect — the behaviour already accepted for `storybook` in Claude Code
+- **AND** the `expect` server and all other OpenCode functionality SHALL be unaffected
+
+#### Scenario: Existing OpenCode config keys are untouched
+
+- **WHEN** `chezmoi apply` deploys the updated OpenCode config
+- **THEN** the `model`, `tui`, `plugin`, `formatter`, and `permission` keys SHALL remain unchanged
+- **AND** the existing `mcp.expect` entry SHALL remain unchanged
+
+#### Scenario: Config remains valid JSONC
+
+- **WHEN** the rendered `~/.config/opencode/opencode.jsonc` is parsed
+- **THEN** it SHALL parse without error against the OpenCode schema declared in `$schema`
+
+### Requirement: Slack setup steps are printed in the manual instructions section
+
+The manual instructions section of `run_onchange_install-packages.sh.tmpl` SHALL include a Slack line covering the three things the script cannot do itself: the Claude Code OAuth flow on first use, the workspace administrator's approval of the Slack MCP connector, and the `SLACK_MCP_TOKEN` needed by OpenCode.
+
+#### Scenario: Slack note printed on macOS
+
+- **WHEN** the install script reaches the "Manual Installation Required" section on macOS
+- **THEN** it SHALL print a Slack MCP line mentioning OAuth on first use, the required workspace admin approval, and `SLACK_MCP_TOKEN` for OpenCode
+
+#### Scenario: Admin approval is not verified by the script
+
+- **WHEN** the install script runs
+- **THEN** it SHALL NOT attempt to verify or request Slack workspace approval, and its exit status SHALL NOT depend on the Slack connector being approved

--- a/openspec/changes/add-slack-mcp/specs/zsh-secrets/spec.md
+++ b/openspec/changes/add-slack-mcp/specs/zsh-secrets/spec.md
@@ -1,0 +1,69 @@
+# Delta: zsh-secrets
+
+## Purpose
+
+Provides a single age-encrypted file, deployed by chezmoi and sourced by the interactive shell, that exports API tokens and other per-user secrets into the environment so tools launched from the terminal can read them without any plaintext secret being committed to the dotfiles repository.
+
+## ADDED Requirements
+
+### Requirement: Encrypted secrets file is managed by chezmoi
+
+The repository SHALL contain `encrypted_private_dot_config/zsh/secrets.zsh.age`, which chezmoi decrypts and deploys to `~/.config/zsh/secrets.zsh` with owner-only permissions (`0600`), using the same age backend already configured for `encrypted_dot_ticker.yaml.age`.
+
+The file SHALL contain only `export NAME=value` assignments. No plaintext copy of the file, and no secret value it carries, SHALL exist anywhere in the repository.
+
+#### Scenario: Deployed on a host holding the age identity
+
+- **WHEN** `chezmoi apply` runs on a machine where `~/.config/chezmoi/key.txt` is present
+- **THEN** `~/.config/zsh/secrets.zsh` SHALL exist with mode `0600`
+- **AND** its contents SHALL match the decrypted source file
+
+#### Scenario: Repository carries no plaintext
+
+- **WHEN** the repository is inspected at any commit
+- **THEN** no unencrypted `secrets.zsh` (or equivalent plaintext token file) SHALL be tracked
+- **AND** the only committed form SHALL be the `.age` ciphertext
+
+#### Scenario: Host without the age identity
+
+- **WHEN** `chezmoi apply` runs on a machine that does not hold the age private key
+- **THEN** the encrypted secrets file SHALL fail to decrypt in the same way as every other `encrypted_*.age` file in the repo, and the bootstrap procedure documented for `chezmoi-encryption` (copy the private key before the first apply) SHALL apply unchanged
+
+### Requirement: Interactive shell sources the secrets file when present
+
+`dot_zshrc.tmpl` SHALL source `~/.config/zsh/secrets.zsh` guarded by an existence test, following the `[[ -f <path> ]] && source <path>` idiom already used for the Catppuccin syntax-highlighting theme. The guard SHALL make a missing file a no-op rather than an error.
+
+#### Scenario: Secrets available in a new shell
+
+- **WHEN** `~/.config/zsh/secrets.zsh` exists and a new interactive zsh session starts
+- **THEN** every variable exported by that file SHALL be present in the session environment
+- **AND** SHALL be inherited by processes started from that session
+
+#### Scenario: Missing secrets file does not break the shell
+
+- **WHEN** `~/.config/zsh/secrets.zsh` does not exist and a new interactive zsh session starts
+- **THEN** the shell SHALL start with no error output and no `no such file or directory` message
+
+#### Scenario: Secret values are never echoed
+
+- **WHEN** the shell sources the secrets file
+- **THEN** no secret value SHALL be printed to the terminal or written to any log or history file
+
+### Requirement: Slack MCP token is delivered through the secrets file
+
+`SLACK_MCP_TOKEN` SHALL be exported from `~/.config/zsh/secrets.zsh` and SHALL hold a Slack user token (`xoxp-` prefix) issued by a workspace app carrying the scopes the Slack MCP server requires. It SHALL NOT be defined inline in `dot_zshrc.tmpl`, in any chezmoi template, or in any OpenCode or Claude Code configuration file.
+
+#### Scenario: Token reaches an MCP client
+
+- **WHEN** an MCP client is launched from an interactive shell on a host where the secrets file exports `SLACK_MCP_TOKEN`
+- **THEN** the client SHALL resolve `SLACK_MCP_TOKEN` from the environment
+
+#### Scenario: Token absent degrades gracefully
+
+- **WHEN** `SLACK_MCP_TOKEN` is unset or empty
+- **THEN** consumers SHALL start normally, the Slack MCP connection SHALL be the only thing that fails, and no other server or shell feature SHALL be affected
+
+#### Scenario: Token is not hardcoded
+
+- **WHEN** `dot_zshrc.tmpl`, `dot_config/opencode/opencode.jsonc`, `dot_claude/settings.json.tmpl`, and `run_onchange_install-packages.sh.tmpl` are inspected
+- **THEN** each SHALL reference `SLACK_MCP_TOKEN` only by name (or via an `{env:…}` placeholder) and never contain a literal token value

--- a/openspec/changes/add-slack-mcp/tasks.md
+++ b/openspec/changes/add-slack-mcp/tasks.md
@@ -1,0 +1,48 @@
+# Tasks: add-slack-mcp
+
+## 1. Slack workspace prerequisites
+
+- [ ] 1.1 Confirm with a workspace admin that the Slack MCP connector is approved for the workspace; without it every client fails OAuth and the rest of this change is inert
+- [ ] 1.2 Create (or reuse) a Slack app with the read scopes the allowlisted tools need per design Migration Plan step 1 (`search:read.public`, `search:read.users`, `channels:history`, `groups:history`, `im:history`, `mpim:history`, `channels:read`, `canvases:read`, `users:read`; add `chat:write` only if message sending is wanted)
+- [ ] 1.3 Install the app to the workspace and issue the `xoxp-` user token; verify it with `curl -H "Authorization: Bearer $TOKEN" https://slack.com/api/auth.test`
+
+## 2. Secret plumbing (`zsh-secrets`)
+
+- [ ] 2.1 Create `~/.config/zsh/secrets.zsh` with mode `0600` exporting `SLACK_MCP_TOKEN`, then add it encrypted with `chezmoi add --encrypt ~/.config/zsh/secrets.zsh`; confirm the source file lands as `encrypted_private_dot_config/zsh/secrets.zsh.age`
+- [x] 2.2 Add the guarded source line to `dot_zshrc.tmpl` following the existing `[[ -f … ]] && source …` idiom (see the Catppuccin syntax-highlighting line)
+- [ ] 2.3 Verify `chezmoi apply` deploys the file at mode `0600`, that a fresh shell exports `SLACK_MCP_TOKEN`, and that removing the deployed file leaves shell startup silent and error-free
+- [ ] 2.4 Verify no plaintext token is tracked: `git status --porcelain` is clean of a plaintext `secrets.zsh` and `chezmoi cat` on the source shows the value only after decryption
+
+## 3. Claude Code
+
+- [x] 3.1 Add `slack@claude-plugins-official` to `CC_PLUGINS` in `run_onchange_install-packages.sh.tmpl`, leaving `CC_MARKETPLACES` untouched (`anthropics/claude-plugins-official` is already registered)
+- [x] 3.2 Add a comment next to `MCP_HTTP_SERVERS` recording that Slack is intentionally absent (no `registration_endpoint` → no Dynamic Client Registration; the plugin supplies the pre-registered `clientId`)
+- [x] 3.3 Add a Slack line to the "Manual Installation Required" section covering OAuth on first use, the required workspace admin approval, and `SLACK_MCP_TOKEN` for OpenCode
+- [x] 3.4 Add `"slack@claude-plugins-official": true` to `enabledPlugins` in `dot_claude/settings.json.tmpl`
+- [ ] 3.5 Run the install script and confirm the plugin installs, then re-run and confirm it reports "already installed"
+- [ ] 3.6 Complete the OAuth flow from `/mcp` and confirm `slack` reports connected; confirm `claude mcp list --scope user` does NOT list it
+
+## 4. Claude Code permissions
+
+- [ ] 4.1 Verify the real tool ids via `/mcp` (or `claude mcp get slack`) once the server is connected; expected form is `mcp__plugin_slack_slack__<tool>`
+- [x] 4.2 Add the seven read-only Slack rules to `permissions.allow` in `dot_claude/settings.json.tmpl` (`slack_search_public`, `slack_search_channels`, `slack_search_users`, `slack_read_channel`, `slack_read_thread`, `slack_read_canvas`, `slack_read_user_profile`), keeping `slack_search_public_and_private` and all write tools out
+- [ ] 4.3 Verify behaviour: a public search runs without a prompt, while `slack_search_public_and_private` and `slack_send_message` still prompt
+
+## 5. OpenCode
+
+- [x] 5.1 Add the `slack` entry to the `mcp` object in `dot_config/opencode/opencode.jsonc` (`type: "remote"`, `url: "https://mcp.slack.com/mcp"`, `enabled: true`, `oauth: false`, `headers.Authorization: "Bearer {env:SLACK_MCP_TOKEN}"`)
+- [ ] 5.2 Apply and validate the rendered file against the declared `$schema`; confirm `model`, `tui`, `plugin`, `formatter`, `permission` and the existing `mcp.expect` entry are unchanged
+- [ ] 5.3 Start OpenCode from a shell exporting the token and confirm `slack` connects and lists its tools
+- [ ] 5.4 Start OpenCode with `SLACK_MCP_TOKEN` unset and confirm only `slack` fails to connect, with `expect` and the rest of OpenCode unaffected
+
+## 6. Docs
+
+- [x] 6.1 Update `docs/manual.html` via the update-manual skill (Slack MCP in both clients, the OAuth-vs-token split, workspace approval, `SLACK_MCP_TOKEN`, and the new encrypted secrets file)
+- [x] 6.2 Update `README.md` via the update-readme skill (What's Included entries for the Slack MCP integration and the zsh secrets mechanism)
+
+## 7. Verification
+
+- [ ] 7.1 Run the install script end-to-end twice and confirm idempotency: the plugin group, the untouched MCP arrays and the manual Slack line all behave on a second run
+- [ ] 7.2 Smoke-test Claude Code: search a public channel and read a thread through the Slack tools without a permission prompt
+- [ ] 7.3 Smoke-test OpenCode: run one Slack read tool against the same workspace and confirm the bearer token path works
+- [x] 7.4 Run `openspec validate add-slack-mcp --strict` and confirm the implementation matches every spec delta before archiving

--- a/run_onchange_install-packages.sh.tmpl
+++ b/run_onchange_install-packages.sh.tmpl
@@ -876,6 +876,10 @@ CC_PLUGINS=(
     "beads@beads-marketplace"
     "code-simplifier@claude-plugins-official"
     "fallow@fallow-skills"
+    # Ships the Slack MCP server definition (http, https://mcp.slack.com/mcp)
+    # with its pre-registered OAuth clientId, plus the Slack skills. Hence no
+    # slack entry in MCP_HTTP_SERVERS below.
+    "slack@claude-plugins-official"
 )
 
 if command -v claude &>/dev/null; then
@@ -1002,6 +1006,12 @@ MCP_STDIO_SERVERS=(
     "fallow:fallow-mcp"
 )
 
+# Slack is deliberately absent here: https://mcp.slack.com/.well-known/oauth-authorization-server
+# advertises no registration_endpoint, so Slack does not support Dynamic Client
+# Registration — the only OAuth path `claude mcp add --transport http` knows.
+# Registering it would report success and then fail to authenticate on every
+# call. Claude Code gets Slack from the slack@claude-plugins-official plugin,
+# which supplies the pre-registered clientId. Do not "fix" this omission.
 MCP_HTTP_SERVERS=(
     "gh_grep:https://mcp.grep.app"
     "atlassian:https://mcp.atlassian.com/v1/mcp"
@@ -1181,6 +1191,7 @@ info "  - Figma MCP: requires OAuth authentication — run 'claude mcp get figma
 info "  - Linear MCP: requires OAuth authentication — run 'claude mcp get linear' or use on first invocation"
 info "  - Notion MCP: requires OAuth authentication — run 'claude mcp get notion' or use on first invocation"
 info "  - Storybook MCP: requires @storybook/addon-mcp installed in each Storybook project and 'storybook dev' running on port 6006"
+info "  - Slack MCP: Claude Code authenticates via OAuth on first use (run '/mcp' to trigger it); a workspace admin must have approved the Slack MCP connector first, or OAuth fails for every client. OpenCode instead needs a Slack user token (xoxp-) exported as SLACK_MCP_TOKEN from ~/.config/zsh/secrets.zsh"
 info ""
 
 {{ else -}}


### PR DESCRIPTION
Implements the OpenSpec change `add-slack-mcp` (spec-driven schema). Repo-side work is done; everything that needs a real Slack token, the OAuth flow or workspace admin approval is still open in `openspec/changes/add-slack-mcp/tasks.md`.

### Why two different integration paths

`https://mcp.slack.com/.well-known/oauth-authorization-server` advertises **no `registration_endpoint`**, so Slack does not support Dynamic Client Registration — the only OAuth path `claude mcp add --transport http` knows. Registering it there would report success and then fail to authenticate on every call.

| Client | How it connects | Auth |
| --- | --- | --- |
| Claude Code | `slack@claude-plugins-official` plugin | Pre-registered client, OAuth on first use via `/mcp` |
| OpenCode | `mcp.slack` remote entry, `oauth: false` | `Bearer {env:SLACK_MCP_TOKEN}` |

Both require a workspace admin to have approved the Slack MCP connector first.

### Changes

- **`run_onchange_install-packages.sh.tmpl`** — `slack@claude-plugins-official` added to `CC_PLUGINS`; a comment on `MCP_HTTP_SERVERS` records why Slack is intentionally absent so nobody "fixes" it later; new Slack line in the *Manual Installation Required* summary.
- **`dot_claude/settings.json.tmpl`** — plugin enabled, plus seven **read-only** Slack tools pre-approved in `permissions.allow` (`slack_search_public`, `slack_search_channels`, `slack_search_users`, `slack_read_channel`, `slack_read_thread`, `slack_read_canvas`, `slack_read_user_profile`). `slack_search_public_and_private` and every write tool stay out and still prompt.
- **`dot_config/opencode/opencode.jsonc`** — `slack` remote server. `oauth: false` is load-bearing: it disables OpenCode's auto-detected flow, which can never complete against Slack, making the bearer header the deciding factor.
- **`dot_zshrc.tmpl`** — guarded `source ~/.config/zsh/secrets.zsh`, following the existing Catppuccin idiom, so a host without the file (or without the age key) starts silently.
- **`README.md` / `docs/manual.html`** — Slack in both client sections, the OAuth-vs-token split, workspace approval, and the new encrypted secrets file.

### Verification

- `openspec validate add-slack-mcp --strict` — valid
- `dot_claude/settings.json.tmpl` rendered via `chezmoi execute-template` → valid JSON, plugin and all seven rules present
- `run_onchange_install-packages.sh.tmpl` rendered → `bash -n` clean
- `opencode.jsonc` parses as JSON5; the `slack` entry matches `McpRemoteConfig` in the declared `$schema`; `mcp.expect` and all other top-level keys unchanged
- `oxfmt --check` clean

### Not done (needs a Slack workspace)

Admin approval of the connector, creating the Slack app and issuing the `xoxp-` token, creating and encrypting `~/.config/zsh/secrets.zsh`, and every smoke test that depends on them — 13 tasks, all still unchecked in `tasks.md`. **Do not merge as "working" until the token exists**: without `SLACK_MCP_TOKEN` the OpenCode `slack` server simply fails to connect (nothing else is affected).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Slack MCP integration for Claude Code and OpenCode.
  * Enabled Slack’s official Claude Code plugin with read-only access by default and confirmations for write actions.
  * Added encrypted shell-secret support for securely providing the OpenCode Slack token.
  * Configured OpenCode to connect using a token-based remote Slack server.

* **Documentation**
  * Added setup, authentication, workspace approval, secret management, and troubleshooting guidance for Slack integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->